### PR TITLE
fix: Add owner view function to manifest validation list

### DIFF
--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -156,7 +156,7 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
             functionId: uint8(FunctionId.VALIDATION_OWNER_OR_SELF),
             dependencyIndex: 0 // Unused.
         });
-        manifest.validationFunctions = new ManifestAssociatedFunction[](7);
+        manifest.validationFunctions = new ManifestAssociatedFunction[](8);
         manifest.validationFunctions[0] = ManifestAssociatedFunction({
             executionSelector: this.transferOwnership.selector,
             associatedFunction: ownerValidationFunction
@@ -189,6 +189,10 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
         });
         manifest.validationFunctions[6] = ManifestAssociatedFunction({
             executionSelector: this.isValidSignature.selector,
+            associatedFunction: alwaysAllowRuntime
+        });
+        manifest.validationFunctions[7] = ManifestAssociatedFunction({
+            executionSelector: this.owner.selector,
             associatedFunction: alwaysAllowRuntime
         });
 

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -419,6 +419,15 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         assertEq(address(account3), address(uint160(uint256(vm.load(address(account1), slot)))));
     }
 
+    function test_transferOwnership() public {
+        assertEq(SingleOwnerPlugin(address(account1)).owner(), owner1);
+
+        vm.prank(owner1);
+        SingleOwnerPlugin(address(account1)).transferOwnership(owner2);
+
+        assertEq(SingleOwnerPlugin(address(account1)).owner(), owner2);
+    }
+
     // Internal Functions
 
     function _printStorageReadsAndWrites(address addr) internal {


### PR DESCRIPTION
## Motivation

The example ownership plugin `SingleOwnerPlugin` declares the `owner` function in the `executionSelectors` list, but does not assign validation to it. This leaves it non-callable from the account's fallback.

## Solution

Add the "always allow runtime" validation function to the `owner` function.

## Note

We didn't detect this earlier because the test `SingleOwnerPlugin.t.sol` testing the plugin directly, rather than the account <> plugin integration. The new `AccountTestBase` would let us spin up a quick new test file for it, but how do we want to handle this for other plugins? Is it different for ownership plugins and non-ownership plugins?