### PR TITLE
feat: [v0.8-develop] merge pre validation types

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -99,15 +99,10 @@ abstract contract AccountLoupe is IAccountLoupe {
     function getPreValidationHooks(bytes4 selector)
         external
         view
-        returns (
-            FunctionReference[] memory preUserOpValidationHooks,
-            FunctionReference[] memory preRuntimeValidationHooks
-        )
+        returns (FunctionReference[] memory preValidationHooks)
     {
-        preUserOpValidationHooks =
-            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preUserOpValidationHooks);
-        preRuntimeValidationHooks =
-            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preRuntimeValidationHooks);
+        preValidationHooks =
+            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preValidationHooks);
     }
 
     /// @inheritdoc IAccountLoupe

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -38,8 +38,7 @@ struct SelectorData {
     // User operation validation and runtime validation share a function reference.
     FunctionReference validation;
     // The pre validation hooks for this function selector.
-    EnumerableMap.Bytes32ToUintMap preUserOpValidationHooks;
-    EnumerableMap.Bytes32ToUintMap preRuntimeValidationHooks;
+    EnumerableMap.Bytes32ToUintMap preValidationHooks;
     // The execution hooks for this function selector.
     EnumerableMap.Bytes32ToUintMap preHooks;
     // bytes21 key = pre hook function reference

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -137,45 +137,22 @@ abstract contract PluginManagerInternals is IPluginManager {
         }
     }
 
-    function _addPreUserOpValidationHook(bytes4 selector, FunctionReference preUserOpValidationHook)
+    function _addPreValidationHook(bytes4 selector, FunctionReference preValidationHook)
         internal
-        notNullFunction(preUserOpValidationHook)
+        notNullFunction(preValidationHook)
     {
         _addOrIncrement(
-            getAccountStorage().selectorData[selector].preUserOpValidationHooks,
-            _toSetValue(preUserOpValidationHook)
+            getAccountStorage().selectorData[selector].preValidationHooks, _toSetValue(preValidationHook)
         );
     }
 
-    function _removePreUserOpValidationHook(bytes4 selector, FunctionReference preUserOpValidationHook)
+    function _removePreValidationHook(bytes4 selector, FunctionReference preValidationHook)
         internal
-        notNullFunction(preUserOpValidationHook)
+        notNullFunction(preValidationHook)
     {
         // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
         _removeOrDecrement(
-            getAccountStorage().selectorData[selector].preUserOpValidationHooks,
-            _toSetValue(preUserOpValidationHook)
-        );
-    }
-
-    function _addPreRuntimeValidationHook(bytes4 selector, FunctionReference preRuntimeValidationHook)
-        internal
-        notNullFunction(preRuntimeValidationHook)
-    {
-        _addOrIncrement(
-            getAccountStorage().selectorData[selector].preRuntimeValidationHooks,
-            _toSetValue(preRuntimeValidationHook)
-        );
-    }
-
-    function _removePreRuntimeValidationHook(bytes4 selector, FunctionReference preRuntimeValidationHook)
-        internal
-        notNullFunction(preRuntimeValidationHook)
-    {
-        // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
-        _removeOrDecrement(
-            getAccountStorage().selectorData[selector].preRuntimeValidationHooks,
-            _toSetValue(preRuntimeValidationHook)
+            getAccountStorage().selectorData[selector].preValidationHooks, _toSetValue(preValidationHook)
         );
     }
 
