### PR TITLE
feat: add execute user op

### DIFF
--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -152,11 +152,11 @@ interface IPlugin {
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param functionId An identifier that routes the call to different internal implementations, should there be
     /// more than one.
-    /// @param sender The caller address.
+    /// @param senderContext The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
     /// @return Context to pass to a post execution hook, if present. An empty bytes array MAY be returned.
-    function preExecutionHook(uint8 functionId, address sender, uint256 value, bytes calldata data)
+    function preExecutionHook(uint8 functionId, bytes calldata senderContext, uint256 value, bytes calldata data)
         external
         returns (bytes memory);
 

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -126,7 +126,7 @@ interface IPlugin {
     /// @return Packed validation data for validAfter (6 bytes), validUntil (6 bytes), and authorizer (20 bytes).
     function userOpValidationFunction(uint8 functionId, PackedUserOperation calldata userOp, bytes32 userOpHash)
         external
-        returns (uint256);
+        returns (bytes memory, uint256);
 
     /// @notice Run the pre runtime validation hook specified by the `functionId`.
     /// @dev To indicate the entire call should revert, the function MUST revert.

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -56,7 +56,7 @@ abstract contract BasePlugin is ERC165, IPlugin {
     function userOpValidationFunction(uint8 functionId, PackedUserOperation calldata userOp, bytes32 userOpHash)
         external
         virtual
-        returns (uint256)
+        returns (bytes memory, uint256)
     {
         (functionId, userOp, userOpHash);
         revert NotImplemented();

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -96,16 +96,16 @@ abstract contract BasePlugin is ERC165, IPlugin {
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param functionId An identifier that routes the call to different internal implementations, should there be
     /// more than one.
-    /// @param sender The caller address.
+    /// @param senderContext Senders context. It'll be an address except for some UOs
     /// @param value The call value.
     /// @param data The calldata sent.
     /// @return Context to pass to a post execution hook, if present. An empty bytes array MAY be returned.
-    function preExecutionHook(uint8 functionId, address sender, uint256 value, bytes calldata data)
+    function preExecutionHook(uint8 functionId, bytes calldata senderContext, uint256 value, bytes calldata data)
         external
         virtual
         returns (bytes memory)
     {
-        (functionId, sender, value, data);
+        (functionId, senderContext, value, data);
         revert NotImplemented();
     }
 

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -97,15 +97,15 @@ contract SingleOwnerPlugin is BasePlugin, ISingleOwnerPlugin, IERC1271 {
         external
         view
         override
-        returns (uint256)
+        returns (bytes memory, uint256)
     {
         if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
             // Validate the user op signature against the owner.
             (address signer,,) = (userOpHash.toEthSignedMessageHash()).tryRecover(userOp.signature);
             if (signer == address(0) || signer != _owners[msg.sender]) {
-                return _SIG_VALIDATION_FAILED;
+                return ("", _SIG_VALIDATION_FAILED);
             }
-            return _SIG_VALIDATION_PASSED;
+            return (abi.encode(signer), _SIG_VALIDATION_PASSED);
         }
         revert NotImplemented();
     }

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -75,7 +75,7 @@ contract AccountExecHooksTest is AccountTestBase {
             abi.encodeWithSelector(
                 IPlugin.preExecutionHook.selector,
                 _PRE_HOOK_FUNCTION_ID_1,
-                address(this), // caller
+                abi.encode(address(this)), // caller context
                 0, // msg.value in call to account
                 abi.encodeWithSelector(_EXEC_SELECTOR)
             ),
@@ -119,7 +119,7 @@ contract AccountExecHooksTest is AccountTestBase {
             abi.encodeWithSelector(
                 IPlugin.preExecutionHook.selector,
                 _PRE_HOOK_FUNCTION_ID_1,
-                address(this), // caller
+                abi.encode(address(this)), // caller context
                 0, // msg.value in call to account
                 abi.encodeWithSelector(_EXEC_SELECTOR)
             ),

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -61,10 +61,10 @@ contract ComprehensivePlugin is BasePlugin {
         external
         pure
         override
-        returns (uint256)
+        returns (bytes memory, uint256)
     {
         if (functionId == uint8(FunctionId.VALIDATION)) {
-            return 0;
+            return ("", 0);
         }
         revert NotImplemented();
     }

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -89,7 +89,7 @@ contract ComprehensivePlugin is BasePlugin {
         revert NotImplemented();
     }
 
-    function preExecutionHook(uint8 functionId, address, uint256, bytes calldata)
+    function preExecutionHook(uint8 functionId, bytes calldata, uint256, bytes calldata)
         external
         pure
         override

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -48,10 +48,10 @@ abstract contract MockBaseUserOpValidationPlugin is BaseTestPlugin {
         external
         view
         override
-        returns (uint256)
+        returns (bytes memory, uint256)
     {
         if (functionId == uint8(FunctionId.USER_OP_VALIDATION)) {
-            return _userOpValidationFunctionData;
+            return ("", _userOpValidationFunctionData);
         }
         revert NotImplemented();
     }

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -137,7 +137,7 @@ contract SingleOwnerPluginTest is OptimizedTest {
         userOp.signature = abi.encodePacked(r, s, v);
 
         // sig check should fail
-        uint256 success = plugin.userOpValidationFunction(
+        (, uint256 success) = plugin.userOpValidationFunction(
             uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), userOp, userOpHash
         );
         assertEq(success, 1);
@@ -147,7 +147,7 @@ contract SingleOwnerPluginTest is OptimizedTest {
         assertEq(signer, plugin.owner());
 
         // sig check should pass
-        success = plugin.userOpValidationFunction(
+        (, success) = plugin.userOpValidationFunction(
             uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), userOp, userOpHash
         );
         assertEq(success, 0);


### PR DESCRIPTION
This is an implementation of adding `executeUserOp` to ERC6900. This means all ERC6900 accounts would pass context from validation to execution via calldata. Accounts can still opt to do TSTORE or SSTORE

Changes:
1. `preExecutionHook` now passes `bytes memory senderContext` instead of `address sender`. This is to account for an r1 curves that have 64 byte public keys
2. `userOpValidationFunction` now returns an additional field, `bytes memory senderContext`. The additional context added in user ops need to validated, and this has to be done in the account or the plugin. This implementation does it in the account. Doing it this way allows flexibility for ERC6900 accounts to pass context from validation to execution with any user op field (userop.sig, userop.nonce etc), and since the plugin is already doing signature format parsing (which can vary from plugin to plugin), we should continue relying on the plugin for this. Note: we could opt to compress `bytes memory senderContext` into `bytes32` by hashing it, at a spec level
3. Plugins signal that they want UO context by setting  128 < `functionId` < 256. The better way to do it is probably to add an additional byte to `FunctionReference` for execution functions to denote if the plugin needs UO context or not. This implementation was chosen to speed up the PR since the better way of doing it would require changes in 20+ files