### PR TITLE
feat: [v0.8-develop, experimental] Merge validation function assignments

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -36,9 +36,7 @@ abstract contract AccountLoupe is IAccountLoupe {
             config.plugin = _storage.selectorData[selector].plugin;
         }
 
-        config.userOpValidationFunction = _storage.selectorData[selector].userOpValidation;
-
-        config.runtimeValidationFunction = _storage.selectorData[selector].runtimeValidation;
+        config.validationFunction = _storage.selectorData[selector].validation;
     }
 
     /// @inheritdoc IAccountLoupe

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -35,8 +35,8 @@ struct SelectorData {
     // The plugin that implements this execution function.
     // If this is a native function, the address must remain address(0).
     address plugin;
-    FunctionReference userOpValidation;
-    FunctionReference runtimeValidation;
+    // User operation validation and runtime validation share a function reference.
+    FunctionReference validation;
     // The pre validation hooks for this function selector.
     EnumerableMap.Bytes32ToUintMap preUserOpValidationHooks;
     EnumerableMap.Bytes32ToUintMap preRuntimeValidationHooks;

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -302,7 +302,10 @@ abstract contract PluginManagerInternals is IPluginManager {
             _addValidationFunction(
                 mv.executionSelector,
                 _resolveManifestFunction(
-                    mv.associatedFunction, plugin, dependencies, ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
+                    mv.associatedFunction,
+                    plugin,
+                    dependencies,
+                    ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
                 )
             );
 

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -41,8 +41,7 @@ abstract contract PluginManagerInternals is IPluginManager {
     error PluginInstallCallbackFailed(address plugin, bytes revertReason);
     error PluginInterfaceNotSupported(address plugin);
     error PluginNotInstalled(address plugin);
-    error RuntimeValidationFunctionAlreadySet(bytes4 selector, FunctionReference validationFunction);
-    error UserOpValidationFunctionAlreadySet(bytes4 selector, FunctionReference validationFunction);
+    error ValidationFunctionAlreadySet(bytes4 selector, FunctionReference validationFunction);
 
     modifier notNullFunction(FunctionReference functionReference) {
         if (functionReference.isEmpty()) {
@@ -76,48 +75,26 @@ abstract contract PluginManagerInternals is IPluginManager {
         _selectorData.plugin = address(0);
     }
 
-    function _addUserOpValidationFunction(bytes4 selector, FunctionReference validationFunction)
+    function _addValidationFunction(bytes4 selector, FunctionReference validationFunction)
         internal
         notNullFunction(validationFunction)
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        if (!_selectorData.userOpValidation.isEmpty()) {
-            revert UserOpValidationFunctionAlreadySet(selector, validationFunction);
+        if (!_selectorData.validation.isEmpty()) {
+            revert ValidationFunctionAlreadySet(selector, validationFunction);
         }
 
-        _selectorData.userOpValidation = validationFunction;
+        _selectorData.validation = validationFunction;
     }
 
-    function _removeUserOpValidationFunction(bytes4 selector, FunctionReference validationFunction)
+    function _removeValidationFunction(bytes4 selector, FunctionReference validationFunction)
         internal
         notNullFunction(validationFunction)
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        _selectorData.userOpValidation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
-    }
-
-    function _addRuntimeValidationFunction(bytes4 selector, FunctionReference validationFunction)
-        internal
-        notNullFunction(validationFunction)
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        if (!_selectorData.runtimeValidation.isEmpty()) {
-            revert RuntimeValidationFunctionAlreadySet(selector, validationFunction);
-        }
-
-        _selectorData.runtimeValidation = validationFunction;
-    }
-
-    function _removeRuntimeValidationFunction(bytes4 selector, FunctionReference validationFunction)
-        internal
-        notNullFunction(validationFunction)
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        _selectorData.runtimeValidation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
+        _selectorData.validation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
     }
 
     function _addExecHooks(bytes4 selector, FunctionReference preExecHook, FunctionReference postExecHook)
@@ -319,31 +296,13 @@ abstract contract PluginManagerInternals is IPluginManager {
             }
         }
 
-        length = manifest.userOpValidationFunctions.length;
+        length = manifest.validationFunctions.length;
         for (uint256 i = 0; i < length;) {
-            ManifestAssociatedFunction memory mv = manifest.userOpValidationFunctions[i];
-            _addUserOpValidationFunction(
+            ManifestAssociatedFunction memory mv = manifest.validationFunctions[i];
+            _addValidationFunction(
                 mv.executionSelector,
                 _resolveManifestFunction(
-                    mv.associatedFunction, plugin, dependencies, ManifestAssociatedFunctionType.NONE
-                )
-            );
-
-            unchecked {
-                ++i;
-            }
-        }
-
-        length = manifest.runtimeValidationFunctions.length;
-        for (uint256 i = 0; i < length;) {
-            ManifestAssociatedFunction memory mv = manifest.runtimeValidationFunctions[i];
-            _addRuntimeValidationFunction(
-                mv.executionSelector,
-                _resolveManifestFunction(
-                    mv.associatedFunction,
-                    plugin,
-                    dependencies,
-                    ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
+                    mv.associatedFunction, plugin, dependencies, ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
                 )
             );
 
@@ -521,31 +480,16 @@ abstract contract PluginManagerInternals is IPluginManager {
             }
         }
 
-        length = manifest.runtimeValidationFunctions.length;
+        length = manifest.validationFunctions.length;
         for (uint256 i = 0; i < length;) {
-            ManifestAssociatedFunction memory mv = manifest.runtimeValidationFunctions[i];
-            _removeRuntimeValidationFunction(
+            ManifestAssociatedFunction memory mv = manifest.validationFunctions[i];
+            _removeValidationFunction(
                 mv.executionSelector,
                 _resolveManifestFunction(
                     mv.associatedFunction,
                     plugin,
                     dependencies,
                     ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
-                )
-            );
-
-            unchecked {
-                ++i;
-            }
-        }
-
-        length = manifest.userOpValidationFunctions.length;
-        for (uint256 i = 0; i < length;) {
-            ManifestAssociatedFunction memory mv = manifest.userOpValidationFunctions[i];
-            _removeUserOpValidationFunction(
-                mv.executionSelector,
-                _resolveManifestFunction(
-                    mv.associatedFunction, plugin, dependencies, ManifestAssociatedFunctionType.NONE
                 )
             );
 

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -336,7 +336,7 @@ contract UpgradeableModularAccount is
         }
         bytes4 selector = bytes4(userOp.callData);
 
-        FunctionReference userOpValidationFunction = getAccountStorage().selectorData[selector].userOpValidation;
+        FunctionReference userOpValidationFunction = getAccountStorage().selectorData[selector].validation;
 
         validationData = _doUserOpValidation(selector, userOpValidationFunction, userOp, userOpHash);
     }
@@ -395,7 +395,9 @@ contract UpgradeableModularAccount is
                     validationData = currentValidationData;
                 }
             } else {
-                // _RUNTIME_VALIDATION_ALWAYS_ALLOW and _PRE_HOOK_ALWAYS_DENY is not permitted here.
+                // _PRE_HOOK_ALWAYS_DENY is not permitted here.
+                // If this is _RUNTIME_VALIDATION_ALWAYS_ALLOW, the call should revert.
+                // Todo: this is the wrong error if it is set to _RUNTIME_VALIDATION_ALWAYS_ALLOW.
                 revert InvalidConfiguration();
             }
         }