@@ -293,24 +270,10 @@ abstract contract PluginManagerInternals is IPluginManager {
         // Hooks are not allowed to be provided as dependencies, so we use an empty array for resolving them.
         FunctionReference[] memory emptyDependencies;
 
-        length = manifest.preUserOpValidationHooks.length;
+        length = manifest.preValidationHooks.length;
         for (uint256 i = 0; i < length; ++i) {
-            ManifestAssociatedFunction memory mh = manifest.preUserOpValidationHooks[i];
-            _addPreUserOpValidationHook(
-                mh.executionSelector,
-                _resolveManifestFunction(
-                    mh.associatedFunction,
-                    plugin,
-                    emptyDependencies,
-                    ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
-                )
-            );
-        }
-
-        length = manifest.preRuntimeValidationHooks.length;
-        for (uint256 i = 0; i < length; ++i) {
-            ManifestAssociatedFunction memory mh = manifest.preRuntimeValidationHooks[i];
-            _addPreRuntimeValidationHook(
+            ManifestAssociatedFunction memory mh = manifest.preValidationHooks[i];
+            _addPreValidationHook(
                 mh.executionSelector,
                 _resolveManifestFunction(
                     mh.associatedFunction,
@@ -401,24 +364,10 @@ abstract contract PluginManagerInternals is IPluginManager {
             );
         }
 
-        length = manifest.preRuntimeValidationHooks.length;
+        length = manifest.preValidationHooks.length;
         for (uint256 i = 0; i < length; ++i) {
-            ManifestAssociatedFunction memory mh = manifest.preRuntimeValidationHooks[i];
-            _removePreRuntimeValidationHook(
-                mh.executionSelector,
-                _resolveManifestFunction(
-                    mh.associatedFunction,
-                    plugin,
-                    emptyDependencies,
-                    ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
-                )
-            );
-        }
-
-        length = manifest.preUserOpValidationHooks.length;
-        for (uint256 i = 0; i < length; ++i) {
-            ManifestAssociatedFunction memory mh = manifest.preUserOpValidationHooks[i];
-            _removePreUserOpValidationHook(
+            ManifestAssociatedFunction memory mh = manifest.preValidationHooks[i];
+            _removePreValidationHook(
                 mh.executionSelector,
                 _resolveManifestFunction(
                     mh.associatedFunction,

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -348,7 +348,7 @@ contract UpgradeableModularAccount is
 
         // Do preUserOpValidation hooks
         EnumerableMap.Bytes32ToUintMap storage preUserOpValidationHooks =
-            getAccountStorage().selectorData[selector].preUserOpValidationHooks;
+            getAccountStorage().selectorData[selector].preValidationHooks;
 
         uint256 preUserOpValidationHooksLength = preUserOpValidationHooks.length();
         for (uint256 i = 0; i < preUserOpValidationHooksLength; ++i) {
@@ -397,7 +397,7 @@ contract UpgradeableModularAccount is
         FunctionReference runtimeValidationFunction = _storage.selectorData[msg.sig].validation;
         // run all preRuntimeValidation hooks
         EnumerableMap.Bytes32ToUintMap storage preRuntimeValidationHooks =
-            getAccountStorage().selectorData[msg.sig].preRuntimeValidationHooks;
+            getAccountStorage().selectorData[msg.sig].preValidationHooks;
 
         uint256 preRuntimeValidationHooksLength = preRuntimeValidationHooks.length();
         for (uint256 i = 0; i < preRuntimeValidationHooksLength; ++i) {

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -30,15 +30,11 @@ interface IAccountLoupe {
 
     /// @notice Get the pre user op and runtime validation hooks associated with a selector.
     /// @param selector The selector to get the hooks for.
-    /// @return preUserOpValidationHooks The pre user op validation hooks for this selector.
-    /// @return preRuntimeValidationHooks The pre runtime validation hooks for this selector.
+    /// @return preValidationHooks The pre validation hooks for this selector.
     function getPreValidationHooks(bytes4 selector)
         external
         view
-        returns (
-            FunctionReference[] memory preUserOpValidationHooks,
-            FunctionReference[] memory preRuntimeValidationHooks
-        );
+        returns (FunctionReference[] memory preValidationHooks);
 
     /// @notice Get an array of all installed plugins.
     /// @return The addresses of all installed plugins.

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -91,8 +91,7 @@ struct PluginManifest {
     bool canSpendNativeToken;
     ManifestExternalCallPermission[] permittedExternalCalls;
     ManifestAssociatedFunction[] validationFunctions;
-    ManifestAssociatedFunction[] preUserOpValidationHooks;
-    ManifestAssociatedFunction[] preRuntimeValidationHooks;
+    ManifestAssociatedFunction[] preValidationHooks;
     ManifestExecutionHook[] executionHooks;
 }
 

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -238,15 +238,11 @@ interface IAccountLoupe {
 
     /// @notice Get the pre user op and runtime validation hooks associated with a selector.
     /// @param selector The selector to get the hooks for.
-    /// @return preUserOpValidationHooks The pre user op validation hooks for this selector.
-    /// @return preRuntimeValidationHooks The pre runtime validation hooks for this selector.
+    /// @return preValidationHooks The pre validation hooks for this selector.
     function getPreValidationHooks(bytes4 selector)
         external
         view
-        returns (
-            FunctionReference[] memory preUserOpValidationHooks,
-            FunctionReference[] memory preRuntimeValidationHooks
-        );
+        returns (FunctionReference[] memory preValidationHooks);
 
     /// @notice Get an array of all installed plugins.
     /// @return The addresses of all installed plugins.
@@ -423,8 +419,7 @@ struct PluginManifest {
     bool canSpendNativeToken;
     ManifestExternalCallPermission[] permittedExternalCalls;
     ManifestAssociatedFunction[] validationFunctions;
-    ManifestAssociatedFunction[] preUserOpValidationHooks;
-    ManifestAssociatedFunction[] preRuntimeValidationHooks;
+    ManifestAssociatedFunction[] preValidationHooks;
     ManifestExecutionHook[] executionHooks;
 }
 

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -185,16 +185,15 @@ contract AccountLoupeTest is AccountTestBase {
         );
     }
 
-    function test_pluginLoupe_getPreUserOpValidationHooks() public {
-        (FunctionReference[] memory hooks,) = account1.getPreValidationHooks(comprehensivePlugin.foo.selector);
+    function test_pluginLoupe_getValidationHooks() public {
+        FunctionReference[] memory hooks = account1.getPreValidationHooks(comprehensivePlugin.foo.selector);
 
         assertEq(hooks.length, 2);
         assertEq(
             FunctionReference.unwrap(hooks[0]),
             FunctionReference.unwrap(
                 FunctionReferenceLib.pack(
-                    address(comprehensivePlugin),
-                    uint8(ComprehensivePlugin.FunctionId.PRE_USER_OP_VALIDATION_HOOK_1)
+                    address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.PRE_VALIDATION_HOOK_1)
                 )
             )
         );
@@ -202,32 +201,7 @@ contract AccountLoupeTest is AccountTestBase {
             FunctionReference.unwrap(hooks[1]),
             FunctionReference.unwrap(
                 FunctionReferenceLib.pack(
-                    address(comprehensivePlugin),
-                    uint8(ComprehensivePlugin.FunctionId.PRE_USER_OP_VALIDATION_HOOK_2)
-                )
-            )
-        );
-    }
-
-    function test_pluginLoupe_getPreRuntimeValidationHooks() public {
-        (, FunctionReference[] memory hooks) = account1.getPreValidationHooks(comprehensivePlugin.foo.selector);
-
-        assertEq(hooks.length, 2);
-        assertEq(
-            FunctionReference.unwrap(hooks[0]),
-            FunctionReference.unwrap(
-                FunctionReferenceLib.pack(
-                    address(comprehensivePlugin),
-                    uint8(ComprehensivePlugin.FunctionId.PRE_RUNTIME_VALIDATION_HOOK_1)
-                )
-            )
-        );
-        assertEq(
-            FunctionReference.unwrap(hooks[1]),
-            FunctionReference.unwrap(
-                FunctionReferenceLib.pack(
-                    address(comprehensivePlugin),
-                    uint8(ComprehensivePlugin.FunctionId.PRE_RUNTIME_VALIDATION_HOOK_2)
+                    address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.PRE_VALIDATION_HOOK_2)
                 )
             )
         );

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -5,8 +5,7 @@ import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.s
 import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
 
 import {
-    BadValidationMagicValue_PreRuntimeValidationHook_Plugin,
-    BadValidationMagicValue_PreUserOpValidationHook_Plugin,
+    BadValidationMagicValue_PreValidationHook_Plugin,
     BadValidationMagicValue_PreExecHook_Plugin,
     BadValidationMagicValue_PostExecHook_Plugin,
     BadHookMagicValue_UserOpValidationFunction_Plugin,
@@ -22,26 +21,9 @@ contract ManifestValidityTest is AccountTestBase {
 
     // Tests that the plugin manager rejects a plugin with a pre-runtime validation hook set to "validation always
     // allow"
-    function test_ManifestValidity_invalid_ValidationAlwaysAllow_PreRuntimeValidationHook() public {
-        BadValidationMagicValue_PreRuntimeValidationHook_Plugin plugin =
-            new BadValidationMagicValue_PreRuntimeValidationHook_Plugin();
-
-        bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
-
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account1.installPlugin({
-            plugin: address(plugin),
-            manifestHash: manifestHash,
-            pluginInstallData: "",
-            dependencies: new FunctionReference[](0)
-        });
-    }
-
-    // Tests that the plugin manager rejects a plugin with a pre-user op validation hook set to "validation always
-    // allow"
-    function test_ManifestValidity_invalid_ValidationAlwaysAllow_PreUserOpValidationHook() public {
-        BadValidationMagicValue_PreUserOpValidationHook_Plugin plugin =
-            new BadValidationMagicValue_PreUserOpValidationHook_Plugin();
+    function test_ManifestValidity_invalid_ValidationAlwaysAllow_PreValidationHook() public {
+        BadValidationMagicValue_PreValidationHook_Plugin plugin =
+            new BadValidationMagicValue_PreValidationHook_Plugin();
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -155,7 +155,7 @@ contract ValidationIntersectionTest is AccountTestBase {
             abi.encodeWithSelector(
                 UpgradeableModularAccount.UnexpectedAggregator.selector,
                 address(oneHookPlugin),
-                MockBaseUserOpValidationPlugin.FunctionId.PRE_USER_OP_VALIDATION_HOOK_1,
+                MockBaseUserOpValidationPlugin.FunctionId.PRE_VALIDATION_HOOK_1,
                 badAuthorizer
             )
         );

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -16,10 +16,8 @@ import {BasePlugin} from "../../../src/plugins/BasePlugin.sol";
 
 contract ComprehensivePlugin is BasePlugin {
     enum FunctionId {
-        PRE_USER_OP_VALIDATION_HOOK_1,
-        PRE_USER_OP_VALIDATION_HOOK_2,
-        PRE_RUNTIME_VALIDATION_HOOK_1,
-        PRE_RUNTIME_VALIDATION_HOOK_2,
+        PRE_VALIDATION_HOOK_1,
+        PRE_VALIDATION_HOOK_2,
         VALIDATION,
         PRE_EXECUTION_HOOK,
         PRE_PERMITTED_CALL_EXECUTION_HOOK,
@@ -51,9 +49,9 @@ contract ComprehensivePlugin is BasePlugin {
         override
         returns (uint256)
     {
-        if (functionId == uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_1)) {
+        if (functionId == uint8(FunctionId.PRE_VALIDATION_HOOK_1)) {
             return 0;
-        } else if (functionId == uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_2)) {
+        } else if (functionId == uint8(FunctionId.PRE_VALIDATION_HOOK_2)) {
             return 0;
         }
         revert NotImplemented();
@@ -72,9 +70,9 @@ contract ComprehensivePlugin is BasePlugin {
     }
 
     function preRuntimeValidationHook(uint8 functionId, address, uint256, bytes calldata) external pure override {
-        if (functionId == uint8(FunctionId.PRE_RUNTIME_VALIDATION_HOOK_1)) {
+        if (functionId == uint8(FunctionId.PRE_VALIDATION_HOOK_1)) {
             return;
-        } else if (functionId == uint8(FunctionId.PRE_RUNTIME_VALIDATION_HOOK_2)) {
+        } else if (functionId == uint8(FunctionId.PRE_VALIDATION_HOOK_2)) {
             return;
         }
         revert NotImplemented();
@@ -131,70 +129,36 @@ contract ComprehensivePlugin is BasePlugin {
             associatedFunction: fooValidationFunction
         });
 
-        manifest.preUserOpValidationHooks = new ManifestAssociatedFunction[](4);
-        manifest.preUserOpValidationHooks[0] = ManifestAssociatedFunction({
+        manifest.preValidationHooks = new ManifestAssociatedFunction[](4);
+        manifest.preValidationHooks[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_1),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_1),
                 dependencyIndex: 0 // Unused.
             })
         });
-        manifest.preUserOpValidationHooks[1] = ManifestAssociatedFunction({
+        manifest.preValidationHooks[1] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_2),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_2),
                 dependencyIndex: 0 // Unused.
             })
         });
-        manifest.preUserOpValidationHooks[2] = ManifestAssociatedFunction({
+        manifest.preValidationHooks[2] = ManifestAssociatedFunction({
             executionSelector: IStandardExecutor.execute.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_1),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_1),
                 dependencyIndex: 0 // Unused.
             })
         });
-        manifest.preUserOpValidationHooks[3] = ManifestAssociatedFunction({
+        manifest.preValidationHooks[3] = ManifestAssociatedFunction({
             executionSelector: IStandardExecutor.execute.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_2),
-                dependencyIndex: 0 // Unused.
-            })
-        });
-
-        manifest.preRuntimeValidationHooks = new ManifestAssociatedFunction[](4);
-        manifest.preRuntimeValidationHooks[0] = ManifestAssociatedFunction({
-            executionSelector: this.foo.selector,
-            associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_RUNTIME_VALIDATION_HOOK_1),
-                dependencyIndex: 0 // Unused.
-            })
-        });
-        manifest.preRuntimeValidationHooks[1] = ManifestAssociatedFunction({
-            executionSelector: this.foo.selector,
-            associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_RUNTIME_VALIDATION_HOOK_2),
-                dependencyIndex: 0 // Unused.
-            })
-        });
-        manifest.preRuntimeValidationHooks[2] = ManifestAssociatedFunction({
-            executionSelector: IStandardExecutor.execute.selector,
-            associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_RUNTIME_VALIDATION_HOOK_1),
-                dependencyIndex: 0 // Unused.
-            })
-        });
-        manifest.preRuntimeValidationHooks[3] = ManifestAssociatedFunction({
-            executionSelector: IStandardExecutor.execute.selector,
-            associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_RUNTIME_VALIDATION_HOOK_2),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_2),
                 dependencyIndex: 0 // Unused.
             })
         });

