### PR TITLE
Fix loop increment issue and add test

### DIFF
--- a/src/account/BaseModularAccountLoupe.sol
+++ b/src/account/BaseModularAccountLoupe.sol
@@ -59,7 +59,7 @@ abstract contract BaseModularAccountLoupe is IPluginLoupe {
         uint256 numHooks = preExecHooks.length;
         execHooks = new ExecutionHooks[](numHooks);
 
-        for (uint256 i = 0; i < numHooks; i++) {
+        for (uint256 i = 0; i < numHooks;) {
             execHooks[i].preExecHook = preExecHooks[i];
             execHooks[i].postExecHook = _storage.selectorData[selector].associatedPostExecHooks[preExecHooks[i]];
 
@@ -88,7 +88,7 @@ abstract contract BaseModularAccountLoupe is IPluginLoupe {
         uint256 numHooks = prePermittedCallHooks.length;
         execHooks = new ExecutionHooks[](numHooks);
 
-        for (uint256 i = 0; i < numHooks; i++) {
+        for (uint256 i = 0; i < numHooks;) {
             execHooks[i].preExecHook = prePermittedCallHooks[i];
             execHooks[i].postExecHook =
                 _storage.permittedCalls[key].associatedPostPermittedCallHooks[prePermittedCallHooks[i]];


### PR DESCRIPTION
## Motivation

There's a bug in the loop increment for the loupe functions for retrieving execution hooks and permitted call hooks: it is duplicated across the for loop line and at the end of the loop, within an unchecked block.

Thank you @leekt for finding this issue.

## Solution

Remove the extra loop increment, and add a test that retrieves >1 execution hooks and permitted call hooks.