### PR TITLE
refactor: [v0.8-develop] account test base

### DIFF
--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -2,9 +2,7 @@
 pragma solidity ^0.8.19;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
 import {
     ManifestAssociatedFunctionType,
@@ -16,33 +14,22 @@ import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
 import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
-import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
-import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
 import {ComprehensivePlugin} from "../mocks/plugins/ComprehensivePlugin.sol";
 import {MockPlugin} from "../mocks/MockPlugin.sol";
-import {OptimizedTest} from "../utils/OptimizedTest.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
-contract AccountLoupeTest is OptimizedTest {
-    EntryPoint public entryPoint;
-    SingleOwnerPlugin public singleOwnerPlugin;
-    MSCAFactoryFixture public factory;
+contract AccountLoupeTest is AccountTestBase {
     ComprehensivePlugin public comprehensivePlugin;
-
-    UpgradeableModularAccount public account1;
 
     FunctionReference public ownerValidation;
 
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     function setUp() public {
-        entryPoint = new EntryPoint();
+        _transferOwnershipToTest();
 
-        singleOwnerPlugin = _deploySingleOwnerPlugin();
-        factory = new MSCAFactoryFixture(entryPoint, singleOwnerPlugin);
         comprehensivePlugin = new ComprehensivePlugin();
-
-        account1 = factory.createAccount(address(this), 0);
 
         bytes32 manifestHash = keccak256(abi.encode(comprehensivePlugin.pluginManifest()));
         account1.installPlugin(address(comprehensivePlugin), manifestHash, "", new FunctionReference[](0));

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -1,49 +1,32 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
-
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
 import {
     RegularResultContract,
     ResultCreatorPlugin,
     ResultConsumerPlugin
 } from "../mocks/plugins/ReturnDataPluginMocks.sol";
-import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
-import {OptimizedTest} from "../utils/OptimizedTest.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
 // Tests all the different ways that return data can be read from plugins through an account
-contract AccountReturnDataTest is OptimizedTest {
-    EntryPoint public entryPoint; // Just to be able to construct the factory
-    SingleOwnerPlugin public singleOwnerPlugin;
-    MSCAFactoryFixture public factory;
-
+contract AccountReturnDataTest is AccountTestBase {
     RegularResultContract public regularResultContract;
     ResultCreatorPlugin public resultCreatorPlugin;
     ResultConsumerPlugin public resultConsumerPlugin;
 
-    UpgradeableModularAccount public account;
-
     function setUp() public {
-        entryPoint = new EntryPoint();
-        singleOwnerPlugin = _deploySingleOwnerPlugin();
-        factory = new MSCAFactoryFixture(entryPoint, singleOwnerPlugin);
+        _transferOwnershipToTest();
 
         regularResultContract = new RegularResultContract();
         resultCreatorPlugin = new ResultCreatorPlugin();
         resultConsumerPlugin = new ResultConsumerPlugin(resultCreatorPlugin, regularResultContract);
 
-        // Create an account with "this" as the owner, so we can execute along the runtime path with regular
-        // solidity semantics
-        account = factory.createAccount(address(this), 0);
-
         // Add the result creator plugin to the account
         bytes32 resultCreatorManifestHash = keccak256(abi.encode(resultCreatorPlugin.pluginManifest()));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(resultCreatorPlugin),
             manifestHash: resultCreatorManifestHash,
             pluginInstallData: "",
@@ -51,7 +34,7 @@ contract AccountReturnDataTest is OptimizedTest {
         });
         // Add the result consumer plugin to the account
         bytes32 resultConsumerManifestHash = keccak256(abi.encode(resultConsumerPlugin.pluginManifest()));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(resultConsumerPlugin),
             manifestHash: resultConsumerManifestHash,
             pluginInstallData: "",
@@ -61,7 +44,7 @@ contract AccountReturnDataTest is OptimizedTest {
 
     // Tests the ability to read the result of plugin execution functions via the account's fallback
     function test_returnData_fallback() public {
-        bytes32 result = ResultCreatorPlugin(address(account)).foo();
+        bytes32 result = ResultCreatorPlugin(address(account1)).foo();
 
         assertEq(result, keccak256("bar"));
     }
@@ -69,7 +52,7 @@ contract AccountReturnDataTest is OptimizedTest {
     // Tests the ability to read the results of contracts called via IStandardExecutor.execute
     function test_returnData_singular_execute() public {
         bytes memory returnData =
-            account.execute(address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()));
+            account1.execute(address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()));
 
         bytes32 result = abi.decode(returnData, (bytes32));
 
@@ -90,7 +73,7 @@ contract AccountReturnDataTest is OptimizedTest {
             data: abi.encodeCall(RegularResultContract.bar, ())
         });
 
-        bytes[] memory returnDatas = account.executeBatch(calls);
+        bytes[] memory returnDatas = account1.executeBatch(calls);
 
         bytes32 result1 = abi.decode(returnDatas[0], (bytes32));
         bytes32 result2 = abi.decode(returnDatas[1], (bytes32));
@@ -101,14 +84,14 @@ contract AccountReturnDataTest is OptimizedTest {
 
     // Tests the ability to read data via executeFromPlugin routing to fallback functions
     function test_returnData_execFromPlugin_fallback() public {
-        bool result = ResultConsumerPlugin(address(account)).checkResultEFPFallback(keccak256("bar"));
+        bool result = ResultConsumerPlugin(address(account1)).checkResultEFPFallback(keccak256("bar"));
 
         assertTrue(result);
     }
 
     // Tests the ability to read data via executeFromPluginExternal
     function test_returnData_execFromPlugin_execute() public {
-        bool result = ResultConsumerPlugin(address(account)).checkResultEFPExternal(
+        bool result = ResultConsumerPlugin(address(account1)).checkResultEFPExternal(
             address(regularResultContract), keccak256("bar")
         );
 

--- a/test/account/ExecuteFromPluginPermissions.t.sol
+++ b/test/account/ExecuteFromPluginPermissions.t.sol
@@ -3,55 +3,39 @@ pragma solidity ^0.8.19;
 
 import {console} from "forge-std/Test.sol";
 
-import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
-
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
-import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
-import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
 import {Counter} from "../mocks/Counter.sol";
 import {ResultCreatorPlugin} from "../mocks/plugins/ReturnDataPluginMocks.sol";
 import {EFPCallerPlugin, EFPCallerPluginAnyExternal} from "../mocks/plugins/ExecFromPluginPermissionsMocks.sol";
-import {OptimizedTest} from "../utils/OptimizedTest.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
-contract ExecuteFromPluginPermissionsTest is OptimizedTest {
+contract ExecuteFromPluginPermissionsTest is AccountTestBase {
     Counter public counter1;
     Counter public counter2;
     Counter public counter3;
     ResultCreatorPlugin public resultCreatorPlugin;
 
-    EntryPoint public entryPoint; // Just to be able to construct the factory
-    SingleOwnerPlugin public singleOwnerPlugin;
-    MSCAFactoryFixture public factory;
-    UpgradeableModularAccount public account;
-
     EFPCallerPlugin public efpCallerPlugin;
     EFPCallerPluginAnyExternal public efpCallerPluginAnyExternal;
 
     function setUp() public {
+        _transferOwnershipToTest();
+
         // Initialize the interaction targets
         counter1 = new Counter();
         counter2 = new Counter();
         counter3 = new Counter();
         resultCreatorPlugin = new ResultCreatorPlugin();
 
-        // Initialize the contracts needed to use the account.
-        entryPoint = new EntryPoint();
-        singleOwnerPlugin = _deploySingleOwnerPlugin();
-        factory = new MSCAFactoryFixture(entryPoint, singleOwnerPlugin);
-
         // Initialize the EFP caller plugins, which will attempt to use the permissions system to authorize calls.
-        efpCallerPlugin = new EFPCallerPlugin();
+        efpCallerPlugin = new EFPCallerPlugin(address(counter1), address(counter2), address(counter3));
         efpCallerPluginAnyExternal = new EFPCallerPluginAnyExternal();
-
-        // Create an account with "this" as the owner, so we can execute along the runtime path with regular
-        // solidity semantics
-        account = factory.createAccount(address(this), 0);
 
         // Add the result creator plugin to the account
         bytes32 resultCreatorManifestHash = keccak256(abi.encode(resultCreatorPlugin.pluginManifest()));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(resultCreatorPlugin),
             manifestHash: resultCreatorManifestHash,
             pluginInstallData: "",
@@ -59,7 +43,7 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
         });
         // Add the EFP caller plugin to the account
         bytes32 efpCallerManifestHash = keccak256(abi.encode(efpCallerPlugin.pluginManifest()));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(efpCallerPlugin),
             manifestHash: efpCallerManifestHash,
             pluginInstallData: "",
@@ -69,7 +53,7 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
         // Add the EFP caller plugin with any external permissions to the account
         bytes32 efpCallerAnyExternalManifestHash =
             keccak256(abi.encode(efpCallerPluginAnyExternal.pluginManifest()));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(efpCallerPluginAnyExternal),
             manifestHash: efpCallerAnyExternalManifestHash,
             pluginInstallData: "",
@@ -88,7 +72,7 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
     }
 
     function test_executeFromPluginAllowed() public {
-        bytes memory result = EFPCallerPlugin(address(account)).useEFPPermissionAllowed();
+        bytes memory result = EFPCallerPlugin(address(account1)).useEFPPermissionAllowed();
         bytes32 actual = abi.decode(result, (bytes32));
 
         assertEq(actual, keccak256("bar"));
@@ -102,18 +86,18 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
                 ResultCreatorPlugin.bar.selector
             )
         );
-        EFPCallerPlugin(address(account)).useEFPPermissionNotAllowed();
+        EFPCallerPlugin(address(account1)).useEFPPermissionNotAllowed();
     }
 
     function test_executeFromPluginExternal_Allowed_IndividualSelectors() public {
-        EFPCallerPlugin(address(account)).setNumberCounter1(17);
-        uint256 retrievedNumber = EFPCallerPlugin(address(account)).getNumberCounter1();
+        EFPCallerPlugin(address(account1)).setNumberCounter1(17);
+        uint256 retrievedNumber = EFPCallerPlugin(address(account1)).getNumberCounter1();
 
         assertEq(retrievedNumber, 17);
     }
 
     function test_executeFromPluginExternal_NotAlowed_IndividualSelectors() public {
-        EFPCallerPlugin(address(account)).setNumberCounter1(17);
+        EFPCallerPlugin(address(account1)).setNumberCounter1(17);
 
         // Call to increment should fail
         vm.expectRevert(
@@ -125,17 +109,17 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
                 abi.encodePacked(Counter.increment.selector)
             )
         );
-        EFPCallerPlugin(address(account)).incrementCounter1();
+        EFPCallerPlugin(address(account1)).incrementCounter1();
 
-        uint256 retrievedNumber = EFPCallerPlugin(address(account)).getNumberCounter1();
+        uint256 retrievedNumber = EFPCallerPlugin(address(account1)).getNumberCounter1();
 
         assertEq(retrievedNumber, 17);
     }
 
     function test_executeFromPluginExternal_Allowed_AllSelectors() public {
-        EFPCallerPlugin(address(account)).setNumberCounter2(17);
-        EFPCallerPlugin(address(account)).incrementCounter2();
-        uint256 retrievedNumber = EFPCallerPlugin(address(account)).getNumberCounter2();
+        EFPCallerPlugin(address(account1)).setNumberCounter2(17);
+        EFPCallerPlugin(address(account1)).incrementCounter2();
+        uint256 retrievedNumber = EFPCallerPlugin(address(account1)).getNumberCounter2();
 
         assertEq(retrievedNumber, 18);
     }
@@ -150,7 +134,7 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
                 abi.encodeWithSelector(Counter.setNumber.selector, uint256(17))
             )
         );
-        EFPCallerPlugin(address(account)).setNumberCounter3(17);
+        EFPCallerPlugin(address(account1)).setNumberCounter3(17);
 
         // Call to increment should fail
         vm.expectRevert(
@@ -162,7 +146,7 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
                 abi.encodePacked(Counter.increment.selector)
             )
         );
-        EFPCallerPlugin(address(account)).incrementCounter3();
+        EFPCallerPlugin(address(account1)).incrementCounter3();
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -173,7 +157,7 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
                 abi.encodePacked(bytes4(keccak256("number()")))
             )
         );
-        EFPCallerPlugin(address(account)).getNumberCounter3();
+        EFPCallerPlugin(address(account1)).getNumberCounter3();
 
         // Validate no state changes
         assert(counter3.number() == 0);
@@ -182,19 +166,19 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
     function test_executeFromPluginExternal_Allowed_AnyContract() public {
         // Run full workflow for counter 1
 
-        EFPCallerPluginAnyExternal(address(account)).passthroughExecute(
+        EFPCallerPluginAnyExternal(address(account1)).passthroughExecute(
             address(counter1), 0, abi.encodeCall(Counter.setNumber, (17))
         );
         uint256 retrievedNumber = counter1.number();
         assertEq(retrievedNumber, 17);
 
-        EFPCallerPluginAnyExternal(address(account)).passthroughExecute(
+        EFPCallerPluginAnyExternal(address(account1)).passthroughExecute(
             address(counter1), 0, abi.encodeCall(Counter.increment, ())
         );
         retrievedNumber = counter1.number();
         assertEq(retrievedNumber, 18);
 
-        bytes memory result = EFPCallerPluginAnyExternal(address(account)).passthroughExecute(
+        bytes memory result = EFPCallerPluginAnyExternal(address(account1)).passthroughExecute(
             address(counter1), 0, abi.encodePacked(bytes4(keccak256("number()")))
         );
         retrievedNumber = abi.decode(result, (uint256));
@@ -202,19 +186,19 @@ contract ExecuteFromPluginPermissionsTest is OptimizedTest {
 
         // Run full workflow for counter 2
 
-        EFPCallerPluginAnyExternal(address(account)).passthroughExecute(
+        EFPCallerPluginAnyExternal(address(account1)).passthroughExecute(
             address(counter2), 0, abi.encodeCall(Counter.setNumber, (17))
         );
         retrievedNumber = counter2.number();
         assertEq(retrievedNumber, 17);
 
-        EFPCallerPluginAnyExternal(address(account)).passthroughExecute(
+        EFPCallerPluginAnyExternal(address(account1)).passthroughExecute(
             address(counter2), 0, abi.encodeCall(Counter.increment, ())
         );
         retrievedNumber = counter2.number();
         assertEq(retrievedNumber, 18);
 
-        result = EFPCallerPluginAnyExternal(address(account)).passthroughExecute(
+        result = EFPCallerPluginAnyExternal(address(account1)).passthroughExecute(
             address(counter2), 0, abi.encodePacked(bytes4(keccak256("number()")))
         );
         retrievedNumber = abi.decode(result, (uint256));

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
-
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
-import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
-import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
 import {
     BadValidationMagicValue_PreRuntimeValidationHook_Plugin,
     BadValidationMagicValue_PreUserOpValidationHook_Plugin,
@@ -19,23 +13,11 @@ import {
     BadHookMagicValue_RuntimeValidationFunction_Plugin,
     BadHookMagicValue_PostExecHook_Plugin
 } from "../mocks/plugins/ManifestValidityMocks.sol";
-import {OptimizedTest} from "../utils/OptimizedTest.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
-contract ManifestValidityTest is OptimizedTest {
-    EntryPoint public entryPoint; // Just to be able to construct the factory
-    SingleOwnerPlugin public singleOwnerPlugin;
-    MSCAFactoryFixture public factory;
-
-    UpgradeableModularAccount public account;
-
+contract ManifestValidityTest is AccountTestBase {
     function setUp() public {
-        entryPoint = new EntryPoint();
-        singleOwnerPlugin = _deploySingleOwnerPlugin();
-        factory = new MSCAFactoryFixture(entryPoint, singleOwnerPlugin);
-
-        // Create an account with "this" as the owner, so we can execute along the runtime path with regular
-        // solidity semantics
-        account = factory.createAccount(address(this), 0);
+        _transferOwnershipToTest();
     }
 
     // Tests that the plugin manager rejects a plugin with a pre-runtime validation hook set to "validation always
@@ -47,7 +29,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",
@@ -64,7 +46,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",
@@ -79,7 +61,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",
@@ -94,7 +76,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",
@@ -110,7 +92,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",
@@ -126,7 +108,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",
@@ -141,7 +123,7 @@ contract ManifestValidityTest is OptimizedTest {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account.installPlugin({
+        account1.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
             pluginInstallData: "",

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -1,44 +1,27 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/UserOperation.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
-import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
-import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
 import {
     MockBaseUserOpValidationPlugin,
     MockUserOpValidation1HookPlugin,
     MockUserOpValidation2HookPlugin,
     MockUserOpValidationPlugin
 } from "../mocks/plugins/ValidationPluginMocks.sol";
-import {OptimizedTest} from "../utils/OptimizedTest.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
-contract ValidationIntersectionTest is OptimizedTest {
+contract ValidationIntersectionTest is AccountTestBase {
     uint256 internal constant _SIG_VALIDATION_FAILED = 1;
 
-    EntryPoint public entryPoint;
-
-    address public owner1;
-    uint256 public owner1Key;
-    UpgradeableModularAccount public account1;
     MockUserOpValidationPlugin public noHookPlugin;
     MockUserOpValidation1HookPlugin public oneHookPlugin;
     MockUserOpValidation2HookPlugin public twoHookPlugin;
 
     function setUp() public {
-        entryPoint = new EntryPoint();
-        owner1 = makeAddr("owner1");
-
-        SingleOwnerPlugin singleOwnerPlugin = _deploySingleOwnerPlugin();
-        MSCAFactoryFixture factory = new MSCAFactoryFixture(entryPoint, singleOwnerPlugin);
-
-        account1 = factory.createAccount(owner1, 0);
-        vm.deal(address(account1), 1 ether);
-
         noHookPlugin = new MockUserOpValidationPlugin();
         oneHookPlugin = new MockUserOpValidation1HookPlugin();
         twoHookPlugin = new MockUserOpValidation2HookPlugin();

--- a/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
+++ b/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
@@ -17,9 +17,9 @@ import {Counter} from "../Counter.sol";
 contract EFPCallerPlugin is BaseTestPlugin {
     // Store the counters as immutables, and use the view -> pure cast to get the manifest
     // solhint-disable private-vars-leading-underscore, immutable-vars-naming
-    address immutable private counter1;
-    address immutable private counter2;
-    address immutable private counter3;
+    address private immutable counter1;
+    address private immutable counter2;
+    address private immutable counter3;
     // solhint-enable private-vars-leading-underscore, immutable-vars-naming
 
     constructor(address _counter1, address _counter2, address _counter3) {

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
+
+import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
+
+import {OptimizedTest} from "./OptimizedTest.sol";
+
+import {MSCAFactoryFixture} from "../mocks/MSCAFactoryFixture.sol";
+
+/// @dev This contract handles common boilerplate setup for tests using UpgradeableModularAccount with
+/// SingleOwnerPlugin.
+abstract contract AccountTestBase is OptimizedTest {
+    EntryPoint public entryPoint;
+    address payable public beneficiary;
+    SingleOwnerPlugin public singleOwnerPlugin;
+    MSCAFactoryFixture public factory;
+
+    address public owner1;
+    uint256 public owner1Key;
+    UpgradeableModularAccount public account1;
+
+    constructor() {
+        entryPoint = new EntryPoint();
+        (owner1, owner1Key) = makeAddrAndKey("owner1");
+        beneficiary = payable(makeAddr("beneficiary"));
+
+        singleOwnerPlugin = _deploySingleOwnerPlugin();
+        factory = new MSCAFactoryFixture(entryPoint, singleOwnerPlugin);
+
+        account1 = factory.createAccount(owner1, 0);
+        vm.deal(address(account1), 100 ether);
+    }
+
+    function _transferOwnershipToTest() internal {
+        // Transfer ownership to test contract for easier invocation.
+        vm.prank(owner1);
+        SingleOwnerPlugin(address(account1)).transferOwnership(address(this));
+    }
+}


### PR DESCRIPTION
## Motivation

All tests in `test/account` used a similar setup sequence - deploying the EntryPoint, deploying SingleOwnerPlugin, setting up the account and owners.

## Solution

To reduce repeated boilerplate code, pull out this test setup to a single test base called `AccountTestBase`, and make the aforementioned tests inherit from this.

To do this, I had to slightly refactor `UpgradeableModularAccount.t.sol` - previously, it used `account1` to refer to the un-deployed account counterfactual and `account2` to refer to the deployed account, but to use the test base, I had to switch these.

Also had to fix the mocks used by the execute from plugin tests, because they previously hardcoded deployment addresses coming from a nonce (create1), but the new abstract test base changed them. Refactored to correctly parameterize the addresses.