--- a/test/mocks/plugins/ManifestValidityMocks.sol
+++ b/test/mocks/plugins/ManifestValidityMocks.sol
@@ -12,7 +12,7 @@ import {
 import {BaseTestPlugin} from "./BaseTestPlugin.sol";
 
 // solhint-disable-next-line contract-name-camelcase
-contract BadValidationMagicValue_PreRuntimeValidationHook_Plugin is BaseTestPlugin {
+contract BadValidationMagicValue_PreValidationHook_Plugin is BaseTestPlugin {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}
@@ -37,50 +37,9 @@ contract BadValidationMagicValue_PreRuntimeValidationHook_Plugin is BaseTestPlug
             })
         });
 
-        manifest.preRuntimeValidationHooks = new ManifestAssociatedFunction[](1);
+        manifest.preValidationHooks = new ManifestAssociatedFunction[](1);
         // Illegal assignment: validation always allow only usable on runtime validation functions
-        manifest.preRuntimeValidationHooks[0] = ManifestAssociatedFunction({
-            executionSelector: this.foo.selector,
-            associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
-                functionId: 0,
-                dependencyIndex: 0
-            })
-        });
-
-        return manifest;
-    }
-}
-
-// solhint-disable-next-line contract-name-camelcase
-contract BadValidationMagicValue_PreUserOpValidationHook_Plugin is BaseTestPlugin {
-    function onInstall(bytes calldata) external override {}
-
-    function onUninstall(bytes calldata) external override {}
-
-    function foo() external pure returns (bytes32) {
-        return keccak256("bar");
-    }
-
-    function pluginManifest() external pure override returns (PluginManifest memory) {
-        PluginManifest memory manifest;
-
-        manifest.executionFunctions = new bytes4[](1);
-        manifest.executionFunctions[0] = this.foo.selector;
-
-        manifest.validationFunctions = new ManifestAssociatedFunction[](1);
-        manifest.validationFunctions[0] = ManifestAssociatedFunction({
-            executionSelector: this.foo.selector,
-            associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: 0,
-                dependencyIndex: 0
-            })
-        });
-
-        manifest.preUserOpValidationHooks = new ManifestAssociatedFunction[](1);
-        // Illegal assignment: validation always allow only usable on runtime validation functions
-        manifest.preUserOpValidationHooks[0] = ManifestAssociatedFunction({
+        manifest.preValidationHooks[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -14,8 +14,8 @@ import {BaseTestPlugin} from "./BaseTestPlugin.sol";
 abstract contract MockBaseUserOpValidationPlugin is BaseTestPlugin {
     enum FunctionId {
         USER_OP_VALIDATION,
-        PRE_USER_OP_VALIDATION_HOOK_1,
-        PRE_USER_OP_VALIDATION_HOOK_2
+        PRE_VALIDATION_HOOK_1,
+        PRE_VALIDATION_HOOK_2
     }
 
     uint256 internal _userOpValidationFunctionData;
@@ -36,9 +36,9 @@ abstract contract MockBaseUserOpValidationPlugin is BaseTestPlugin {
         override
         returns (uint256)
     {
-        if (functionId == uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_1)) {
+        if (functionId == uint8(FunctionId.PRE_VALIDATION_HOOK_1)) {
             return _preUserOpValidationHook1Data;
-        } else if (functionId == uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_2)) {
+        } else if (functionId == uint8(FunctionId.PRE_VALIDATION_HOOK_2)) {
             return _preUserOpValidationHook2Data;
         }
         revert NotImplemented();
@@ -127,12 +127,12 @@ contract MockUserOpValidation1HookPlugin is MockBaseUserOpValidationPlugin {
             associatedFunction: userOpValidationFunctionRef
         });
 
-        manifest.preUserOpValidationHooks = new ManifestAssociatedFunction[](1);
-        manifest.preUserOpValidationHooks[0] = ManifestAssociatedFunction({
+        manifest.preValidationHooks = new ManifestAssociatedFunction[](1);
+        manifest.preValidationHooks[0] = ManifestAssociatedFunction({
             executionSelector: this.bar.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_1),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_1),
                 dependencyIndex: 0 // Unused.
             })
         });
@@ -179,20 +179,20 @@ contract MockUserOpValidation2HookPlugin is MockBaseUserOpValidationPlugin {
             associatedFunction: userOpValidationFunctionRef
         });
 
-        manifest.preUserOpValidationHooks = new ManifestAssociatedFunction[](2);
-        manifest.preUserOpValidationHooks[0] = ManifestAssociatedFunction({
+        manifest.preValidationHooks = new ManifestAssociatedFunction[](2);
+        manifest.preValidationHooks[0] = ManifestAssociatedFunction({
             executionSelector: this.baz.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_1),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_1),
                 dependencyIndex: 0 // Unused.
             })
         });
