### PR TITLE
feat: [v0.8-develop] Bump solidity version and remove optimizations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "solidity.packageDefaultDependenciesContractsDirectory": "src",
   "solidity.packageDefaultDependenciesDirectory": "lib",
-  "solidity.compileUsingRemoteVersion": "v0.8.19",
+  "solidity.compileUsingRemoteVersion": "v0.8.25",
   "editor.formatOnSave": true,
   "[solidity]": {
     "editor.defaultFormatter": "JuanBlanco.solidity"

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc = '0.8.19'
+solc = '0.8.25'
 via_ir = false
 src = 'src'
 test = 'test'

--- a/src/account/AccountExecutor.sol
+++ b/src/account/AccountExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {IPlugin} from "../interfaces/IPlugin.sol";

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -14,8 +14,6 @@ abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    error ManifestDiscrepancy(address plugin);
-
     /// @inheritdoc IAccountLoupe
     function getExecutionFunctionConfig(bytes4 selector)
         external

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -47,11 +47,10 @@ abstract contract AccountLoupe is IAccountLoupe {
         uint256 maxExecHooksLength = postOnlyExecHooksLength;
 
         // There can only be as many associated post hooks to run as there are pre hooks.
-        for (uint256 i = 0; i < preExecHooksLength;) {
+        for (uint256 i = 0; i < preExecHooksLength; ++i) {
             (, uint256 count) = selectorData.preHooks.at(i);
             unchecked {
                 maxExecHooksLength += (count + 1);
-                ++i;
             }
         }
 
@@ -59,20 +58,19 @@ abstract contract AccountLoupe is IAccountLoupe {
         execHooks = new ExecutionHooks[](maxExecHooksLength);
         uint256 actualExecHooksLength;
 
-        for (uint256 i = 0; i < preExecHooksLength;) {
+        for (uint256 i = 0; i < preExecHooksLength; ++i) {
             (bytes32 key,) = selectorData.preHooks.at(i);
             FunctionReference preExecHook = FunctionReference.wrap(bytes21(key));
 
             uint256 associatedPostExecHooksLength = selectorData.associatedPostHooks[preExecHook].length();
             if (associatedPostExecHooksLength > 0) {
-                for (uint256 j = 0; j < associatedPostExecHooksLength;) {
+                for (uint256 j = 0; j < associatedPostExecHooksLength; ++j) {
                     execHooks[actualExecHooksLength].preExecHook = preExecHook;
                     (key,) = selectorData.associatedPostHooks[preExecHook].at(j);
                     execHooks[actualExecHooksLength].postExecHook = FunctionReference.wrap(bytes21(key));
 
                     unchecked {
                         ++actualExecHooksLength;
-                        ++j;
                     }
                 }
             } else {
@@ -82,19 +80,14 @@ abstract contract AccountLoupe is IAccountLoupe {
                     ++actualExecHooksLength;
                 }
             }
-
-            unchecked {
-                ++i;
-            }
         }
 
-        for (uint256 i = 0; i < postOnlyExecHooksLength;) {
+        for (uint256 i = 0; i < postOnlyExecHooksLength; ++i) {
             (bytes32 key,) = selectorData.postOnlyHooks.at(i);
             execHooks[actualExecHooksLength].postExecHook = FunctionReference.wrap(bytes21(key));
 
             unchecked {
                 ++actualExecHooksLength;
-                ++i;
             }
         }
 

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -83,13 +83,9 @@ function toFunctionReferenceArray(EnumerableMap.Bytes32ToUintMap storage map)
 {
     uint256 length = map.length();
     FunctionReference[] memory result = new FunctionReference[](length);
-    for (uint256 i = 0; i < length;) {
+    for (uint256 i = 0; i < length; ++i) {
         (bytes32 key,) = map.at(i);
         result[i] = FunctionReference.wrap(bytes21(key));
-
-        unchecked {
-            ++i;
-        }
     }
     return result;
 }

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/src/account/AccountStorageInitializable.sol
+++ b/src/account/AccountStorageInitializable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -209,7 +209,7 @@ abstract contract PluginManagerInternals is IPluginManager {
         }
 
         uint256 length = dependencies.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             // Check the dependency interface id over the address of the dependency.
             (address dependencyAddr,) = dependencies[i].unpack();
 
@@ -225,10 +225,6 @@ abstract contract PluginManagerInternals is IPluginManager {
 
             // Increment the dependency's dependents counter.
             _storage.pluginData[dependencyAddr].dependentCount += 1;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add the plugin metadata to the account
@@ -243,24 +239,16 @@ abstract contract PluginManagerInternals is IPluginManager {
         }
 
         length = manifest.executionFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _setExecutionFunction(manifest.executionFunctions[i], plugin);
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add installed plugin and selectors this plugin can call
         length = manifest.permittedExecutionSelectors.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             // If there are duplicates, this will just enable the flag again. This is not a problem, since the
             // boolean will be set to false twice during uninstall, which is fine.
             _storage.callPermitted[getPermittedCallKey(plugin, manifest.permittedExecutionSelectors[i])] = true;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add the permitted external calls to the account.
@@ -269,7 +257,7 @@ abstract contract PluginManagerInternals is IPluginManager {
         } else {
             // Only store the specific permitted external calls if "permit any" flag was not set.
             length = manifest.permittedExternalCalls.length;
-            for (uint256 i = 0; i < length;) {
+            for (uint256 i = 0; i < length; ++i) {
                 ManifestExternalCallPermission memory externalCallPermission = manifest.permittedExternalCalls[i];
 
                 PermittedExternalCallData storage permittedExternalCallData =
@@ -281,23 +269,15 @@ abstract contract PluginManagerInternals is IPluginManager {
                     permittedExternalCallData.anySelectorPermitted = true;
                 } else {
                     uint256 externalContractSelectorsLength = externalCallPermission.selectors.length;
-                    for (uint256 j = 0; j < externalContractSelectorsLength;) {
+                    for (uint256 j = 0; j < externalContractSelectorsLength; ++j) {
                         permittedExternalCallData.permittedSelectors[externalCallPermission.selectors[j]] = true;
-
-                        unchecked {
-                            ++j;
-                        }
                     }
-                }
-
-                unchecked {
-                    ++i;
                 }
             }
         }
 
         length = manifest.validationFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mv = manifest.validationFunctions[i];
             _addValidationFunction(
                 mv.executionSelector,
@@ -308,17 +288,13 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Hooks are not allowed to be provided as dependencies, so we use an empty array for resolving them.
         FunctionReference[] memory emptyDependencies;
 
         length = manifest.preUserOpValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = manifest.preUserOpValidationHooks[i];
             _addPreUserOpValidationHook(
                 mh.executionSelector,
@@ -329,14 +305,10 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.preRuntimeValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = manifest.preRuntimeValidationHooks[i];
             _addPreRuntimeValidationHook(
                 mh.executionSelector,
@@ -347,13 +319,10 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.executionHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             _addExecHooks(
                 mh.executionSelector,
@@ -364,18 +333,11 @@ abstract contract PluginManagerInternals is IPluginManager {
                     mh.postExecHook, plugin, emptyDependencies, ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.interfaceIds.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _storage.supportedIfaces[manifest.interfaceIds[i]] += 1;
-            unchecked {
-                ++i;
-            }
         }
 
         // Initialize the plugin storage for the account.
@@ -412,16 +374,12 @@ abstract contract PluginManagerInternals is IPluginManager {
         // Remove this plugin as a dependent from its dependencies.
         FunctionReference[] memory dependencies = _storage.pluginData[plugin].dependencies;
         uint256 length = dependencies.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             FunctionReference dependency = dependencies[i];
             (address dependencyAddr,) = dependency.unpack();
 
             // Decrement the dependent count for the dependency function.
             _storage.pluginData[dependencyAddr].dependentCount -= 1;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove components according to the manifest, in reverse order (by component type) of their installation.
@@ -430,7 +388,7 @@ abstract contract PluginManagerInternals is IPluginManager {
         FunctionReference[] memory emptyDependencies;
 
         length = manifest.executionHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             _removeExecHooks(
                 mh.executionSelector,
@@ -441,14 +399,10 @@ abstract contract PluginManagerInternals is IPluginManager {
                     mh.postExecHook, plugin, emptyDependencies, ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.preRuntimeValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = manifest.preRuntimeValidationHooks[i];
             _removePreRuntimeValidationHook(
                 mh.executionSelector,
@@ -459,14 +413,10 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.preUserOpValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = manifest.preUserOpValidationHooks[i];
             _removePreUserOpValidationHook(
                 mh.executionSelector,
@@ -477,14 +427,10 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.validationFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mv = manifest.validationFunctions[i];
             _removeValidationFunction(
                 mv.executionSelector,
@@ -495,10 +441,6 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // remove external call permissions
@@ -509,7 +451,7 @@ abstract contract PluginManagerInternals is IPluginManager {
         } else {
             // Only clear the specific permitted external calls if "permit any" flag was not set.
             length = manifest.permittedExternalCalls.length;
-            for (uint256 i = 0; i < length;) {
+            for (uint256 i = 0; i < length; ++i) {
                 ManifestExternalCallPermission memory externalCallPermission = manifest.permittedExternalCalls[i];
 
                 PermittedExternalCallData storage permittedExternalCallData =
@@ -522,45 +464,26 @@ abstract contract PluginManagerInternals is IPluginManager {
                     permittedExternalCallData.anySelectorPermitted = false;
                 } else {
                     uint256 externalContractSelectorsLength = externalCallPermission.selectors.length;
-                    for (uint256 j = 0; j < externalContractSelectorsLength;) {
+                    for (uint256 j = 0; j < externalContractSelectorsLength; ++j) {
                         permittedExternalCallData.permittedSelectors[externalCallPermission.selectors[j]] = false;
-
-                        unchecked {
-                            ++j;
-                        }
                     }
-                }
-
-                unchecked {
-                    ++i;
                 }
             }
         }
 
         length = manifest.permittedExecutionSelectors.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _storage.callPermitted[getPermittedCallKey(plugin, manifest.permittedExecutionSelectors[i])] = false;
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.executionFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _removeExecutionFunction(manifest.executionFunctions[i]);
-
-            unchecked {
-                ++i;
-            }
         }
 
         length = manifest.interfaceIds.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _storage.supportedIfaces[manifest.interfaceIds[i]] -= 1;
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove the plugin metadata from the account.

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {BaseAccount} from "@eth-infinitism/account-abstraction/core/BaseAccount.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";

--- a/src/helpers/FunctionReferenceLib.sol
+++ b/src/helpers/FunctionReferenceLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {FunctionReference} from "../interfaces/IPluginManager.sol";
 

--- a/src/helpers/ValidationDataHelpers.sol
+++ b/src/helpers/ValidationDataHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // solhint-disable-next-line private-vars-leading-underscore
 function _coalescePreValidation(uint256 validationData1, uint256 validationData2)

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {FunctionReference} from "../interfaces/IPluginManager.sol";
 

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/UserOperation.sol";
 

--- a/src/interfaces/IPluginExecutor.sol
+++ b/src/interfaces/IPluginExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 interface IPluginExecutor {
     /// @notice Execute a call from a plugin to another plugin, via an execution function installed on the account.

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 type FunctionReference is bytes21;
 

--- a/src/interfaces/IStandardExecutor.sol
+++ b/src/interfaces/IStandardExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 struct Call {
     // The target address for the account to call.

--- a/src/libraries/AssociatedLinkedListSetLib.sol
+++ b/src/libraries/AssociatedLinkedListSetLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // type SetValue is bytes30;
 

--- a/src/libraries/PluginStorageLib.sol
+++ b/src/libraries/PluginStorageLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // type StoragePointer is bytes32;
 

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/UserOperation.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC777Recipient} from "@openzeppelin/contracts/interfaces/IERC777Recipient.sol";

--- a/src/plugins/owner/ISingleOwnerPlugin.sol
+++ b/src/plugins/owner/ISingleOwnerPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 interface ISingleOwnerPlugin {
     enum FunctionId {

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";

--- a/src/samples/plugins/ModularSessionKeyPlugin.sol
+++ b/src/samples/plugins/ModularSessionKeyPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 // import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/src/samples/plugins/TokenSessionKeyPlugin.sol
+++ b/src/samples/plugins/TokenSessionKeyPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // import {
 //     ManifestFunction,

--- a/src/samples/plugins/interfaces/ISessionKeyPlugin.sol
+++ b/src/samples/plugins/interfaces/ISessionKeyPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/UserOperation.sol";
 

--- a/src/samples/plugins/interfaces/ITokenSessionKeyPlugin.sol
+++ b/src/samples/plugins/interfaces/ITokenSessionKeyPlugin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/UserOperation.sol";
 


### PR DESCRIPTION
## Motivation

The purpose of the reference implementation should be to provide a readable and easy to comprehend implementation of the standard. Optimizations are useful for performance and necessary in production implementations of modular accounts and plugins, but impede readability of the reference implementation.

Specifically, we have lots of unchecked loop increments adding to SLOC without contributing to core account functionality. These are also automatically set to be unchecked in most cases starting with solidity v0.8.22.

## Solution

Remove unchecked loop increments.

Bump solc to v0.8.25.

Remove an unused custom error type.
