### PR TITLE
feat: [v0.8-develop, experimental] multi-validation in calldata

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -11,6 +11,7 @@ import {
     AccountStorage,
     getAccountStorage,
     SelectorData,
+    toFunctionReference,
     toFunctionReferenceArray,
     toExecutionHook
 } from "./AccountStorage.sol";
@@ -38,7 +39,7 @@ abstract contract AccountLoupe is IAccountLoupe {
             config.plugin = _storage.selectorData[selector].plugin;
         }
 
-        config.validationFunction = _storage.selectorData[selector].validation;
+        config.defaultValidationFunction = toFunctionReference(_storage.selectorData[selector].validations.at(0));
     }
 
     /// @inheritdoc IAccountLoupe
@@ -53,6 +54,10 @@ abstract contract AccountLoupe is IAccountLoupe {
             ExecutionHook memory execHook = execHooks[i];
             (execHook.hookFunction, execHook.isPreHook, execHook.isPostHook) = toExecutionHook(key);
         }
+    }
+
+    function getValidationFunctions(bytes4 selector) external view returns (FunctionReference[] memory) {
+        return toFunctionReferenceArray(getAccountStorage().selectorData[selector].validations);
     }
 
     /// @inheritdoc IAccountLoupe

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -41,7 +41,7 @@ struct SelectorData {
     // but it packs alongside `plugin` while still leaving some other space in the slot for future packing.
     uint48 denyExecutionCount;
     // User operation validation and runtime validation share a function reference.
-    FunctionReference validation;
+    EnumerableSet.Bytes32Set validations;
     // The pre validation hooks for this function selector.
     EnumerableSet.Bytes32Set preValidationHooks;
     // The execution hooks for this function selector.

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -82,11 +82,11 @@ abstract contract PluginManagerInternals is IPluginManager {
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        if (_selectorData.validation.notEmpty()) {
+        // Fail on duplicate definitions - otherwise dependencies could shadow non-depdency
+        // validation functions, leading to partial uninstalls.
+        if (!_selectorData.validations.add(toSetValue(validationFunction))) {
             revert ValidationFunctionAlreadySet(selector, validationFunction);
         }
-
-        _selectorData.validation = validationFunction;
     }
 
     function _removeValidationFunction(bytes4 selector, FunctionReference validationFunction)
@@ -95,7 +95,9 @@ abstract contract PluginManagerInternals is IPluginManager {
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        _selectorData.validation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
+        // May ignore return value, as the manifest hash is validated to ensure that the validation function
+        // exists.
+        _selectorData.validations.remove(toSetValue(validationFunction));
     }
 
     function _addExecHooks(

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -15,7 +15,7 @@ interface IAccountLoupe {
     /// @notice Config for an execution function, given a selector.
     struct ExecutionFunctionConfig {
         address plugin;
-        FunctionReference validationFunction;
+        FunctionReference defaultValidationFunction;
     }
 
     /// @notice Get the validation functions and plugin address for a selector.
@@ -28,6 +28,11 @@ interface IAccountLoupe {
     /// @param selector The selector to get the hooks for.
     /// @return The pre and post execution hooks for this selector.
     function getExecutionHooks(bytes4 selector) external view returns (ExecutionHook[] memory);
+
+    // todo: natspec
+    function getValidationFunctions(bytes4 selector) external view returns (FunctionReference[] memory);
+
+    // todo: should we support a validation checking function (bytes4, FunctionReference) -> bool?
 
     /// @notice Get the pre user op and runtime validation hooks associated with a selector.
     /// @param selector The selector to get the hooks for.

--- a/src/interfaces/IStandardExecutor.sol
+++ b/src/interfaces/IStandardExecutor.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.25;
 
+import {FunctionReference} from "./IPluginManager.sol";
+
 struct Call {
     // The target address for the account to call.
     address target;
@@ -25,4 +27,9 @@ interface IStandardExecutor {
     /// @param calls The array of calls.
     /// @return An array containing the return data from the calls.
     function executeBatch(Call[] calldata calls) external payable returns (bytes[] memory);
+
+    // todo: natspec
+    function executeWithValidation(FunctionReference validation, bytes calldata data)
+        external
+        returns (bytes memory);
 }

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -66,7 +66,7 @@ contract AccountLoupeTest is AccountTestBase {
 
             assertEq(config.plugin, address(account1));
             assertEq(
-                FunctionReference.unwrap(config.validationFunction),
+                FunctionReference.unwrap(config.defaultValidationFunction),
                 FunctionReference.unwrap(expectedValidations[i])
             );
         }
@@ -93,7 +93,7 @@ contract AccountLoupeTest is AccountTestBase {
 
             assertEq(config.plugin, expectedPluginAddress[i]);
             assertEq(
-                FunctionReference.unwrap(config.validationFunction),
+                FunctionReference.unwrap(config.defaultValidationFunction),
                 FunctionReference.unwrap(expectedValidations[i])
             );
         }

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+
+import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
+import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
+import {FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
+import {SingleOwnerPlugin2} from "../mocks/plugins/SingleOwnerPlugin2.sol";
+import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
+
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
+
+contract MultiValidationTest is AccountTestBase {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
+
+    SingleOwnerPlugin2 public validator2;
+
+    address public owner2;
+    uint256 public owner2Key;
+
+    uint256 public constant CALL_GAS_LIMIT = 50000;
+    uint256 public constant VERIFICATION_GAS_LIMIT = 1200000;
+
+    function setUp() public {
+        validator2 = new SingleOwnerPlugin2();
+
+        (owner2, owner2Key) = makeAddrAndKey("owner2");
+    }
+
+    function test_overlappingValidationInstall() public {
+        bytes32 manifestHash = keccak256(abi.encode(validator2.pluginManifest()));
+        vm.prank(owner1);
+        account1.installPlugin(address(validator2), manifestHash, abi.encode(owner2), new FunctionReference[](0));
+
+        FunctionReference[] memory validations = new FunctionReference[](2);
+        validations[0] = FunctionReferenceLib.pack(
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
+        validations[1] = FunctionReferenceLib.pack(
+            address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
+        FunctionReference[] memory validations2 =
+            account1.getValidationFunctions(IStandardExecutor.execute.selector);
+        assertEq(validations2.length, 2);
+        assertEq(FunctionReference.unwrap(validations2[0]), FunctionReference.unwrap(validations[0]));
+        assertEq(FunctionReference.unwrap(validations2[1]), FunctionReference.unwrap(validations[1]));
+    }
+
+    function test_runtimeValidation_default() public {
+        test_overlappingValidationInstall();
+
+        // Assert that the default runtime validation is the first validation function.
+
+        vm.prank(owner1);
+        account1.execute(address(0), 0, "");
+
+        vm.prank(owner2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
+                address(singleOwnerPlugin),
+                0,
+                abi.encodePacked(ISingleOwnerPlugin.NotAuthorized.selector)
+            )
+        );
+        account1.execute(address(0), 0, "");
+    }
+
+    function test_runtimeValidation_specify() public {
+        test_overlappingValidationInstall();
+
+        // Assert that the runtime validation can be specified.
+
+        vm.prank(owner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
+                address(validator2),
+                0,
+                abi.encodeWithSignature("Error(string)", "NotAuthorized()")
+            )
+        );
+        account1.executeWithValidation(
+            FunctionReferenceLib.pack(
+                address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            ),
+            abi.encodeCall(IStandardExecutor.execute, (address(0), 0, ""))
+        );
+
+        vm.prank(owner2);
+        account1.executeWithValidation(
+            FunctionReferenceLib.pack(
+                address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            ),
+            abi.encodeCall(IStandardExecutor.execute, (address(0), 0, ""))
+        );
+    }
+
+    function test_userOpValidation_default() public {
+        test_overlappingValidationInstall();
+
+        // Assert that the default userOp validation is the first validation function.
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: "",
+            callData: abi.encodeCall(UpgradeableModularAccount.execute, (address(0), 0, "")),
+            accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: "",
+            signature: ""
+        });
+
+        // Generate signature
+        bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(r, s, v);
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        // Sign with owner 2, expect fail
+        userOp.nonce = 1;
+        (v, r, s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(r, s, v);
+
+        userOps[0] = userOp;
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));
+        entryPoint.handleOps(userOps, beneficiary);
+    }
+
+    function test_userOpValidation_specify() public {
+        test_overlappingValidationInstall();
+
+        // Assert that the userOp validation can be specified.
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: "",
+            callData: abi.encodeCall(
+                UpgradeableModularAccount.executeWithValidation,
+                (
+                    FunctionReferenceLib.pack(
+                        address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+                    ),
+                    abi.encodeCall(UpgradeableModularAccount.execute, (address(0), 0, ""))
+                )
+            ),
+            accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: "",
+            signature: ""
+        });
+
+        // Generate signature
+        bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(r, s, v);
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        // Sign with owner 1, expect fail
+
+        userOp.nonce = 1;
+        (v, r, s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(r, s, v);
+
+        userOps[0] = userOp;
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));
+        entryPoint.handleOps(userOps, beneficiary);
+    }
+}


### PR DESCRIPTION
## Motivation

As described in https://github.com/erc6900/resources/issues/4, supporting multiple validation functions at once has been a long-standing goal of ERC-6900.

## Proposed Solution

This PR implements the first suggestion described in the issue above, implementing a new native function called `executeWithValidation(FunctionReference validation, bytes calldata data)`.

_Note that this does not implement the function `executeWithContext`, where additional data can be made available to validation plugins, because the current validation interface does not support out-of-band extra data, beyond what's in the user operation for UO validation and calldata for RT validation._

**Account behavior changes**:
- Validation is now an enumerable set, rather than a single field.
   - Internal installation functions are updated to add and remove from the set.
   - The manifest format stays the same in this PR.
- When the function `executeWithValidation` is put into `userOp.callData`, user op validation will rely on the provided validation function, if it is installed and made available to the actual execution function selector being called within the `data` parameter.
- When the function `executeWithValidation` is called directly, runtime validation will rely on the provided validation function, if it is installed and made available to the actual execution function selector being called within the `data` parameter.
- Then, `executeWithvalidation` forwards the call in `data` to itself with a self-call (not self-delegatecall).
- To correctly implement this functionality, this PR also changes account behavior with self-calls: now, if the call is from self, runtime validation will be bypassed (validation is assumed to have passed in a different context).
   - This is necessary to support multi-validation for native functions _if_ we don't implement an internal switching function and make all functions public. Doing this would involve a large account code change and overhead to implementers, particularly for semi-modular accounts, so I don't prefer it as a solution.
   - Note that this changes the security properties of validation over `execute` and `executeBatch` - no change is made to those functions here, if we wish to pursue this form of multi-validation, we will have to address that eventually.
- The account loupe is updated to add a function that supports retrieving all possible applicable validation functions for a selector.
- This PR does not change how pre-validation hooks are assigned, they remain associated with the execution selector. For reasons outlined below, I believe this needs to change, but this PR does not do that yet.
- Add a test to show switching between multiple installed validation functions: `MultiValidation.t.sol`.

## Additional discussion

### Reasons for choosing a calldata-based encoding of validation selection

- If we wish to support switching validation methods with a user-specified field for runtime validation, the switching logic must exist in calldata, because other user operation fields are not present when directly calling the account.

### Ramifications of choosing calldata to specify validation switching

- While we can support switching validation methods for runtime validation, we likely also want to support calling functions via runtime validation without wrapping the call in the `executeWithValidation` function format.
- The reason calling functions without nesting them into the data field of `executeWithValidation` is useful, is that this is how we make use of contract interfaces that the account supports through execution function. I.e. in tests, we may wrap the account with a different interface like `SingleOwnerPlugin(account1).transferOwnership(...)`, or frontends may use the plugin abi to generate function calls on the account.
- To support those "direct call" flows, we must have a "default validator" to use for validation when the validation-switching function is _not_ used.
   - In other words, runtime validation + execution functions implementing interaces necesitate a "default validation" to exist.
- Note that this is a "default validation" in a different sense than https://github.com/erc6900/resources/issues/37 describes: the issue describes the ability for validation to apply over some number of execution functions, despite not manually being added to each. In this PR, I used "default validation" to refer to which validation to run when one isn't manually specified via `executeWithValidation`.
- In the implementation of this PR, the first validation added for an execution function becomes the default. The behavior gets weird with the OZ enumerbleset if the first added one is removed and others exist. If we wish to pursue this mechanism for validation switching, we will need to expose setting this field to the end user somehow.

### Ramifications of multi-validation in general

- You can't install two instances of the same plugin twice, if they define _any_ execution functions. This happens because, upon trying to install the second instance, they will have two definitions for execution functions, and collisions are not permitted for execution functions.
   - See the test cases in `MultiValidation.t.sol`: we have to define a new version of `SingleOwnerPlugin` with the execution function names changed: `transferOwnership` -> `transferOwnership2`, `owner` -> `owner2`.
   - Does this warrant breaking the invariant previously established where we assert "target of `execute`/`executeBatch` is not a plugin?
   - Should the decision to install execution function handlers be user-controlled, as part of https://github.com/erc6900/resources/issues/9?
- Pre-validation hooks are currently associated to selectors. Question: should they be associated with selectors, validation functions, or validation functions + selectors?
  - If we continue associating them only with a selector, then a single pre-validation hook would apply over multiple validation types. If the pre-validation hook reads from something like `userOp.signature`, then it could break composability.
  - If we attach it to both selector + validation functions, and the intent of the pre-validation hook is to limit the capabilities of a given validation function, then the pre-validation hook can be bypassed whenever the validation function is added to a new function via a dependency.
     - (this is also the most gas-expensive option)
  - This leaves associating pre-validation hooks with validation functions directly as the last remaining option. Generally, I think this makes the most sense - the combination of N pre-validation hooks plus 1 validation function logically makes up 1 "unit", regardless of the action being validated.
     - This does still have some degree of composability risk: if the pre-validation hook is inspecting the contents of calldata, and the validation function it is attached to gets added to an execution function that it is unaware of the calldata encoding for, then it must deny execution, otherwise risk a breach of access control.
         - If we support installing the same validation function multiple times, with different pre-validation hooks and domain of access, this problem can be avoided.
      - This pattern is also difficult to use with the current install flow, if the pre-validation hook defining plugin is intended to be composable. The mechanism used for composability right now is dependencies, but only of a fixed number. To allow associating pre-validation hooks with an arbitrary number of validation functions, possibly including validation functions defined later, would require a different model of install state than what we currently have.
- Does multi-validation necessitate creating specializations of hooks that only apply to specific validation functions? Previously, there was an invariant held that 1 exec selector had 1 validation function, which influenced stateful hook design.

## Conclusion

Doing multi-validation while supporting runtime validation in its current form introduces some added complexities that we had previously not discovered: the requirement to put validation selection into calldata, which itself leads to an additional requirement of having a default validation per selector. We may want to consider changing how we handle runtime validation to make multi-validation support easier.

Additionally, multi-validation introduces association complexities to pre-validation hooks, regardless of the switching mechanism chosen. Pre-validation hooks make the most sense to be associated with validation functions, rather than execution selectors; however, doing so is difficult with the current parameter format for `installPlugin` dependencies, and requires changes there as well.

And finally, the use of execution functions as the exclusive way to do for plugin state management makes it impossible to install two instances of the same validation plugin at the same time. This is a big composability break, and we should consider removing the check in standard execute functions to be non-plugin contracts.