### PR TITLE
fix: improve comments in IPluginExecutor interface

### DIFF
--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -186,10 +186,9 @@ This prevents accidental misconfiguration or misuse of plugins (both installed a
 
 ```solidity
 interface IPluginExecutor {
-    /// @notice Execute a call from a plugin to another plugin, via an execution function installed on the account.
-    /// @dev Plugins are not allowed to call native functions on the account. Permissions must be granted to the
-    /// calling plugin for the call to go through.
-    /// @param data The calldata to send to the plugin.
+    /// @notice Execute a call from a plugin through the account.
+    /// @dev Permissions must be granted to the calling plugin for the call to go through.
+    /// @param data The calldata to send to the account.
     /// @return The return data from the call.
     function executeFromPlugin(bytes calldata data) external payable returns (bytes memory);
 


### PR DESCRIPTION
#36 erroneously added strict restrictions on what a plugin can call.

Currently in v0.6.0:
```solidity
interface IPluginExecutor {
    /// @notice Method from calls made from plugins.
    /// @param data The call data for the call.
    /// @return The return data from the call.
    function executeFromPlugin(bytes calldata data) external payable returns (bytes memory);

    /// @notice Method from cals made from plugins.
    /// @dev If the target is a plugin, the call SHOULD revert.
    /// @param target The target of the external contract to be called.
    /// @param value The value to pass.
    /// @param data The data to pass.
    function executeFromPluginExternal(address target, uint256 value, bytes calldata data) external payable;
}
```