@@ -405,7 +407,7 @@ contract UpgradeableModularAccount is
         if (msg.sender == address(_ENTRY_POINT)) return;
 
         AccountStorage storage _storage = getAccountStorage();
-        FunctionReference runtimeValidationFunction = _storage.selectorData[msg.sig].runtimeValidation;
+        FunctionReference runtimeValidationFunction = _storage.selectorData[msg.sig].validation;
         // run all preRuntimeValidation hooks
         EnumerableMap.Bytes32ToUintMap storage preRuntimeValidationHooks =
             getAccountStorage().selectorData[msg.sig].preRuntimeValidationHooks;

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -397,7 +397,6 @@ contract UpgradeableModularAccount is
             } else {
                 // _PRE_HOOK_ALWAYS_DENY is not permitted here.
                 // If this is _RUNTIME_VALIDATION_ALWAYS_ALLOW, the call should revert.
-                // Todo: this is the wrong error if it is set to _RUNTIME_VALIDATION_ALWAYS_ALLOW.
                 revert InvalidConfiguration();
             }
         }

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -7,8 +7,7 @@ interface IAccountLoupe {
     /// @notice Config for an execution function, given a selector.
     struct ExecutionFunctionConfig {
         address plugin;
-        FunctionReference userOpValidationFunction;
-        FunctionReference runtimeValidationFunction;
+        FunctionReference validationFunction;
     }
 
     /// @notice Pre and post hooks for a given selector.

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -90,8 +90,7 @@ struct PluginManifest {
     // plugin MUST still be able to spend up to the balance that it sends to the account in the same call.
     bool canSpendNativeToken;
     ManifestExternalCallPermission[] permittedExternalCalls;
-    ManifestAssociatedFunction[] userOpValidationFunctions;
-    ManifestAssociatedFunction[] runtimeValidationFunctions;
+    ManifestAssociatedFunction[] validationFunctions;
     ManifestAssociatedFunction[] preUserOpValidationHooks;
     ManifestAssociatedFunction[] preRuntimeValidationHooks;
     ManifestExecutionHook[] executionHooks;

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -84,20 +84,20 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC777Recipient, I
             functionId: 0, // Unused.
             dependencyIndex: 0 // Unused.
         });
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](4);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](4);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.tokensReceived.selector,
             associatedFunction: alwaysAllowFunction
         });
