### PR TITLE
feat: [v0.8-develop, experimental] signature validator interface

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -61,6 +61,8 @@ struct AccountStorage {
     mapping(IPlugin => mapping(address => PermittedExternalCallData)) permittedExternalCalls;
     // For ERC165 introspection
     mapping(bytes4 => uint256) supportedIfaces;
+    // Holds all added signature validators.
+    EnumerableSet.AddressSet signatureValidators;
 }
 
 function getAccountStorage() pure returns (AccountStorage storage _storage) {

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -137,6 +137,17 @@ interface IPlugin {
     /// @param data The calldata sent.
     function validateRuntime(address sender, uint256 value, bytes calldata data) external;
 
+    /// @notice Validates a signature using ERC-1271.
+    /// @param sender the address that sent the ERC-1271 request to the smart account
+    /// @param hash the hash of the ERC-1271 request
+    /// @param signature the signature of the ERC-1271 request
+    ///
+    /// @return the ERC-1271 `MAGIC_VALUE` if the signature is valid, or 0xFFFFFFFF if invalid.
+    function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
+        external
+        view
+        returns (bytes4);
+
     /// @notice Run the pre execution hook.
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param sender The caller address.

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -137,17 +137,6 @@ interface IPlugin {
     /// @param data The calldata sent.
     function validateRuntime(address sender, uint256 value, bytes calldata data) external;
 
-    /// @notice Validates a signature using ERC-1271.
-    /// @param sender the address that sent the ERC-1271 request to the smart account
-    /// @param hash the hash of the ERC-1271 request
-    /// @param signature the signature of the ERC-1271 request
-    ///
-    /// @return the ERC-1271 `MAGIC_VALUE` if the signature is valid, or 0xFFFFFFFF if invalid.
-    function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
-        external
-        view
-        returns (bytes4);
-
     /// @notice Run the pre execution hook.
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param sender The caller address.
@@ -162,6 +151,17 @@ interface IPlugin {
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param preExecHookData The context returned by its associated pre execution hook.
     function postExecutionHook(bytes calldata preExecHookData) external;
+
+    /// @notice Validates a signature using ERC-1271.
+    /// @param sender the address that sent the ERC-1271 request to the smart account
+    /// @param hash the hash of the ERC-1271 request
+    /// @param signature the signature of the ERC-1271 request
+    ///
+    /// @return the ERC-1271 `MAGIC_VALUE` if the signature is valid, or 0xFFFFFFFF if invalid.
+    function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
+        external
+        view
+        returns (bytes4);
 
     /// @notice Describe the contents and intended configuration of the plugin.
     /// @dev This manifest MUST stay constant over time.

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -57,6 +57,16 @@ abstract contract BasePlugin is ERC165, IPlugin {
         revert NotImplemented();
     }
 
+    function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        (sender, hash, signature);
+        revert NotImplemented();
+    }
+
     /// @inheritdoc IPlugin
     function preExecutionHook(address sender, uint256 value, bytes calldata data)
         external

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -58,17 +58,6 @@ abstract contract BasePlugin is ERC165, IPlugin {
     }
 
     /// @inheritdoc IPlugin
-    function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
-        external
-        virtual
-        view
-        returns (bytes4)
-    {
-        (sender, hash, signature);
-        revert NotImplemented();
-    }
-
-    /// @inheritdoc IPlugin
     function preExecutionHook(address sender, uint256 value, bytes calldata data)
         external
         virtual
@@ -81,6 +70,17 @@ abstract contract BasePlugin is ERC165, IPlugin {
     /// @inheritdoc IPlugin
     function postExecutionHook(bytes calldata preExecHookData) external virtual {
         (preExecHookData);
+        revert NotImplemented();
+    }
+
+    /// @inheritdoc IPlugin
+    function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
+        external
+        view
+        virtual
+        returns (bytes4)
+    {
+        (sender, hash, signature);
         revert NotImplemented();
     }
 

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -57,10 +57,11 @@ abstract contract BasePlugin is ERC165, IPlugin {
         revert NotImplemented();
     }
 
+    /// @inheritdoc IPlugin
     function isValidSignatureWithSender(address sender, bytes32 hash, bytes calldata signature)
         external
-        pure
-        override
+        virtual
+        view
         returns (bytes4)
     {
         (sender, hash, signature);

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -65,7 +65,12 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin {
     /// validation used in `validateUserOp`, this does///*not** wrap the digest in
     /// an "Ethereum Signed Message" envelope before checking the signature in
     /// the EOA-owner case.
-    function isValidSignatureWithSender(address sender, bytes32 digest, bytes memory signature) public view override returns (bytes4) {
+    function isValidSignatureWithSender(address sender, bytes32 digest, bytes memory signature)
+        public
+        view
+        override
+        returns (bytes4)
+    {
         (sender);
         if (SignatureChecker.isValidSignatureNow(_owners[msg.sender], digest, signature)) {
             return _1271_MAGIC_VALUE;

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -139,7 +139,7 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
             functionType: ManifestAssociatedFunctionType.SELF,
             dependencyIndex: 0 // Unused.
         });
-        manifest.validationFunctions = new ManifestAssociatedFunction[](8);
+        manifest.validationFunctions = new ManifestAssociatedFunction[](7);
         manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.transferOwnership.selector,
             associatedFunction: ownerValidationFunction
@@ -167,15 +167,6 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
         manifest.validationFunctions[6] = ManifestAssociatedFunction({
             executionSelector: UUPSUpgradeable.upgradeToAndCall.selector,
             associatedFunction: ownerValidationFunction
-        });
-
-        ManifestFunction memory alwaysAllowFunction = ManifestFunction({
-            functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
-            dependencyIndex: 0 // Unused.
-        });
-        manifest.validationFunctions[7] = ManifestAssociatedFunction({
-            executionSelector: this.isValidSignature.selector,
-            associatedFunction: alwaysAllowFunction
         });
 
         return manifest;

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -420,6 +420,14 @@ contract UpgradeableModularAccountTest is OptimizedTest {
         assertEq(plugins[1], address(plugin));
     }
 
+    function test_isValidSignature_EOA() public {
+        bytes32 digest = keccak256("test");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, digest);
+
+        // sig check should pass using 1271 magic value
+        assertEq(bytes4(0x1626ba7e), account2.isValidSignature(digest, abi.encodePacked(r, s, v)));
+    }
+
     function _installPluginWithExecHooks() internal returns (MockPlugin plugin) {
         vm.startPrank(owner2);
 

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -151,20 +151,20 @@ contract SingleOwnerPluginTest is OptimizedTest {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
         // sig check should fail
-        assertEq(plugin.isValidSignature(digest, abi.encodePacked(r, s, v)), bytes4(0xFFFFFFFF));
+        assertEq(plugin.isValidSignatureWithSender(address(0), digest, abi.encodePacked(r, s, v)), bytes4(0xFFFFFFFF));
 
         // transfer ownership to signer
         plugin.transferOwnership(signer);
         assertEq(signer, plugin.owner());
 
         // sig check should pass
-        assertEq(plugin.isValidSignature(digest, abi.encodePacked(r, s, v)), _1271_MAGIC_VALUE);
+        assertEq(plugin.isValidSignatureWithSender(address(0), digest, abi.encodePacked(r, s, v)), _1271_MAGIC_VALUE);
     }
 
     function testFuzz_isValidSignatureForContractOwner(bytes32 digest) public {
         vm.startPrank(a);
         plugin.transferOwnership(address(contractOwner));
         bytes memory signature = contractOwner.sign(digest);
-        assertEq(plugin.isValidSignature(digest, signature), _1271_MAGIC_VALUE);
+        assertEq(plugin.isValidSignatureWithSender(address(0), digest, signature), _1271_MAGIC_VALUE);
     }
 }

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -151,14 +151,18 @@ contract SingleOwnerPluginTest is OptimizedTest {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
         // sig check should fail
-        assertEq(plugin.isValidSignatureWithSender(address(0), digest, abi.encodePacked(r, s, v)), bytes4(0xFFFFFFFF));
+        assertEq(
+            plugin.isValidSignatureWithSender(address(0), digest, abi.encodePacked(r, s, v)), bytes4(0xFFFFFFFF)
+        );
 
         // transfer ownership to signer
         plugin.transferOwnership(signer);
         assertEq(signer, plugin.owner());
 
         // sig check should pass
-        assertEq(plugin.isValidSignatureWithSender(address(0), digest, abi.encodePacked(r, s, v)), _1271_MAGIC_VALUE);
+        assertEq(
+            plugin.isValidSignatureWithSender(address(0), digest, abi.encodePacked(r, s, v)), _1271_MAGIC_VALUE
+        );
     }
 
     function testFuzz_isValidSignatureForContractOwner(bytes32 digest) public {


### PR DESCRIPTION
## Motivation

Previous, ERC-1271 support for 6900 accounts was left up to plugin implementation. This could cause potential function definition conflicts, and we can address this by adding it to the validation interface and supporting multiple validation plugins at once (https://github.com/erc6900/resources/issues/4).

This is an experimental implementation to gather feedback on the proposed change.

## Solution

Following the miniMSA pattern of defining `isValidSignatureWithSender`, rather than the standard 1271 function.
Fully implementing signature validation switching depends on multi-validation support, so that isn't implemented here. Instead, the old defined signature validator is used. This change is intended to cover the expansion to the plugin interface.