### PR TITLE
feat: [v0.8-develop] remove hook overlap support

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.25;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -41,7 +41,6 @@ abstract contract AccountLoupe is IAccountLoupe {
         uint256 preExecHooksLength = selectorData.preHooks.length();
         uint256 postOnlyExecHooksLength = selectorData.postOnlyHooks.length();
 
-        // Overallocate on length - not all of this may get filled up. We set the correct length later.
         execHooks = new ExecutionHooks[](preExecHooksLength + postOnlyExecHooksLength);
 
         for (uint256 i = 0; i < preExecHooksLength; ++i) {

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IPlugin} from "../interfaces/IPlugin.sol";
@@ -35,7 +34,7 @@ struct SelectorData {
     // The plugin that implements this execution function.
     // If this is a native function, the address must remain address(0).
     address plugin;
-    // uint overlappingDenies TODO
+    uint48 denyExecutionCount;
     // User operation validation and runtime validation share a function reference.
     FunctionReference validation;
     // The pre validation hooks for this function selector.

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -35,15 +35,16 @@ struct SelectorData {
     // The plugin that implements this execution function.
     // If this is a native function, the address must remain address(0).
     address plugin;
+    // uint overlappingDenies TODO
     // User operation validation and runtime validation share a function reference.
     FunctionReference validation;
     // The pre validation hooks for this function selector.
-    EnumerableMap.Bytes32ToUintMap preValidationHooks;
+    EnumerableSet.Bytes32Set preValidationHooks;
     // The execution hooks for this function selector.
-    EnumerableMap.Bytes32ToUintMap preHooks;
+    EnumerableSet.Bytes32Set preHooks;
     // bytes21 key = pre hook function reference
-    mapping(FunctionReference => EnumerableMap.Bytes32ToUintMap) associatedPostHooks;
-    EnumerableMap.Bytes32ToUintMap postOnlyHooks;
+    mapping(FunctionReference => FunctionReference) associatedPostHooks;
+    EnumerableSet.Bytes32Set postOnlyHooks;
 }
 
 struct AccountStorage {
@@ -74,16 +75,16 @@ function getPermittedCallKey(address addr, bytes4 selector) pure returns (bytes2
 }
 
 // Helper function to get all elements of a set into memory.
-using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
+using EnumerableSet for EnumerableSet.Bytes32Set;
 
-function toFunctionReferenceArray(EnumerableMap.Bytes32ToUintMap storage map)
+function toFunctionReferenceArray(EnumerableSet.Bytes32Set storage set)
     view
     returns (FunctionReference[] memory)
 {
-    uint256 length = map.length();
+    uint256 length = set.length();
     FunctionReference[] memory result = new FunctionReference[](length);
     for (uint256 i = 0; i < length; ++i) {
-        (bytes32 key,) = map.at(i);
+        bytes32 key = set.at(i);
         result[i] = FunctionReference.wrap(bytes21(key));
     }
     return result;

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -34,6 +34,10 @@ struct SelectorData {
     // The plugin that implements this execution function.
     // If this is a native function, the address must remain address(0).
     address plugin;
+    // How many times a `PRE_HOOK_ALWAYS_DENY` has been added for this function.
+    // Since that is the only type of hook that may overlap, we can use this to track the number of times it has
+    // been applied, and whether or not the deny should apply. The size `uint48` was chosen somewhat arbitrarily,
+    // but it packs alongside `plugin` while still leaving some other space in the slot for future packing.
     uint48 denyExecutionCount;
     // User operation validation and runtime validation share a function reference.
     FunctionReference validation;
@@ -73,9 +77,9 @@ function getPermittedCallKey(address addr, bytes4 selector) pure returns (bytes2
     return bytes24(bytes20(addr)) | (bytes24(selector) >> 160);
 }
 
-// Helper function to get all elements of a set into memory.
 using EnumerableSet for EnumerableSet.Bytes32Set;
 
+/// @dev Helper function to get all elements of a set into memory.
 function toFunctionReferenceArray(EnumerableSet.Bytes32Set storage set)
     view
     returns (FunctionReference[] memory)

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -103,7 +103,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         if (!preExecHook.isEmpty()) {
             if (preExecHook.eq(FunctionReferenceLib._PRE_HOOK_ALWAYS_DENY)) {
-                // Increment the overlappingDenies counter.
+                // Increment `denyExecutionCount`, because this pre exec hook may be applied multiple times.
                 _selectorData.denyExecutionCount += 1;
                 return;
             }
@@ -133,7 +133,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         if (!preExecHook.isEmpty()) {
             if (preExecHook.eq(FunctionReferenceLib._PRE_HOOK_ALWAYS_DENY)) {
-                // Decrement the overlappingDenies counter.
+                // Decrement `denyExecutionCount`, because this pre exec hook may be applied multiple times.
                 _selectorData.denyExecutionCount -= 1;
                 return;
             }

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -80,7 +80,7 @@ abstract contract PluginManagerInternals is IPluginManager {
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        if (!_selectorData.validation.isEmpty()) {
+        if (_selectorData.validation.notEmpty()) {
             revert ValidationFunctionAlreadySet(selector, validationFunction);
         }
 
@@ -101,7 +101,7 @@ abstract contract PluginManagerInternals is IPluginManager {
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        if (!preExecHook.isEmpty()) {
+        if (preExecHook.notEmpty()) {
             if (preExecHook.eq(FunctionReferenceLib._PRE_HOOK_ALWAYS_DENY)) {
                 // Increment `denyExecutionCount`, because this pre exec hook may be applied multiple times.
                 _selectorData.denyExecutionCount += 1;
@@ -111,7 +111,7 @@ abstract contract PluginManagerInternals is IPluginManager {
             // Don't need to check for duplicates, as the hook can be run at most once.
             _selectorData.preHooks.add(_toSetValue(preExecHook));
 
-            if (!postExecHook.isEmpty()) {
+            if (postExecHook.notEmpty()) {
                 _selectorData.associatedPostHooks[preExecHook] = postExecHook;
             }
 
@@ -131,7 +131,7 @@ abstract contract PluginManagerInternals is IPluginManager {
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        if (!preExecHook.isEmpty()) {
+        if (preExecHook.notEmpty()) {
             if (preExecHook.eq(FunctionReferenceLib._PRE_HOOK_ALWAYS_DENY)) {
                 // Decrement `denyExecutionCount`, because this pre exec hook may be applied multiple times.
                 _selectorData.denyExecutionCount -= 1;
@@ -140,7 +140,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
             _selectorData.preHooks.remove(_toSetValue(preExecHook));
 
-            if (!postExecHook.isEmpty()) {
+            if (postExecHook.notEmpty()) {
                 _selectorData.associatedPostHooks[preExecHook] = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
             }
 

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -459,7 +459,7 @@ contract UpgradeableModularAccount is
 
             FunctionReference associatedPostExecHook = selectorData.associatedPostHooks[preExecHook];
 
-            if (associatedPostExecHook.notEq(FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE)) {
+            if (associatedPostExecHook.notEmpty()) {
                 postHooksToRun[i + postOnlyHooksLength].postExecHook = associatedPostExecHook;
             }
         }
@@ -480,7 +480,7 @@ contract UpgradeableModularAccount is
 
             // If there is an associated post-exec hook, save the return data.
             PostExecToRun memory postExecToRun = postHooksToRun[i + postOnlyHooksLength];
-            if (postExecToRun.postExecHook.notEq(FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE)) {
+            if (postExecToRun.postExecHook.notEmpty()) {
                 postExecToRun.preExecHookReturnData = preExecHookReturnData;
             }
         }
@@ -509,7 +509,7 @@ contract UpgradeableModularAccount is
 
             PostExecToRun memory postHookToRun = postHooksToRun[i];
 
-            if (postHookToRun.postExecHook.eq(FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE)) {
+            if (postHookToRun.postExecHook.isEmpty()) {
                 // This is an empty post hook, from a pre-only hook, so we skip it.
                 continue;
             }

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -420,8 +420,6 @@ contract UpgradeableModularAccount is
             } else {
                 if (runtimeValidationFunction.isEmpty()) {
                     revert RuntimeValidationFunctionMissing(msg.sig);
-                } else if (runtimeValidationFunction.eq(FunctionReferenceLib._PRE_HOOK_ALWAYS_DENY)) {
-                    revert InvalidConfiguration();
                 }
                 // If _RUNTIME_VALIDATION_ALWAYS_ALLOW, just let the function finish.
             }
@@ -433,10 +431,6 @@ contract UpgradeableModularAccount is
         returns (PostExecToRun[] memory postHooksToRun)
     {
         SelectorData storage selectorData = getAccountStorage().selectorData[selector];
-
-        if (selectorData.denyExecutionCount > 0) {
-            revert AlwaysDenyRule();
-        }
 
         uint256 preExecHooksLength = selectorData.preHooks.length();
         uint256 postOnlyHooksLength = selectorData.postOnlyHooks.length();
@@ -469,12 +463,6 @@ contract UpgradeableModularAccount is
         for (uint256 i = 0; i < preExecHooksLength; ++i) {
             bytes32 key = selectorData.preHooks.at(i);
             FunctionReference preExecHook = _toFunctionReference(key);
-
-            if (preExecHook.isEmptyOrMagicValue()) {
-                // The function reference must be PRE_HOOK_ALWAYS_DENY in this case, because zero and any other
-                // magic value is unassignable here.
-                revert AlwaysDenyRule();
-            }
 
             bytes memory preExecHookReturnData = _runPreExecHook(preExecHook, data);
 

--- a/src/helpers/FunctionReferenceLib.sol
+++ b/src/helpers/FunctionReferenceLib.sol
@@ -26,6 +26,10 @@ library FunctionReferenceLib {
         return FunctionReference.unwrap(fr) == bytes21(0);
     }
 
+    function notEmpty(FunctionReference fr) internal pure returns (bool) {
+        return FunctionReference.unwrap(fr) != bytes21(0);
+    }
+
     function isEmptyOrMagicValue(FunctionReference fr) internal pure returns (bool) {
         return FunctionReference.unwrap(fr) <= bytes21(uint168(2));
     }

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -19,10 +19,9 @@ enum ManifestAssociatedFunctionType {
     // setting a hook and is therefore disallowed.
     RUNTIME_VALIDATION_ALWAYS_ALLOW,
     // Resolves to a magic value to always fail in a hook for a given function.
-    // This is only assignable to pre hooks (pre validation and pre execution). It should not be used on
-    // validation functions themselves, because this is equivalent to leaving the validation functions unset.
-    // It should not be used in post-exec hooks, because if it is known to always revert, that should happen
-    // as early as possible to save gas.
+    // This is only assignable to pre execution hooks. It should not be used on validation functions themselves, because
+    // this is equivalent to leaving the validation functions unset. It should not be used in post-exec hooks, because
+    // if it is known to always revert, that should happen as early as possible to save gas.
     PRE_HOOK_ALWAYS_DENY
 }
 // forgefmt: disable-end

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -348,10 +348,9 @@ enum ManifestAssociatedFunctionType {
     // setting a hook and is therefore disallowed.
     RUNTIME_VALIDATION_ALWAYS_ALLOW,
     // Resolves to a magic value to always fail in a hook for a given function.
-    // This is only assignable to pre hooks (pre validation and pre execution). It should not be used on
-    // validation functions themselves, because this is equivalent to leaving the validation functions unset.
-    // It should not be used in post-exec hooks, because if it is known to always revert, that should happen
-    // as early as possible to save gas.
+    // This is only assignable to pre execution hooks. It should not be used on validation functions themselves, because
+    // this is equivalent to leaving the validation functions unset. It should not be used in post-exec hooks, because
+    // if it is known to always revert, that should happen as early as possible to save gas.
     PRE_HOOK_ALWAYS_DENY
 }
 
@@ -498,7 +497,7 @@ Finally, the function MUST emit the event `PluginUninstalled` with the plugin's 
 
 When the function `validateUserOp` is called on modular account by the `EntryPoint`, it MUST find the user operation validation function associated to the function selector in the first four bytes of `userOp.callData`. If there is no function defined for the selector, or if `userOp.callData.length < 4`, then execution MUST revert.
 
-If the function selector has associated pre user operation validation hooks, then those hooks MUST be run sequentially. If any revert, the outer call MUST revert. If any are set to `PRE_HOOK_ALWAYS_DENY`, the call MUST revert. If any return an `authorizer` value other than 0 or 1, execution MUST revert. If any return an `authorizer` value of 1, indicating an invalid signature, the returned validation data of the outer call MUST also be 1. If any return time-bounded validation by specifying either a `validUntil` or `validBefore` value, the resulting validation data MUST be the intersection of all time bounds provided.
+If the function selector has associated pre user operation validation hooks, then those hooks MUST be run sequentially. If any revert, the outer call MUST revert. If the selector has any pre execution hooks set to `PRE_HOOK_ALWAYS_DENY`, the call MUST revert. If any return an `authorizer` value other than 0 or 1, execution MUST revert. If any return an `authorizer` value of 1, indicating an invalid signature, the returned validation data of the outer call MUST also be 1. If any return time-bounded validation by specifying either a `validUntil` or `validBefore` value, the resulting validation data MUST be the intersection of all time bounds provided.
 
 Then, the modular account MUST execute the validation function with the user operation and its hash as parameters using the `call` opcode. The returned validation data from the user operation validation function MUST be updated, if necessary, by the return values of any pre user operation validation hooks, then returned by `validateUserOp`.
 
@@ -510,7 +509,7 @@ Additionally, when the modular account natively implements functions in `IPlugin
 
 The steps to perform are:
 
-- If the call is not from the `EntryPoint`, then find an associated runtime validation function. If one does not exist, execution MUST revert. The modular account MUST execute all pre runtime validation hooks, then the runtime validation function, with the `call` opcode. All of these functions MUST receive the caller, value, and execution function's calldata as parameters. If any of these functions revert, execution MUST revert. If any pre runtime validation hooks are set to `PRE_HOOK_ALWAYS_DENY`, execution MUST revert. If the runtime validation function is set to `RUNTIME_VALIDATION_ALWAYS_ALLOW`, the validation function MUST be bypassed.
+- If the call is not from the `EntryPoint`, then find an associated runtime validation function. If one does not exist, execution MUST revert. The modular account MUST execute all pre runtime validation hooks, then the runtime validation function, with the `call` opcode. All of these functions MUST receive the caller, value, and execution function's calldata as parameters. If any of these functions revert, execution MUST revert. If any pre execution hooks are set to `PRE_HOOK_ALWAYS_DENY`, execution MUST revert. If the validation function is set to `RUNTIME_VALIDATION_ALWAYS_ALLOW`, the runtime validation function MUST be bypassed.
 - If there are pre execution hooks defined for the execution function, execute those hooks with the caller, value, and execution function's calldata as parameters. If any of these hooks returns data, it MUST be preserved until the call to the post execution hook. The operation MUST be done with the `call` opcode. If there are duplicate pre execution hooks (i.e., hooks with identical `FunctionReference`s), run the hook only once. If any of these functions revert, execution MUST revert.
 - Run the execution function.
 - If any post execution hooks are defined, run the functions. If a pre execution hook returned data to the account, that data MUST be passed as a parameter to the associated post execution hook. The operation MUST be done with the `call` opcode. If there are duplicate post execution hooks, run them once for each unique associated pre execution hook. For post execution hooks without an associated pre execution hook, run the hook only once. If any of these functions revert, execution MUST revert.


### PR DESCRIPTION
## Motivation

Overlapping hooks were an edge case introduced to handle certain behavior when using hooks as dependencies. However, hook dependencies as a whole were disabled in v0.7 due to risks around inconsistent plugin state configuration, meaning overlapping hooks became impossible except when using the "always deny" magic value.

This has led to the large amounts of code in the reference implementation handling multiple hooks assignments overlapping going unused, since this case only happens under one condition and never results in hooks actually being executed. This worsens readability & slows development when changing how account state is stored.

## Solution

- Revert the usage of `EnumerableMap.Bytes32ToUintMap` to `EnumerableSet.Bytes32Set` for holding plugin functions.
- Remove internal helpers like  `_addOrIncrement` and `_removeOrDecrement` intended to handle hook overlaps.
- Remove the hook "unrolling" behavior in `_doPreExecHooks` and in the `getExecutionHooks` loupe function.

### How this change handles overlapping `PRE_HOOK_ALWAYS_DENY`

Rather than assigning a "count" to a `FunctionReference` type, and incrementing the count for the number of overlapping deny hooks, this change moves the count of overlapping denies out to a variable within `SelectorData`. The "magic value" `FunctionReference` indicating `PRE_HOOK_ALWAYS_DENY` is now no longer added to the actual hooks set, and instead this counter reflects how many times it has been applied.

Note that previously, the `PRE_HOOK_ALWAYS_DENY` value could be applied over any of pre validation hooks (previously split across user op and runtime, but now merged) or execution hooks. However, this would cause an annoying split given the current architecture - the hook could apply in one of two places, meaning we would need to track two counters rather than one.

To simplify, this PR changes the spec to only allow the `PRE_HOOK_ALWAYS_DENY` magic value to be assigned to pre validation hooks. However, if any are assigned (count > 0), then the account behavior will be to revert during any validation or execution path for that selector.

To discuss: this handles all previous workflows except one, where `PRE_HOOK_ALWAYS_DENY` is applied to pre validation hooks but not pre execution. In that case, any regular plugin execution would be denied, but it would still be possible to call via `executeFromPlugin`. Given the number of validation-path changes coming in v0.8, this seems fine, but flagging here in case anyone has thoughts about that workflow.