-        manifest.preUserOpValidationHooks[1] = ManifestAssociatedFunction({
+        manifest.preValidationHooks[1] = ManifestAssociatedFunction({
             executionSelector: this.baz.selector,
             associatedFunction: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_USER_OP_VALIDATION_HOOK_2),
+                functionId: uint8(FunctionId.PRE_VALIDATION_HOOK_2),
                 dependencyIndex: 0 // Unused.
             })
         });


### PR DESCRIPTION
## Motivation

Motivation and rationale very similar to #40. With validation function assignments merged, it makes sense to also merge pre-validation types.

"Merge" here means that when a pre validation hook is applied (an installed plugin address + a function id for the hook), then the two plugin functions `preUserOpValidationHook` and `preRuntimeValidationHook` should both start to be called in their respective workflow paths, using the same function id.

This reduces redundancy in manifests, and avoids the possibility of configuring one type of validation but not the other.

This simplification helps pave the way for multiple validation & better composability by reducing the size and complexity of account state.

## Solution

- Consolidate the manifest fields (and account storage fields) `preUserOpValidationHooks` and `preRuntimeValidationHooks` into one field `preValidationHooks`.
- Merge pre validation hook function ids in provided sample and mock plugins.
- Update the return type of `getPreValidationHooks` in `IAccountLoupe` to only return one array of `FunctionRefernce` types.