-        manifest.runtimeValidationFunctions[1] = ManifestAssociatedFunction({
+        manifest.validationFunctions[1] = ManifestAssociatedFunction({
             executionSelector: this.onERC721Received.selector,
             associatedFunction: alwaysAllowFunction
         });
-        manifest.runtimeValidationFunctions[2] = ManifestAssociatedFunction({
+        manifest.validationFunctions[2] = ManifestAssociatedFunction({
             executionSelector: this.onERC1155Received.selector,
             associatedFunction: alwaysAllowFunction
         });
-        manifest.runtimeValidationFunctions[3] = ManifestAssociatedFunction({
+        manifest.validationFunctions[3] = ManifestAssociatedFunction({
             executionSelector: this.onERC1155BatchReceived.selector,
             associatedFunction: alwaysAllowFunction
         });

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -79,7 +79,7 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC777Recipient, I
         manifest.executionFunctions[3] = this.onERC1155BatchReceived.selector;
 
         // Only runtime validationFunction is needed since callbacks come from token contracts only
-        ManifestFunction memory alwaysAllowFunction = ManifestFunction({
+        ManifestFunction memory alwaysAllowRuntime = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
             functionId: 0, // Unused.
             dependencyIndex: 0 // Unused.
@@ -87,19 +87,19 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC777Recipient, I
         manifest.validationFunctions = new ManifestAssociatedFunction[](4);
         manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.tokensReceived.selector,
-            associatedFunction: alwaysAllowFunction
+            associatedFunction: alwaysAllowRuntime
         });
         manifest.validationFunctions[1] = ManifestAssociatedFunction({
             executionSelector: this.onERC721Received.selector,
-            associatedFunction: alwaysAllowFunction
+            associatedFunction: alwaysAllowRuntime
         });
         manifest.validationFunctions[2] = ManifestAssociatedFunction({
             executionSelector: this.onERC1155Received.selector,
-            associatedFunction: alwaysAllowFunction
+            associatedFunction: alwaysAllowRuntime
         });
         manifest.validationFunctions[3] = ManifestAssociatedFunction({
             executionSelector: this.onERC1155BatchReceived.selector,
-            associatedFunction: alwaysAllowFunction
+            associatedFunction: alwaysAllowRuntime
         });
 
         manifest.interfaceIds = new bytes4[](3);

--- a/src/plugins/owner/ISingleOwnerPlugin.sol
+++ b/src/plugins/owner/ISingleOwnerPlugin.sol
@@ -5,8 +5,7 @@ import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/User
 
 interface ISingleOwnerPlugin {
     enum FunctionId {
-        RUNTIME_VALIDATION_OWNER_OR_SELF,
-        USER_OP_VALIDATION_OWNER
+        VALIDATION_OWNER_OR_SELF
     }
 
     /// @notice This event is emitted when ownership of the account changes.

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -180,14 +180,14 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
             associatedFunction: ownerValidationFunction
         });
 
-        ManifestFunction memory alwaysAllowFunction = ManifestFunction({
+        ManifestFunction memory alwaysAllowRuntime = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
             functionId: 0, // Unused.
             dependencyIndex: 0 // Unused.
         });
         manifest.validationFunctions[7] = ManifestAssociatedFunction({
             executionSelector: this.isValidSignature.selector,
-            associatedFunction: alwaysAllowFunction
+            associatedFunction: alwaysAllowRuntime
         });
 
         return manifest;

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -108,7 +108,7 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
         view
         override
     {
-        if (functionId == uint8(FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)) {
+        if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
             // Validate that the sender is the owner of the account or self.
             if (sender != _owners[msg.sender] && sender != msg.sender) {
                 revert NotAuthorized();
@@ -125,7 +125,7 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
         override
         returns (uint256)
     {
-        if (functionId == uint8(FunctionId.USER_OP_VALIDATION_OWNER)) {
+        if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
             // Validate the user op signature against the owner.
             (address signer,) = (userOpHash.toEthSignedMessageHash()).tryRecover(userOp.signature);
             if (signer == address(0) || signer != _owners[msg.sender]) {
@@ -145,85 +145,47 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
         manifest.executionFunctions[1] = this.isValidSignature.selector;
         manifest.executionFunctions[2] = this.owner.selector;
 
-        ManifestFunction memory ownerUserOpValidationFunction = ManifestFunction({
+        ManifestFunction memory ownerValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.SELF,
-            functionId: uint8(FunctionId.USER_OP_VALIDATION_OWNER),
+            functionId: uint8(FunctionId.VALIDATION_OWNER_OR_SELF),
             dependencyIndex: 0 // Unused.
         });
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](7);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](8);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.transferOwnership.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[1] = ManifestAssociatedFunction({
+        manifest.validationFunctions[1] = ManifestAssociatedFunction({
             executionSelector: IStandardExecutor.execute.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[2] = ManifestAssociatedFunction({
+        manifest.validationFunctions[2] = ManifestAssociatedFunction({
             executionSelector: IStandardExecutor.executeBatch.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[3] = ManifestAssociatedFunction({
+        manifest.validationFunctions[3] = ManifestAssociatedFunction({
             executionSelector: IPluginManager.installPlugin.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[4] = ManifestAssociatedFunction({
+        manifest.validationFunctions[4] = ManifestAssociatedFunction({
             executionSelector: IPluginManager.uninstallPlugin.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[5] = ManifestAssociatedFunction({
+        manifest.validationFunctions[5] = ManifestAssociatedFunction({
             executionSelector: UUPSUpgradeable.upgradeTo.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[6] = ManifestAssociatedFunction({
+        manifest.validationFunctions[6] = ManifestAssociatedFunction({
             executionSelector: UUPSUpgradeable.upgradeToAndCall.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
 
-        ManifestFunction memory ownerOrSelfRuntimeValidationFunction = ManifestFunction({
-            functionType: ManifestAssociatedFunctionType.SELF,
-            functionId: uint8(FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF),
-            dependencyIndex: 0 // Unused.
-        });
         ManifestFunction memory alwaysAllowFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
             functionId: 0, // Unused.
             dependencyIndex: 0 // Unused.
         });
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](9);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
-            executionSelector: this.transferOwnership.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[1] = ManifestAssociatedFunction({
-            executionSelector: this.owner.selector,
-            associatedFunction: alwaysAllowFunction
-        });
-        manifest.runtimeValidationFunctions[2] = ManifestAssociatedFunction({
-            executionSelector: IStandardExecutor.execute.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[3] = ManifestAssociatedFunction({
-            executionSelector: IStandardExecutor.executeBatch.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[4] = ManifestAssociatedFunction({
-            executionSelector: IPluginManager.installPlugin.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[5] = ManifestAssociatedFunction({
-            executionSelector: IPluginManager.uninstallPlugin.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[6] = ManifestAssociatedFunction({
-            executionSelector: UUPSUpgradeable.upgradeTo.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[7] = ManifestAssociatedFunction({
-            executionSelector: UUPSUpgradeable.upgradeToAndCall.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[8] = ManifestAssociatedFunction({
+        manifest.validationFunctions[7] = ManifestAssociatedFunction({
             executionSelector: this.isValidSignature.selector,
             associatedFunction: alwaysAllowFunction
         });

--- a/src/samples/plugins/ModularSessionKeyPlugin.sol
+++ b/src/samples/plugins/ModularSessionKeyPlugin.sol
@@ -192,7 +192,7 @@ contract ModularSessionKeyPlugin is BasePlugin, IModularSessionKeyPlugin {
         override
         returns (uint256)
     {
-        if (functionId == uint8(FunctionId.USER_OP_VALIDATION_TEMPORARY_OWNER)) {
+        if (functionId == uint8(FunctionId.VALIDATION_TEMPORARY_OWNER)) {
             (address signer, ECDSA.RecoverError err) =
                 userOpHash.toEthSignedMessageHash().tryRecover(userOp.signature);
             if (err != ECDSA.RecoverError.NoError) {
@@ -216,7 +216,7 @@ contract ModularSessionKeyPlugin is BasePlugin, IModularSessionKeyPlugin {
         view
         override
     {
-        if (functionId == uint8(FunctionId.RUNTIME_VALIDATION_TEMPORARY_OWNER)) {
+        if (functionId == uint8(FunctionId.VALIDATION_TEMPORARY_OWNER)) {
             bytes4 selector = bytes4(data[0:4]);
             bytes memory key = msg.sender.allocateAssociatedStorageKey(0, 1);
             StoragePointer ptr = key.associatedStorageLookup(keccak256(abi.encodePacked(sender, selector)));
@@ -245,65 +245,42 @@ contract ModularSessionKeyPlugin is BasePlugin, IModularSessionKeyPlugin {
         manifest.executionFunctions[2] = this.addSessionKeyBatch.selector;
         manifest.executionFunctions[3] = this.removeSessionKeyBatch.selector;
 
-        ManifestFunction memory ownerUserOpValidationFunction = ManifestFunction({
+        ManifestFunction memory ownerValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.DEPENDENCY,
             functionId: 0, // Unused.
             dependencyIndex: 0 // Used as first index.
         });
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](4);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](5);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.addSessionKey.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[1] = ManifestAssociatedFunction({
+        manifest.validationFunctions[1] = ManifestAssociatedFunction({
             executionSelector: this.removeSessionKey.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[2] = ManifestAssociatedFunction({
+        manifest.validationFunctions[2] = ManifestAssociatedFunction({
             executionSelector: this.addSessionKeyBatch.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
-        manifest.userOpValidationFunctions[3] = ManifestAssociatedFunction({
+        manifest.validationFunctions[3] = ManifestAssociatedFunction({
             executionSelector: this.removeSessionKeyBatch.selector,
-            associatedFunction: ownerUserOpValidationFunction
+            associatedFunction: ownerValidationFunction
         });
 
-        ManifestFunction memory ownerOrSelfRuntimeValidationFunction = ManifestFunction({
-            functionType: ManifestAssociatedFunctionType.DEPENDENCY,
-            functionId: 0, // Unused.
-            dependencyIndex: 1
-        });
         ManifestFunction memory alwaysAllowFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
             functionId: 0, // Unused.
             dependencyIndex: 0 // Unused.
         });
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](5);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
-            executionSelector: this.addSessionKey.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[1] = ManifestAssociatedFunction({
-            executionSelector: this.removeSessionKey.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[2] = ManifestAssociatedFunction({
-            executionSelector: this.addSessionKeyBatch.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[3] = ManifestAssociatedFunction({
-            executionSelector: this.removeSessionKeyBatch.selector,
-            associatedFunction: ownerOrSelfRuntimeValidationFunction
-        });
-        manifest.runtimeValidationFunctions[4] = ManifestAssociatedFunction({
+        manifest.validationFunctions[4] = ManifestAssociatedFunction({
             executionSelector: this.getSessionDuration.selector,
             associatedFunction: alwaysAllowFunction
         });
 
-        manifest.dependencyInterfaceIds = new bytes4[](2);
+        manifest.dependencyInterfaceIds = new bytes4[](1);
         manifest.dependencyInterfaceIds[0] = type(ISingleOwnerPlugin).interfaceId;
-        manifest.dependencyInterfaceIds[1] = type(ISingleOwnerPlugin).interfaceId;
 
         return manifest;
     }

--- a/src/samples/plugins/TokenSessionKeyPlugin.sol
+++ b/src/samples/plugins/TokenSessionKeyPlugin.sol
@@ -68,32 +68,20 @@ contract TokenSessionKeyPlugin is BasePlugin, ITokenSessionKeyPlugin {
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.transferFromSessionKey.selector;
 
-        ManifestFunction memory tempOwnerUserOpValidationFunction = ManifestFunction({
+        ManifestFunction memory tempOwnerValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.DEPENDENCY,
             functionId: 0, // Unused
             dependencyIndex: 0 // Used as first index
         });
-        ManifestFunction memory tempOwnerRuntimeValidationFunction = ManifestFunction({
-            functionType: ManifestAssociatedFunctionType.DEPENDENCY,
-            functionId: 0, // Unused
-            dependencyIndex: 1 // Used as second index
-        });
 
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.transferFromSessionKey.selector,
-            associatedFunction: tempOwnerUserOpValidationFunction
+            associatedFunction: tempOwnerValidationFunction
         });
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
-            executionSelector: this.transferFromSessionKey.selector,
-            associatedFunction: tempOwnerRuntimeValidationFunction
-        });
-
-        manifest.dependencyInterfaceIds = new bytes4[](2);
+        manifest.dependencyInterfaceIds = new bytes4[](1);
         manifest.dependencyInterfaceIds[0] = type(IModularSessionKeyPlugin).interfaceId;
-        manifest.dependencyInterfaceIds[1] = type(IModularSessionKeyPlugin).interfaceId;
 
         bytes4[] memory permittedExternalSelectors = new bytes4[](1);
         permittedExternalSelectors[0] = TRANSFERFROM_SELECTOR;

--- a/src/samples/plugins/interfaces/ISessionKeyPlugin.sol
+++ b/src/samples/plugins/interfaces/ISessionKeyPlugin.sol
@@ -5,8 +5,7 @@ import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/User
 
 interface IModularSessionKeyPlugin {
     enum FunctionId {
-        RUNTIME_VALIDATION_TEMPORARY_OWNER,
-        USER_OP_VALIDATION_TEMPORARY_OWNER
+        VALIDATION_TEMPORARY_OWNER
     }
 
     /// @notice This event is emitted when a session key is added to the account.

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -215,8 +215,7 @@ interface IAccountLoupe {
     /// @notice Config for an execution function, given a selector.
     struct ExecutionFunctionConfig {
         address plugin;
-        FunctionReference userOpValidationFunction;
-        FunctionReference runtimeValidationFunction;
+        FunctionReference validationFunction;
     }
 
     /// @notice Pre and post hooks for a given selector.
@@ -423,8 +422,7 @@ struct PluginManifest {
     // plugin MUST still be able to spend up to the balance that it sends to the account in the same call.
     bool canSpendNativeToken;
     ManifestExternalCallPermission[] permittedExternalCalls;
-    ManifestAssociatedFunction[] userOpValidationFunctions;
-    ManifestAssociatedFunction[] runtimeValidationFunctions;
+    ManifestAssociatedFunction[] validationFunctions;
     ManifestAssociatedFunction[] preUserOpValidationHooks;
     ManifestAssociatedFunction[] preRuntimeValidationHooks;
     ManifestExecutionHook[] executionHooks;

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -60,7 +60,7 @@ contract AccountExecHooksTest is OptimizedTest {
 
         m1.executionFunctions.push(_EXEC_SELECTOR);
 
-        m1.runtimeValidationFunctions.push(
+        m1.validationFunctions.push(
             ManifestAssociatedFunction({
                 executionSelector: _EXEC_SELECTOR,
                 associatedFunction: ManifestFunction({

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -31,8 +31,7 @@ contract AccountLoupeTest is OptimizedTest {
 
     UpgradeableModularAccount public account1;
 
-    FunctionReference public ownerUserOpValidation;
-    FunctionReference public ownerRuntimeValidation;
+    FunctionReference public ownerValidation;
 
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
@@ -48,11 +47,8 @@ contract AccountLoupeTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(comprehensivePlugin.pluginManifest()));
         account1.installPlugin(address(comprehensivePlugin), manifestHash, "", new FunctionReference[](0));
 
-        ownerUserOpValidation = FunctionReferenceLib.pack(
-            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
-        );
-        ownerRuntimeValidation = FunctionReferenceLib.pack(
-            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+        ownerValidation = FunctionReferenceLib.pack(
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
         );
     }
 
@@ -67,28 +63,22 @@ contract AccountLoupeTest is OptimizedTest {
 
     function test_pluginLoupe_getExecutionFunctionConfig_native() public {
         bytes4[] memory selectorsToCheck = new bytes4[](5);
-        FunctionReference[] memory expectedUserOpValidations = new FunctionReference[](5);
-        FunctionReference[] memory expectedRuntimeValidations = new FunctionReference[](5);
+        FunctionReference[] memory expectedValidations = new FunctionReference[](5);
 
         selectorsToCheck[0] = IStandardExecutor.execute.selector;
-        expectedUserOpValidations[0] = ownerUserOpValidation;
-        expectedRuntimeValidations[0] = ownerRuntimeValidation;
+        expectedValidations[0] = ownerValidation;
 
         selectorsToCheck[1] = IStandardExecutor.executeBatch.selector;
-        expectedUserOpValidations[1] = ownerUserOpValidation;
-        expectedRuntimeValidations[1] = ownerRuntimeValidation;
+        expectedValidations[1] = ownerValidation;
 
         selectorsToCheck[2] = UUPSUpgradeable.upgradeToAndCall.selector;
-        expectedUserOpValidations[2] = ownerUserOpValidation;
-        expectedRuntimeValidations[2] = ownerRuntimeValidation;
+        expectedValidations[2] = ownerValidation;
 
         selectorsToCheck[3] = IPluginManager.installPlugin.selector;
-        expectedUserOpValidations[3] = ownerUserOpValidation;
-        expectedRuntimeValidations[3] = ownerRuntimeValidation;
+        expectedValidations[3] = ownerValidation;
 
         selectorsToCheck[4] = IPluginManager.uninstallPlugin.selector;
-        expectedUserOpValidations[4] = ownerUserOpValidation;
-        expectedRuntimeValidations[4] = ownerRuntimeValidation;
+        expectedValidations[4] = ownerValidation;
 
         for (uint256 i = 0; i < selectorsToCheck.length; i++) {
             IAccountLoupe.ExecutionFunctionConfig memory config =
@@ -96,12 +86,8 @@ contract AccountLoupeTest is OptimizedTest {
 
             assertEq(config.plugin, address(account1));
             assertEq(
-                FunctionReference.unwrap(config.userOpValidationFunction),
-                FunctionReference.unwrap(expectedUserOpValidations[i])
-            );
-            assertEq(
-                FunctionReference.unwrap(config.runtimeValidationFunction),
-                FunctionReference.unwrap(expectedRuntimeValidations[i])
+                FunctionReference.unwrap(config.validationFunction),
+                FunctionReference.unwrap(expectedValidations[i])
             );
         }
     }
@@ -109,22 +95,17 @@ contract AccountLoupeTest is OptimizedTest {
     function test_pluginLoupe_getExecutionFunctionConfig_plugin() public {
         bytes4[] memory selectorsToCheck = new bytes4[](2);
         address[] memory expectedPluginAddress = new address[](2);
-        FunctionReference[] memory expectedUserOpValidations = new FunctionReference[](2);
-        FunctionReference[] memory expectedRuntimeValidations = new FunctionReference[](2);
+        FunctionReference[] memory expectedValidations = new FunctionReference[](2);
 
         selectorsToCheck[0] = comprehensivePlugin.foo.selector;
         expectedPluginAddress[0] = address(comprehensivePlugin);
-        expectedUserOpValidations[0] = FunctionReferenceLib.pack(
-            address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.USER_OP_VALIDATION)
-        );
-        expectedRuntimeValidations[0] = FunctionReferenceLib.pack(
-            address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.RUNTIME_VALIDATION)
+        expectedValidations[0] = FunctionReferenceLib.pack(
+            address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.VALIDATION)
         );
 
         selectorsToCheck[1] = singleOwnerPlugin.transferOwnership.selector;
         expectedPluginAddress[1] = address(singleOwnerPlugin);
-        expectedUserOpValidations[1] = ownerUserOpValidation;
-        expectedRuntimeValidations[1] = ownerRuntimeValidation;
+        expectedValidations[1] = ownerValidation;
 
         for (uint256 i = 0; i < selectorsToCheck.length; i++) {
             IAccountLoupe.ExecutionFunctionConfig memory config =
@@ -132,12 +113,8 @@ contract AccountLoupeTest is OptimizedTest {
 
             assertEq(config.plugin, expectedPluginAddress[i]);
             assertEq(
-                FunctionReference.unwrap(config.userOpValidationFunction),
-                FunctionReference.unwrap(expectedUserOpValidations[i])
-            );
-            assertEq(
-                FunctionReference.unwrap(config.runtimeValidationFunction),
-                FunctionReference.unwrap(expectedRuntimeValidations[i])
+                FunctionReference.unwrap(config.validationFunction),
+                FunctionReference.unwrap(expectedValidations[i])
             );
         }
     }

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -11,7 +11,6 @@ import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
 import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
 import {
-    BadValidationMagicValue_UserOp_Plugin,
     BadValidationMagicValue_PreRuntimeValidationHook_Plugin,
     BadValidationMagicValue_PreUserOpValidationHook_Plugin,
     BadValidationMagicValue_PreExecHook_Plugin,
@@ -37,22 +36,6 @@ contract ManifestValidityTest is OptimizedTest {
         // Create an account with "this" as the owner, so we can execute along the runtime path with regular
         // solidity semantics
         account = factory.createAccount(address(this), 0);
-    }
-
-    // Tests that the plugin manager rejects a plugin with a user op validationFunction set to "validation always
-    // allow"
-    function test_ManifestValidity_invalid_ValidationAlwaysAllow_UserOpValidationFunction() public {
-        BadValidationMagicValue_UserOp_Plugin plugin = new BadValidationMagicValue_UserOp_Plugin();
-
-        bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
-
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
-            plugin: address(plugin),
-            manifestHash: manifestHash,
-            pluginInstallData: "",
-            dependencies: new FunctionReference[](0)
-        });
     }
 
     // Tests that the plugin manager rejects a plugin with a pre-runtime validation hook set to "validation always

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -202,7 +202,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
             initCode: "",
             callData: abi.encodeCall(
                 UpgradeableModularAccount.execute, (address(counter), 0, abi.encodeCall(counter.increment, ()))
-                ),
+            ),
             callGasLimit: CALL_GAS_LIMIT,
             verificationGasLimit: VERIFICATION_GAS_LIMIT,
             preVerificationGas: 0,

--- a/test/comparison/CompareSimpleAccount.t.sol
+++ b/test/comparison/CompareSimpleAccount.t.sol
@@ -135,7 +135,7 @@ contract CompareSimpleAccountTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 SimpleAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-                ),
+            ),
             callGasLimit: 5000000,
             verificationGasLimit: 5000000,
             preVerificationGas: 0,

--- a/test/mocks/plugins/BadTransferOwnershipPlugin.sol
+++ b/test/mocks/plugins/BadTransferOwnershipPlugin.sol
@@ -47,8 +47,8 @@ contract BadTransferOwnershipPlugin is BasePlugin {
         manifest.permittedExecutionSelectors = new bytes4[](1);
         manifest.permittedExecutionSelectors[0] = ISingleOwnerPlugin.transferOwnership.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.evilTransferOwnership.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -18,10 +18,9 @@ contract ComprehensivePlugin is BasePlugin {
     enum FunctionId {
         PRE_USER_OP_VALIDATION_HOOK_1,
         PRE_USER_OP_VALIDATION_HOOK_2,
-        USER_OP_VALIDATION,
         PRE_RUNTIME_VALIDATION_HOOK_1,
         PRE_RUNTIME_VALIDATION_HOOK_2,
-        RUNTIME_VALIDATION,
+        VALIDATION,
         PRE_EXECUTION_HOOK,
         PRE_PERMITTED_CALL_EXECUTION_HOOK,
         POST_EXECUTION_HOOK,
@@ -66,7 +65,7 @@ contract ComprehensivePlugin is BasePlugin {
         override
         returns (uint256)
     {
-        if (functionId == uint8(FunctionId.USER_OP_VALIDATION)) {
+        if (functionId == uint8(FunctionId.VALIDATION)) {
             return 0;
         }
         revert NotImplemented();
@@ -86,7 +85,7 @@ contract ComprehensivePlugin is BasePlugin {
         pure
         override
     {
-        if (functionId == uint8(FunctionId.RUNTIME_VALIDATION)) {
+        if (functionId == uint8(FunctionId.VALIDATION)) {
             return;
         }
         revert NotImplemented();
@@ -121,26 +120,15 @@ contract ComprehensivePlugin is BasePlugin {
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.foo.selector;
 
-        ManifestFunction memory fooUserOpValidationFunction = ManifestFunction({
+        ManifestFunction memory fooValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.SELF,
-            functionId: uint8(FunctionId.USER_OP_VALIDATION),
+            functionId: uint8(FunctionId.VALIDATION),
             dependencyIndex: 0 // Unused.
         });
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
-            associatedFunction: fooUserOpValidationFunction
-        });
-
-        ManifestFunction memory fooRuntimeValidationFunction = ManifestFunction({
-            functionType: ManifestAssociatedFunctionType.SELF,
-            functionId: uint8(FunctionId.RUNTIME_VALIDATION),
-            dependencyIndex: 0 // Unused.
-        });
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
-            executionSelector: this.foo.selector,
-            associatedFunction: fooRuntimeValidationFunction
+            associatedFunction: fooValidationFunction
         });
 
         manifest.preUserOpValidationHooks = new ManifestAssociatedFunction[](4);

--- a/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
+++ b/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
@@ -45,7 +45,7 @@ contract EFPCallerPlugin is BaseTestPlugin {
         manifest.executionFunctions[9] = this.getNumberCounter3.selector;
         manifest.executionFunctions[10] = this.incrementCounter3.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](11);
+        manifest.validationFunctions = new ManifestAssociatedFunction[](11);
 
         ManifestFunction memory alwaysAllowValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
@@ -54,7 +54,7 @@ contract EFPCallerPlugin is BaseTestPlugin {
         });
 
         for (uint256 i = 0; i < manifest.executionFunctions.length; i++) {
-            manifest.runtimeValidationFunctions[i] = ManifestAssociatedFunction({
+            manifest.validationFunctions[i] = ManifestAssociatedFunction({
                 executionSelector: manifest.executionFunctions[i],
                 associatedFunction: alwaysAllowValidationFunction
             });
@@ -181,8 +181,8 @@ contract EFPCallerPluginAnyExternal is BaseTestPlugin {
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.passthroughExecute.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.passthroughExecute.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,

--- a/test/mocks/plugins/ManifestValidityMocks.sol
+++ b/test/mocks/plugins/ManifestValidityMocks.sol
@@ -16,36 +16,6 @@ import {IPlugin} from "../../../src/interfaces/IPlugin.sol";
 
 import {BaseTestPlugin} from "./BaseTestPlugin.sol";
 
-contract BadValidationMagicValue_UserOp_Plugin is BaseTestPlugin {
-    function onInstall(bytes calldata) external override {}
-
-    function onUninstall(bytes calldata) external override {}
-
-    function foo() external pure returns (bytes32) {
-        return keccak256("bar");
-    }
-
-    function pluginManifest() external pure override returns (PluginManifest memory) {
-        PluginManifest memory manifest;
-
-        manifest.executionFunctions = new bytes4[](1);
-        manifest.executionFunctions[0] = this.foo.selector;
-
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
-            executionSelector: this.foo.selector,
-            associatedFunction: ManifestFunction({
-                // Illegal assignment: validation always allow only usable on runtime validation functions
-                functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
-                functionId: 0,
-                dependencyIndex: 0
-            })
-        });
-
-        return manifest;
-    }
-}
-
 contract BadValidationMagicValue_PreRuntimeValidationHook_Plugin is BaseTestPlugin {
     function onInstall(bytes calldata) external override {}
 
@@ -61,8 +31,8 @@ contract BadValidationMagicValue_PreRuntimeValidationHook_Plugin is BaseTestPlug
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.foo.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
@@ -101,8 +71,8 @@ contract BadValidationMagicValue_PreUserOpValidationHook_Plugin is BaseTestPlugi
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.foo.selector;
 
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
@@ -212,8 +182,8 @@ contract BadHookMagicValue_UserOpValidationFunction_Plugin is BaseTestPlugin {
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.foo.selector;
 
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY,
@@ -241,8 +211,8 @@ contract BadHookMagicValue_RuntimeValidationFunction_Plugin is BaseTestPlugin {
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.foo.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY,

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -45,8 +45,8 @@ contract ResultCreatorPlugin is BaseTestPlugin {
         manifest.executionFunctions[0] = this.foo.selector;
         manifest.executionFunctions[1] = this.bar.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
@@ -121,8 +121,8 @@ contract ResultConsumerPlugin is BaseTestPlugin {
         manifest.executionFunctions[0] = this.checkResultEFPFallback.selector;
         manifest.executionFunctions[1] = this.checkResultEFPExternal.selector;
 
-        manifest.runtimeValidationFunctions = new ManifestAssociatedFunction[](2);
-        manifest.runtimeValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](2);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.checkResultEFPFallback.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
@@ -130,7 +130,7 @@ contract ResultConsumerPlugin is BaseTestPlugin {
                 dependencyIndex: 0
             })
         });
-        manifest.runtimeValidationFunctions[1] = ManifestAssociatedFunction({
+        manifest.validationFunctions[1] = ManifestAssociatedFunction({
             executionSelector: this.checkResultEFPExternal.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -78,8 +78,8 @@ contract MockUserOpValidationPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions = new bytes4[](1);
         manifest.executionFunctions[0] = this.foo.selector;
 
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
@@ -121,8 +121,8 @@ contract MockUserOpValidation1HookPlugin is MockBaseUserOpValidationPlugin {
             functionId: uint8(FunctionId.USER_OP_VALIDATION),
             dependencyIndex: 0 // Unused.
         });
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.bar.selector,
             associatedFunction: userOpValidationFunctionRef
         });
@@ -173,8 +173,8 @@ contract MockUserOpValidation2HookPlugin is MockBaseUserOpValidationPlugin {
             functionId: uint8(FunctionId.USER_OP_VALIDATION),
             dependencyIndex: 0 // Unused.
         });
-        manifest.userOpValidationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.userOpValidationFunctions[0] = ManifestAssociatedFunction({
+        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
+        manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.baz.selector,
             associatedFunction: userOpValidationFunctionRef
         });

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -113,13 +113,13 @@ contract SingleOwnerPluginTest is OptimizedTest {
         plugin.transferOwnership(owner1);
         assertEq(owner1, plugin.owner());
         plugin.runtimeValidationFunction(
-            uint8(ISingleOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF), owner1, 0, ""
+            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, ""
         );
 
         vm.startPrank(b);
         vm.expectRevert(ISingleOwnerPlugin.NotAuthorized.selector);
         plugin.runtimeValidationFunction(
-            uint8(ISingleOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF), owner1, 0, ""
+            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, ""
         );
     }
 
@@ -136,7 +136,7 @@ contract SingleOwnerPluginTest is OptimizedTest {
 
         // sig check should fail
         uint256 success = plugin.userOpValidationFunction(
-            uint8(ISingleOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER), userOp, userOpHash
+            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), userOp, userOpHash
         );
         assertEq(success, 1);
 
@@ -146,7 +146,7 @@ contract SingleOwnerPluginTest is OptimizedTest {
 
         // sig check should pass
         success = plugin.userOpValidationFunction(
-            uint8(ISingleOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER), userOp, userOpHash
+            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), userOp, userOpHash
         );
         assertEq(success, 0);
     }

--- a/test/samples/plugins/ModularSessionKeyPlugin.t.sol
+++ b/test/samples/plugins/ModularSessionKeyPlugin.t.sol
@@ -129,8 +129,7 @@ contract ModularSessionKeyPluginTest is Test {
 
         FunctionReference[] memory tokenSessionDependency = new FunctionReference[](1);
         tokenSessionDependency[0] = FunctionReferenceLib.pack(
-            address(modularSessionKeyPlugin),
-            uint8(IModularSessionKeyPlugin.FunctionId.VALIDATION_TEMPORARY_OWNER)
+            address(modularSessionKeyPlugin), uint8(IModularSessionKeyPlugin.FunctionId.VALIDATION_TEMPORARY_OWNER)
         );
         bytes32 tokenSessionKeyManifestHash = keccak256(abi.encode(tokenSessionKeyPlugin.pluginManifest()));
 

--- a/test/samples/plugins/ModularSessionKeyPlugin.t.sol
+++ b/test/samples/plugins/ModularSessionKeyPlugin.t.sol
@@ -99,12 +99,9 @@ contract ModularSessionKeyPluginTest is Test {
         vm.deal(address(account), 1 ether);
 
         vm.startPrank(owner);
-        FunctionReference[] memory modularSessionDependency = new FunctionReference[](2);
+        FunctionReference[] memory modularSessionDependency = new FunctionReference[](1);
         modularSessionDependency[0] = FunctionReferenceLib.pack(
-            address(ownerPlugin), uint8(ISingleOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
-        );
-        modularSessionDependency[1] = FunctionReferenceLib.pack(
-            address(ownerPlugin), uint8(ISingleOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+            address(ownerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
         );
 
         bytes32 modularSessionKeyManifestHash = keccak256(abi.encode(modularSessionKeyPlugin.pluginManifest()));
@@ -130,14 +127,10 @@ contract ModularSessionKeyPluginTest is Test {
             dependencies: modularSessionDependency
         });
 
-        FunctionReference[] memory tokenSessionDependency = new FunctionReference[](2);
+        FunctionReference[] memory tokenSessionDependency = new FunctionReference[](1);
         tokenSessionDependency[0] = FunctionReferenceLib.pack(
             address(modularSessionKeyPlugin),
-            uint8(IModularSessionKeyPlugin.FunctionId.USER_OP_VALIDATION_TEMPORARY_OWNER)
-        );
-        tokenSessionDependency[1] = FunctionReferenceLib.pack(
-            address(modularSessionKeyPlugin),
-            uint8(IModularSessionKeyPlugin.FunctionId.RUNTIME_VALIDATION_TEMPORARY_OWNER)
+            uint8(IModularSessionKeyPlugin.FunctionId.VALIDATION_TEMPORARY_OWNER)
         );
         bytes32 tokenSessionKeyManifestHash = keccak256(abi.encode(tokenSessionKeyPlugin.pluginManifest()));
 
@@ -245,7 +238,7 @@ contract ModularSessionKeyPluginTest is Test {
             abi.encodeWithSelector(
                 UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
                 address(modularSessionKeyPlugin),
-                IModularSessionKeyPlugin.FunctionId.RUNTIME_VALIDATION_TEMPORARY_OWNER,
+                IModularSessionKeyPlugin.FunctionId.VALIDATION_TEMPORARY_OWNER,
                 revertReason
             )
         );
@@ -286,7 +279,7 @@ contract ModularSessionKeyPluginTest is Test {
             abi.encodeWithSelector(
                 UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
                 address(modularSessionKeyPlugin),
-                IModularSessionKeyPlugin.FunctionId.RUNTIME_VALIDATION_TEMPORARY_OWNER,
+                IModularSessionKeyPlugin.FunctionId.VALIDATION_TEMPORARY_OWNER,
                 revertReason
             )
         );
@@ -308,7 +301,7 @@ contract ModularSessionKeyPluginTest is Test {
             abi.encodeWithSelector(
                 UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
                 address(modularSessionKeyPlugin),
-                IModularSessionKeyPlugin.FunctionId.RUNTIME_VALIDATION_TEMPORARY_OWNER,
+                IModularSessionKeyPlugin.FunctionId.VALIDATION_TEMPORARY_OWNER,
                 revertReason
             )
         );


### PR DESCRIPTION
## Motivation

Under the current design of ERC-6900, the account is responsible for tracking the assigned validation plugin for user op validation and runtime validation separately. In practice, it rarely makes sense for these to be assigned differently, and may actually cause ambiguity around whether or not a plugin should leave one validator unassigned or set to a magic value if the plugin doesn't implement it.

Therefore, it _might_ make sense to merge the assignment of these functions, and expect plugins to implement the functions (or revert if unsupported). This is an experimental change, looking for feedback.

The merge of these two assignments also simplifies the work needed to support multiple validation schemes per function (https://github.com/erc6900/resources/issues/4).

## Solution

- Replace the manifest fields `userOpValidationFunctions` and `runtimeValidationFunctions` with `validationFunctions`.
- Replace the storage fields `userOpValidation` and `runtimeValidation` within `SelectorData` with just `validation`.
- Use either `userOpValidationFunction` or `runtimeValidationFunction` with the same function id assigned from `UpgradeableModularAccount`.
- Merge validation function id's in the provided sample and mock plugins.
- Update the manifests used in sample and mock plugins to only specify validation functions once.
- Update the dependencies used by plugins to only specify one dependent validation function, rather than two.