### PR TITLE
feat: [v0.8-develop] Simplify hook declaration and storage

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -7,7 +7,13 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
 import {FunctionReference, IPluginManager} from "../interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
-import {AccountStorage, getAccountStorage, SelectorData, toFunctionReferenceArray} from "./AccountStorage.sol";
+import {
+    AccountStorage,
+    getAccountStorage,
+    SelectorData,
+    toFunctionReferenceArray,
+    toHookData
+} from "./AccountStorage.sol";
 
 abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -38,23 +44,14 @@ abstract contract AccountLoupe is IAccountLoupe {
     /// @inheritdoc IAccountLoupe
     function getExecutionHooks(bytes4 selector) external view returns (ExecutionHooks[] memory execHooks) {
         SelectorData storage selectorData = getAccountStorage().selectorData[selector];
-        uint256 preExecHooksLength = selectorData.preHooks.length();
-        uint256 postOnlyExecHooksLength = selectorData.postOnlyHooks.length();
+        uint256 executionHooksLength = selectorData.executionHooks.length();
 
-        execHooks = new ExecutionHooks[](preExecHooksLength + postOnlyExecHooksLength);
+        execHooks = new ExecutionHooks[](executionHooksLength);
 
-        for (uint256 i = 0; i < preExecHooksLength; ++i) {
-            bytes32 key = selectorData.preHooks.at(i);
-            FunctionReference preExecHook = FunctionReference.wrap(bytes21(key));
-            FunctionReference associatedPostExecHook = selectorData.associatedPostHooks[preExecHook];
-
-            execHooks[i].preExecHook = preExecHook;
-            execHooks[i].postExecHook = associatedPostExecHook;
-        }
-
-        for (uint256 i = 0; i < postOnlyExecHooksLength; ++i) {
-            bytes32 key = selectorData.postOnlyHooks.at(i);
-            execHooks[preExecHooksLength + i].postExecHook = FunctionReference.wrap(bytes21(key));
+        for (uint256 i = 0; i < executionHooksLength; ++i) {
+            bytes32 key = selectorData.executionHooks.at(i);
+            ExecutionHooks memory execHook = execHooks[i];
+            (execHook.hookFunction, execHook.isPreHook, execHook.isPostHook) = toHookData(key);
         }
     }
 

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.25;
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
+import {IAccountLoupe, ExecutionHook} from "../interfaces/IAccountLoupe.sol";
 import {FunctionReference, IPluginManager} from "../interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 import {
@@ -12,7 +12,7 @@ import {
     getAccountStorage,
     SelectorData,
     toFunctionReferenceArray,
-    toHookData
+    toExecutionHook
 } from "./AccountStorage.sol";
 
 abstract contract AccountLoupe is IAccountLoupe {
@@ -42,16 +42,16 @@ abstract contract AccountLoupe is IAccountLoupe {
     }
 
     /// @inheritdoc IAccountLoupe
-    function getExecutionHooks(bytes4 selector) external view returns (ExecutionHooks[] memory execHooks) {
+    function getExecutionHooks(bytes4 selector) external view returns (ExecutionHook[] memory execHooks) {
         SelectorData storage selectorData = getAccountStorage().selectorData[selector];
         uint256 executionHooksLength = selectorData.executionHooks.length();
 
-        execHooks = new ExecutionHooks[](executionHooksLength);
+        execHooks = new ExecutionHook[](executionHooksLength);
 
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = selectorData.executionHooks.at(i);
-            ExecutionHooks memory execHook = execHooks[i];
-            (execHook.hookFunction, execHook.isPreHook, execHook.isPostHook) = toHookData(key);
+            ExecutionHook memory execHook = execHooks[i];
+            (execHook.hookFunction, execHook.isPreHook, execHook.isPostHook) = toExecutionHook(key);
         }
     }
 

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IPlugin} from "../interfaces/IPlugin.sol";
+import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
 import {FunctionReference} from "../interfaces/IPluginManager.sol";
 
 // bytes = keccak256("ERC6900.UpgradeableModularAccount.Storage")
@@ -27,12 +28,6 @@ struct PermittedExternalCallData {
     bool addressPermitted;
     bool anySelectorPermitted;
     mapping(bytes4 => bool) permittedSelectors;
-}
-
-struct HookData {
-    FunctionReference hookFunction;
-    bool isPreHook;
-    bool isPostHook;
 }
 
 // Represents data associated with a specifc function selector.
@@ -90,17 +85,18 @@ function toFunctionReference(bytes32 setValue) pure returns (FunctionReference) 
     return FunctionReference.wrap(bytes21(setValue));
 }
 
-// HookData layout:
+// ExecutionHook layout:
 // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF______________________ Hook Function Reference
 // 0x__________________________________________AA____________________ is pre hook
 // 0x____________________________________________BB__________________ is post hook
 
-function toSetValue(HookData memory hookData) pure returns (bytes32) {
-    return bytes32(FunctionReference.unwrap(hookData.hookFunction))
-        | bytes32(hookData.isPreHook ? uint256(1) << 80 : 0) | bytes32(hookData.isPostHook ? uint256(1) << 72 : 0);
+function toSetValue(ExecutionHook memory executionHook) pure returns (bytes32) {
+    return bytes32(FunctionReference.unwrap(executionHook.hookFunction))
+        | bytes32(executionHook.isPreHook ? uint256(1) << 80 : 0)
+        | bytes32(executionHook.isPostHook ? uint256(1) << 72 : 0);
 }
 
-function toHookData(bytes32 setValue)
+function toExecutionHook(bytes32 setValue)
     pure
     returns (FunctionReference hookFunction, bool isPreHook, bool isPostHook)
 {

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -14,11 +14,11 @@ import {
     ManifestExternalCallPermission,
     PluginManifest
 } from "../interfaces/IPlugin.sol";
+import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
 import {FunctionReference, IPluginManager} from "../interfaces/IPluginManager.sol";
 import {
     AccountStorage,
     getAccountStorage,
-    HookData,
     SelectorData,
     toSetValue,
     getPermittedCallKey,
@@ -106,7 +106,7 @@ abstract contract PluginManagerInternals is IPluginManager {
     ) internal {
         getAccountStorage().selectorData[selector].executionHooks.add(
             toSetValue(
-                HookData({hookFunction: hookFunction, isPreHook: isPreExecHook, isPostHook: isPostExecHook})
+                ExecutionHook({hookFunction: hookFunction, isPreHook: isPreExecHook, isPostHook: isPostExecHook})
             )
         );
     }
@@ -119,7 +119,7 @@ abstract contract PluginManagerInternals is IPluginManager {
     ) internal {
         getAccountStorage().selectorData[selector].executionHooks.remove(
             toSetValue(
-                HookData({hookFunction: hookFunction, isPreHook: isPreExecHook, isPostHook: isPostExecHook})
+                ExecutionHook({hookFunction: hookFunction, isPreHook: isPreExecHook, isPostHook: isPostExecHook})
             )
         );
     }

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -16,7 +16,14 @@ import {FunctionReference, IPluginManager} from "../interfaces/IPluginManager.so
 import {IStandardExecutor, Call} from "../interfaces/IStandardExecutor.sol";
 import {AccountExecutor} from "./AccountExecutor.sol";
 import {AccountLoupe} from "./AccountLoupe.sol";
-import {AccountStorage, getAccountStorage, getPermittedCallKey, SelectorData} from "./AccountStorage.sol";
+import {
+    AccountStorage,
+    getAccountStorage,
+    getPermittedCallKey,
+    SelectorData,
+    toFunctionReference,
+    toHookData
+} from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
 import {PluginManagerInternals} from "./PluginManagerInternals.sol";
 
@@ -51,7 +58,6 @@ contract UpgradeableModularAccount is
     error AuthorizeUpgradeReverted(bytes revertReason);
     error ExecFromPluginNotPermitted(address plugin, bytes4 selector);
     error ExecFromPluginExternalNotPermitted(address plugin, address target, uint256 value, bytes data);
-    error InvalidConfiguration();
     error NativeTokenSpendingNotPermitted(address plugin);
     error PostExecHookReverted(address plugin, uint8 functionId, bytes revertReason);
     error PreExecHookReverted(address plugin, uint8 functionId, bytes revertReason);
@@ -355,7 +361,7 @@ contract UpgradeableModularAccount is
         uint256 preUserOpValidationHooksLength = preUserOpValidationHooks.length();
         for (uint256 i = 0; i < preUserOpValidationHooksLength; ++i) {
             bytes32 key = preUserOpValidationHooks.at(i);
-            FunctionReference preUserOpValidationHook = _toFunctionReference(key);
+            FunctionReference preUserOpValidationHook = toFunctionReference(key);
 
             (address plugin, uint8 functionId) = preUserOpValidationHook.unpack();
             currentValidationData = IPlugin(plugin).preUserOpValidationHook(functionId, userOp, userOpHash);
@@ -398,7 +404,7 @@ contract UpgradeableModularAccount is
         uint256 preRuntimeValidationHooksLength = preRuntimeValidationHooks.length();
         for (uint256 i = 0; i < preRuntimeValidationHooksLength; ++i) {
             bytes32 key = preRuntimeValidationHooks.at(i);
-            FunctionReference preRuntimeValidationHook = _toFunctionReference(key);
+            FunctionReference preRuntimeValidationHook = toFunctionReference(key);
 
             (address plugin, uint8 functionId) = preRuntimeValidationHook.unpack();
             // solhint-disable-next-line no-empty-blocks
@@ -432,44 +438,34 @@ contract UpgradeableModularAccount is
     {
         SelectorData storage selectorData = getAccountStorage().selectorData[selector];
 
-        uint256 preExecHooksLength = selectorData.preHooks.length();
-        uint256 postOnlyHooksLength = selectorData.postOnlyHooks.length();
+        uint256 hooksLength = selectorData.executionHooks.length();
 
         // Overallocate on length - not all of this may get filled up. We set the correct length later.
-        postHooksToRun = new PostExecToRun[](preExecHooksLength + postOnlyHooksLength);
+        postHooksToRun = new PostExecToRun[](hooksLength);
 
         // Copy all post hooks to the array. This happens before any pre hooks are run, so we can
         // be sure that the set of hooks to run will not be affected by state changes mid-execution.
-
-        // Copy post-only hooks.
-        for (uint256 i = 0; i < postOnlyHooksLength; ++i) {
-            bytes32 key = selectorData.postOnlyHooks.at(i);
-            postHooksToRun[i].postExecHook = _toFunctionReference(key);
-        }
-
-        // Copy associated post hooks to the array.
-        for (uint256 i = 0; i < preExecHooksLength; ++i) {
-            FunctionReference preExecHook = _toFunctionReference(selectorData.preHooks.at(i));
-
-            FunctionReference associatedPostExecHook = selectorData.associatedPostHooks[preExecHook];
-
-            if (associatedPostExecHook.notEmpty()) {
-                postHooksToRun[i + postOnlyHooksLength].postExecHook = associatedPostExecHook;
+        for (uint256 i = 0; i < hooksLength; ++i) {
+            bytes32 key = selectorData.executionHooks.at(i);
+            (FunctionReference hookFunction,, bool isPostHook) = toHookData(key);
+            if (isPostHook) {
+                postHooksToRun[i].postExecHook = hookFunction;
             }
         }
 
         // Run the pre hooks and copy their return data to the post hooks array, if an associated post-exec hook
         // exists.
-        for (uint256 i = 0; i < preExecHooksLength; ++i) {
-            bytes32 key = selectorData.preHooks.at(i);
-            FunctionReference preExecHook = _toFunctionReference(key);
+        for (uint256 i = 0; i < hooksLength; ++i) {
+            bytes32 key = selectorData.executionHooks.at(i);
+            (FunctionReference hookFunction, bool isPreHook, bool isPostHook) = toHookData(key);
 
-            bytes memory preExecHookReturnData = _runPreExecHook(preExecHook, data);
+            if (isPreHook) {
+                bytes memory preExecHookReturnData = _runPreExecHook(hookFunction, data);
 
-            // If there is an associated post-exec hook, save the return data.
-            PostExecToRun memory postExecToRun = postHooksToRun[i + postOnlyHooksLength];
-            if (postExecToRun.postExecHook.notEmpty()) {
-                postExecToRun.preExecHookReturnData = preExecHookReturnData;
+                // If there is an associated post-exec hook, save the return data.
+                if (isPostHook) {
+                    postHooksToRun[i].preExecHookReturnData = preExecHookReturnData;
+                }
             }
         }
     }

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -22,7 +22,7 @@ import {
     getPermittedCallKey,
     SelectorData,
     toFunctionReference,
-    toHookData
+    toExecutionHook
 } from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
 import {PluginManagerInternals} from "./PluginManagerInternals.sol";
@@ -447,7 +447,7 @@ contract UpgradeableModularAccount is
         // be sure that the set of hooks to run will not be affected by state changes mid-execution.
         for (uint256 i = 0; i < hooksLength; ++i) {
             bytes32 key = selectorData.executionHooks.at(i);
-            (FunctionReference hookFunction,, bool isPostHook) = toHookData(key);
+            (FunctionReference hookFunction,, bool isPostHook) = toExecutionHook(key);
             if (isPostHook) {
                 postHooksToRun[i].postExecHook = hookFunction;
             }
@@ -457,7 +457,7 @@ contract UpgradeableModularAccount is
         // exists.
         for (uint256 i = 0; i < hooksLength; ++i) {
             bytes32 key = selectorData.executionHooks.at(i);
-            (FunctionReference hookFunction, bool isPreHook, bool isPostHook) = toHookData(key);
+            (FunctionReference hookFunction, bool isPreHook, bool isPostHook) = toExecutionHook(key);
 
             if (isPreHook) {
                 bytes memory preExecHookReturnData = _runPreExecHook(hookFunction, data);

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -3,19 +3,19 @@ pragma solidity ^0.8.25;
 
 import {FunctionReference} from "../interfaces/IPluginManager.sol";
 
+/// @notice Pre and post hooks for a given selector.
+/// @dev It's possible for one of either `preExecHook` or `postExecHook` to be empty.
+struct ExecutionHook {
+    FunctionReference hookFunction;
+    bool isPreHook;
+    bool isPostHook;
+}
+
 interface IAccountLoupe {
     /// @notice Config for an execution function, given a selector.
     struct ExecutionFunctionConfig {
         address plugin;
         FunctionReference validationFunction;
-    }
-
-    /// @notice Pre and post hooks for a given selector.
-    /// @dev It's possible for one of either `preExecHook` or `postExecHook` to be empty.
-    struct ExecutionHooks {
-        FunctionReference hookFunction;
-        bool isPreHook;
-        bool isPostHook;
     }
 
     /// @notice Get the validation functions and plugin address for a selector.
@@ -27,7 +27,7 @@ interface IAccountLoupe {
     /// @notice Get the pre and post execution hooks for a selector.
     /// @param selector The selector to get the hooks for.
     /// @return The pre and post execution hooks for this selector.
-    function getExecutionHooks(bytes4 selector) external view returns (ExecutionHooks[] memory);
+    function getExecutionHooks(bytes4 selector) external view returns (ExecutionHook[] memory);
 
     /// @notice Get the pre user op and runtime validation hooks associated with a selector.
     /// @param selector The selector to get the hooks for.

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -13,8 +13,9 @@ interface IAccountLoupe {
     /// @notice Pre and post hooks for a given selector.
     /// @dev It's possible for one of either `preExecHook` or `postExecHook` to be empty.
     struct ExecutionHooks {
-        FunctionReference preExecHook;
-        FunctionReference postExecHook;
+        FunctionReference hookFunction;
+        bool isPreHook;
+        bool isPostHook;
     }
 
     /// @notice Get the validation functions and plugin address for a selector.

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -40,9 +40,11 @@ struct ManifestAssociatedFunction {
 }
 
 struct ManifestExecutionHook {
+    // TODO(erc6900 spec): These fields can be packed into a single word
     bytes4 executionSelector;
-    ManifestFunction preExecHook;
-    ManifestFunction postExecHook;
+    uint8 functionId;
+    bool isPreHook;
+    bool isPostHook;
 }
 
 struct ManifestExternalCallPermission {

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -221,8 +221,9 @@ interface IAccountLoupe {
     /// @notice Pre and post hooks for a given selector.
     /// @dev It's possible for one of either `preExecHook` or `postExecHook` to be empty.
     struct ExecutionHooks {
-        FunctionReference preExecHook;
-        FunctionReference postExecHook;
+        FunctionReference hookFunction;
+        bool isPreHook;
+        bool isPostHook;
     }
 
     /// @notice Get the validation functions and plugin address for a selector.
@@ -368,9 +369,11 @@ struct ManifestAssociatedFunction {
 }
 
 struct ManifestExecutionHook {
-    bytes4 selector;
-    ManifestFunction preExecHook;
-    ManifestFunction postExecHook;
+    // TODO(erc6900 spec): These fields can be packed into a single word
+    bytes4 executionSelector;
+    uint8 functionId;
+    bool isPreHook;
+    bool isPostHook;
 }
 
 struct ManifestExternalCallPermission {

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
-import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
+import {IAccountLoupe, ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
 import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
@@ -100,23 +100,23 @@ contract AccountLoupeTest is AccountTestBase {
     }
 
     function test_pluginLoupe_getExecutionHooks() public {
-        IAccountLoupe.ExecutionHooks[] memory hooks = account1.getExecutionHooks(comprehensivePlugin.foo.selector);
-        IAccountLoupe.ExecutionHooks[3] memory expectedHooks = [
-            IAccountLoupe.ExecutionHooks({
+        ExecutionHook[] memory hooks = account1.getExecutionHooks(comprehensivePlugin.foo.selector);
+        ExecutionHook[3] memory expectedHooks = [
+            ExecutionHook({
                 hookFunction: FunctionReferenceLib.pack(
                     address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.BOTH_EXECUTION_HOOKS)
                 ),
                 isPreHook: true,
                 isPostHook: true
             }),
-            IAccountLoupe.ExecutionHooks({
+            ExecutionHook({
                 hookFunction: FunctionReferenceLib.pack(
                     address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.PRE_EXECUTION_HOOK)
                 ),
                 isPreHook: true,
                 isPostHook: false
             }),
-            IAccountLoupe.ExecutionHooks({
+            ExecutionHook({
                 hookFunction: FunctionReferenceLib.pack(
                     address(comprehensivePlugin), uint8(ComprehensivePlugin.FunctionId.POST_EXECUTION_HOOK)
                 ),

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -6,11 +6,8 @@ import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
 
 import {
     BadValidationMagicValue_PreValidationHook_Plugin,
-    BadValidationMagicValue_PreExecHook_Plugin,
-    BadValidationMagicValue_PostExecHook_Plugin,
     BadHookMagicValue_UserOpValidationFunction_Plugin,
-    BadHookMagicValue_RuntimeValidationFunction_Plugin,
-    BadHookMagicValue_PostExecHook_Plugin
+    BadHookMagicValue_RuntimeValidationFunction_Plugin
 } from "../mocks/plugins/ManifestValidityMocks.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
@@ -24,36 +21,6 @@ contract ManifestValidityTest is AccountTestBase {
     function test_ManifestValidity_invalid_ValidationAlwaysAllow_PreValidationHook() public {
         BadValidationMagicValue_PreValidationHook_Plugin plugin =
             new BadValidationMagicValue_PreValidationHook_Plugin();
-
-        bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
-
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account1.installPlugin({
-            plugin: address(plugin),
-            manifestHash: manifestHash,
-            pluginInstallData: "",
-            dependencies: new FunctionReference[](0)
-        });
-    }
-
-    // Tests that the plugin manager rejects a plugin with a pre-execution hook set to "validation always allow"
-    function test_ManifestValidity_invalid_ValidationAlwaysAllow_PreExecHook() public {
-        BadValidationMagicValue_PreExecHook_Plugin plugin = new BadValidationMagicValue_PreExecHook_Plugin();
-
-        bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
-
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account1.installPlugin({
-            plugin: address(plugin),
-            manifestHash: manifestHash,
-            pluginInstallData: "",
-            dependencies: new FunctionReference[](0)
-        });
-    }
-
-    // Tests that the plugin manager rejects a plugin with a post-execution hook set to "validation always allow"
-    function test_ManifestValidity_invalid_ValidationAlwaysAllow_PostExecHook() public {
-        BadValidationMagicValue_PostExecHook_Plugin plugin = new BadValidationMagicValue_PostExecHook_Plugin();
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
@@ -86,21 +53,6 @@ contract ManifestValidityTest is AccountTestBase {
     function test_ManifestValidity_invalid_HookAlwaysDeny_RuntimeValidationFunction() public {
         BadHookMagicValue_RuntimeValidationFunction_Plugin plugin =
             new BadHookMagicValue_RuntimeValidationFunction_Plugin();
-
-        bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
-
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
-        account1.installPlugin({
-            plugin: address(plugin),
-            manifestHash: manifestHash,
-            pluginInstallData: "",
-            dependencies: new FunctionReference[](0)
-        });
-    }
-
-    // Tests that the plugin manager rejects a plugin with a post-execution hook set to "hook always deny"
-    function test_ManifestValidity_invalid_HookAlwaysDeny_PostExecHook() public {
-        BadHookMagicValue_PostExecHook_Plugin plugin = new BadHookMagicValue_PostExecHook_Plugin();
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -19,10 +19,9 @@ contract ComprehensivePlugin is BasePlugin {
         PRE_VALIDATION_HOOK_1,
         PRE_VALIDATION_HOOK_2,
         VALIDATION,
+        BOTH_EXECUTION_HOOKS,
         PRE_EXECUTION_HOOK,
-        PRE_PERMITTED_CALL_EXECUTION_HOOK,
-        POST_EXECUTION_HOOK,
-        POST_PERMITTED_CALL_EXECUTION_HOOK
+        POST_EXECUTION_HOOK
     }
 
     string public constant NAME = "Comprehensive Plugin";
@@ -97,7 +96,7 @@ contract ComprehensivePlugin is BasePlugin {
     {
         if (functionId == uint8(FunctionId.PRE_EXECUTION_HOOK)) {
             return "";
-        } else if (functionId == uint8(FunctionId.PRE_PERMITTED_CALL_EXECUTION_HOOK)) {
+        } else if (functionId == uint8(FunctionId.BOTH_EXECUTION_HOOKS)) {
             return "";
         }
         revert NotImplemented();
@@ -106,7 +105,7 @@ contract ComprehensivePlugin is BasePlugin {
     function postExecutionHook(uint8 functionId, bytes calldata) external pure override {
         if (functionId == uint8(FunctionId.POST_EXECUTION_HOOK)) {
             return;
-        } else if (functionId == uint8(FunctionId.POST_PERMITTED_CALL_EXECUTION_HOOK)) {
+        } else if (functionId == uint8(FunctionId.BOTH_EXECUTION_HOOKS)) {
             return;
         }
         revert NotImplemented();
@@ -163,19 +162,24 @@ contract ComprehensivePlugin is BasePlugin {
             })
         });
 
-        manifest.executionHooks = new ManifestExecutionHook[](1);
+        manifest.executionHooks = new ManifestExecutionHook[](3);
         manifest.executionHooks[0] = ManifestExecutionHook({
             executionSelector: this.foo.selector,
-            preExecHook: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.PRE_EXECUTION_HOOK),
-                dependencyIndex: 0 // Unused.
-            }),
-            postExecHook: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: uint8(FunctionId.POST_EXECUTION_HOOK),
-                dependencyIndex: 0 // Unused.
-            })
+            functionId: uint8(FunctionId.BOTH_EXECUTION_HOOKS),
+            isPreHook: true,
+            isPostHook: true
+        });
+        manifest.executionHooks[1] = ManifestExecutionHook({
+            executionSelector: this.foo.selector,
+            functionId: uint8(FunctionId.PRE_EXECUTION_HOOK),
+            isPreHook: true,
+            isPostHook: false
+        });
+        manifest.executionHooks[2] = ManifestExecutionHook({
+            executionSelector: this.foo.selector,
+            functionId: uint8(FunctionId.POST_EXECUTION_HOOK),
+            isPreHook: false,
+            isPostHook: true
         });
 
         return manifest;

--- a/test/mocks/plugins/ManifestValidityMocks.sol
+++ b/test/mocks/plugins/ManifestValidityMocks.sol
@@ -5,7 +5,6 @@ import {
     ManifestFunction,
     ManifestAssociatedFunctionType,
     ManifestAssociatedFunction,
-    ManifestExecutionHook,
     PluginManifest
 } from "../../../src/interfaces/IPlugin.sol";
 
@@ -42,79 +41,6 @@ contract BadValidationMagicValue_PreValidationHook_Plugin is BaseTestPlugin {
         manifest.preValidationHooks[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
-                functionId: 0,
-                dependencyIndex: 0
-            })
-        });
-
-        return manifest;
-    }
-}
-
-// solhint-disable-next-line contract-name-camelcase
-contract BadValidationMagicValue_PreExecHook_Plugin is BaseTestPlugin {
-    function onInstall(bytes calldata) external override {}
-
-    function onUninstall(bytes calldata) external override {}
-
-    function foo() external pure returns (bytes32) {
-        return keccak256("bar");
-    }
-
-    function pluginManifest() external pure override returns (PluginManifest memory) {
-        PluginManifest memory manifest;
-
-        manifest.executionFunctions = new bytes4[](1);
-        manifest.executionFunctions[0] = this.foo.selector;
-
-        manifest.executionHooks = new ManifestExecutionHook[](1);
-
-        // Illegal assignment: validation always allow only usable on runtime validation functions
-        manifest.executionHooks[0] = ManifestExecutionHook({
-            executionSelector: this.foo.selector,
-            preExecHook: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
-                functionId: 0,
-                dependencyIndex: 0
-            }),
-            postExecHook: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: 0, // Dummy unimplemented function id, but can be added correctly
-                dependencyIndex: 0
-            })
-        });
-
-        return manifest;
-    }
-}
-
-// solhint-disable-next-line contract-name-camelcase
-contract BadValidationMagicValue_PostExecHook_Plugin is BaseTestPlugin {
-    function onInstall(bytes calldata) external override {}
-
-    function onUninstall(bytes calldata) external override {}
-
-    function foo() external pure returns (bytes32) {
-        return keccak256("bar");
-    }
-
-    function pluginManifest() external pure override returns (PluginManifest memory) {
-        PluginManifest memory manifest;
-
-        manifest.executionFunctions = new bytes4[](1);
-        manifest.executionFunctions[0] = this.foo.selector;
-
-        manifest.executionHooks = new ManifestExecutionHook[](1);
-        // Illegal assignment: validation always allow only usable on runtime validation functions
-        manifest.executionHooks[0] = ManifestExecutionHook({
-            executionSelector: this.foo.selector,
-            preExecHook: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: 0, // Dummy unimplemented function id, but can be added correctly
-                dependencyIndex: 0
-            }),
-            postExecHook: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW,
                 functionId: 0,
                 dependencyIndex: 0
@@ -175,42 +101,6 @@ contract BadHookMagicValue_RuntimeValidationFunction_Plugin is BaseTestPlugin {
         manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.foo.selector,
             associatedFunction: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY,
-                functionId: 0,
-                dependencyIndex: 0
-            })
-        });
-
-        return manifest;
-    }
-}
-
-// solhint-disable-next-line contract-name-camelcase
-contract BadHookMagicValue_PostExecHook_Plugin is BaseTestPlugin {
-    function onInstall(bytes calldata) external override {}
-
-    function onUninstall(bytes calldata) external override {}
-
-    function foo() external pure returns (bytes32) {
-        return keccak256("bar");
-    }
-
-    function pluginManifest() external pure override returns (PluginManifest memory) {
-        PluginManifest memory manifest;
-
-        manifest.executionFunctions = new bytes4[](1);
-        manifest.executionFunctions[0] = this.foo.selector;
-
-        manifest.executionHooks = new ManifestExecutionHook[](1);
-        // Illegal assignment: hook always deny only usable on runtime validation functions
-        manifest.executionHooks[0] = ManifestExecutionHook({
-            executionSelector: this.foo.selector,
-            preExecHook: ManifestFunction({
-                functionType: ManifestAssociatedFunctionType.SELF,
-                functionId: 0, // Dummy unimplemented function id, but can be added correctly
-                dependencyIndex: 0
-            }),
-            postExecHook: ManifestFunction({
                 functionType: ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY,
                 functionId: 0,
                 dependencyIndex: 0


### PR DESCRIPTION
## Motivation

Since v0.7, execution hooks can’t be dependencies anymore. This means that pre and post hooks have to be defined by the same plugin.

We can make a simplification similar to the “validation types” merges ([#40](https://github.com/erc6900/reference-implementation/pull/40), [#46](https://github.com/erc6900/reference-implementation/pull/46)) , by treating pre- and post- hooks as an interface, and require pre/post hooks to share a function id.

If there is a many-to-one relationship between pre and post hooks, the plugins can still handle that routing internally.

## Solution

- Simplify the manifest structure to not use `ManifestAssociatedFunction` types within `ManifestExecutionHook`, instead just declaring the selector, functionId, and pre/post status
- Simplify hook storage from 3 structures (`preHooks`, `associatedPostHooks`, and `postOnlyHooks`) to just 1 structure (`executionHooks`).
- Update `IAccountLoupe` interface to the new format (`FunctionReference` + pre/post status).
- Update tests, and remove now-impossible test failure cases 😄 

### Notes
- Eventually, we should create a scalable way to pack fields in the manifest & storage.
   - Right now, the 4 fields within `ManifestExecutionHook` take up 4 words in memory (4 * 32 = 128 bytes), despite fitting into a single `bytes32` word. This is an unfortunate limitation of abi encoding & solidity conventions.
   - Similarly, the `HookData` struct used within the account is kept in memory and occupies more space than is needed.
   - We've already set some precedent for using packed types with `FunctionReference` - does this warrant creating a new type for hook function references? How do we handle this going into the future?
   - For now, I left the encoding efficiency problem as a `todo` in the interface spec. We can further address this with work connected to manifest simplification.