### PR TITLE
Use parentheses to explicitly set the order of execution of operators

### DIFF
--- a/src/account/AccountStorageInitializable.sol
+++ b/src/account/AccountStorageInitializable.sol
@@ -15,8 +15,8 @@ abstract contract AccountStorageInitializable {
         AccountStorage storage _storage = getAccountStorage();
         bool isTopLevelCall = !_storage.initializing;
         if (
-            isTopLevelCall && _storage.initialized < 1
-                || !Address.isContract(address(this)) && _storage.initialized == 1
+            (isTopLevelCall && _storage.initialized < 1)
+                || (!Address.isContract(address(this)) && _storage.initialized == 1)
         ) {
             _storage.initialized = 1;
             if (isTopLevelCall) {


### PR DESCRIPTION
Use parentheses to explicitly set the order of execution of operators. I think that's easier to read.

Other projects do this too, Here is an [example](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d506e3b1a575b39a7248f0fde17203b315ac17dc/contracts/proxy/utils/Initializable.sol#L81)
