### PR TITLE
feat: [v0.8-develop, experimental]: sig validation in interface [2/N]

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -63,7 +63,13 @@ struct AccountStorage {
     mapping(IPlugin => mapping(address => PermittedExternalCallData)) permittedExternalCalls;
     // For ERC165 introspection
     mapping(bytes4 => uint256) supportedIfaces;
+    // Installed plugins capable of signature validation.
+    EnumerableSet.Bytes32Set signatureValidations;
 }
+
+// TODO: Change how pre-validation hooks work to allow association with validation, rather than selector.
+// Pre signature validation hooks
+// mapping(FunctionReference => EnumerableSet.Bytes32Set) preSignatureValidationHooks;
 
 function getAccountStorage() pure returns (AccountStorage storage _storage) {
     assembly ("memory-safe") {

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -262,6 +262,13 @@ abstract contract PluginManagerInternals is IPluginManager {
             );
         }
 
+        length = manifest.signatureValidationFunctions.length;
+        for (uint256 i = 0; i < length; ++i) {
+            FunctionReference signatureValidationFunction =
+                FunctionReferenceLib.pack(plugin, manifest.signatureValidationFunctions[i]);
+            _storage.signatureValidations.add(toSetValue(signatureValidationFunction));
+        }
+
         // Hooks are not allowed to be provided as dependencies, so we use an empty array for resolving them.
         FunctionReference[] memory emptyDependencies;
 
@@ -357,6 +364,13 @@ abstract contract PluginManagerInternals is IPluginManager {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
+        }
+
+        length = manifest.signatureValidationFunctions.length;
+        for (uint256 i = 0; i < length; ++i) {
+            FunctionReference signatureValidationFunction =
+                FunctionReferenceLib.pack(plugin, manifest.signatureValidationFunctions[i]);
+            _storage.signatureValidations.remove(toSetValue(signatureValidationFunction));
         }
 
         length = manifest.validationFunctions.length;

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -94,6 +94,7 @@ struct PluginManifest {
     ManifestAssociatedFunction[] validationFunctions;
     ManifestAssociatedFunction[] preValidationHooks;
     ManifestExecutionHook[] executionHooks;
+    uint8[] signatureValidationFunctions;
 }
 
 interface IPlugin is IERC165 {

--- a/src/interfaces/IValidation.sol
+++ b/src/interfaces/IValidation.sol
@@ -24,4 +24,17 @@ interface IValidation is IPlugin {
     /// @param value The call value.
     /// @param data The calldata sent.
     function validateRuntime(uint8 functionId, address sender, uint256 value, bytes calldata data) external;
+
+    /// @notice Validates a signature using ERC-1271.
+    /// @dev To indicate the entire call should revert, the function MUST revert.
+    /// @param functionId An identifier that routes the call to different internal implementations, should there be
+    /// more than one.
+    /// @param sender the address that sent the ERC-1271 request to the smart account
+    /// @param hash the hash of the ERC-1271 request
+    /// @param signature the signature of the ERC-1271 request
+    /// @return the ERC-1271 `MAGIC_VALUE` if the signature is valid, or 0xFFFFFFFF if invalid.
+    function validateSignature(uint8 functionId, address sender, bytes32 hash, bytes calldata signature)
+        external
+        view
+        returns (bytes4);
 }

--- a/src/interfaces/IValidationHook.sol
+++ b/src/interfaces/IValidationHook.sol
@@ -26,4 +26,19 @@ interface IValidationHook is IPlugin {
     /// @param data The calldata sent.
     function preRuntimeValidationHook(uint8 functionId, address sender, uint256 value, bytes calldata data)
         external;
+
+    // TODO: support this hook type within the account & in the manifest
+
+    /// @notice Run the pre signature validation hook specified by the `functionId`.
+    /// @dev To indicate the call should revert, the function MUST revert.
+    /// @param functionId An identifier that routes the call to different internal implementations, should there be
+    /// more than one.
+    /// @param sender The caller address.
+    /// @param hash The hash of the message being signed.
+    /// @param signature The signature of the message.
+    // function preSignatureValidationHook(uint8 functionId, address sender, bytes32 hash, bytes calldata
+    // signature)
+    //     external
+    //     view
+    //     returns (bytes4);
 }

--- a/src/plugins/owner/ISingleOwnerPlugin.sol
+++ b/src/plugins/owner/ISingleOwnerPlugin.sol
@@ -5,7 +5,8 @@ import {IValidation} from "../../interfaces/IValidation.sol";
 
 interface ISingleOwnerPlugin is IValidation {
     enum FunctionId {
-        VALIDATION_OWNER_OR_SELF
+        VALIDATION_OWNER_OR_SELF,
+        SIG_VALIDATION
     }
 
     /// @notice This event is emitted when ownership of the account changes.

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -26,7 +26,8 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
         VALIDATION,
         BOTH_EXECUTION_HOOKS,
         PRE_EXECUTION_HOOK,
-        POST_EXECUTION_HOOK
+        POST_EXECUTION_HOOK,
+        SIG_VALIDATION
     }
 
     string public constant NAME = "Comprehensive Plugin";
@@ -85,6 +86,17 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
     function validateRuntime(uint8 functionId, address, uint256, bytes calldata) external pure override {
         if (functionId == uint8(FunctionId.VALIDATION)) {
             return;
+        }
+        revert NotImplemented();
+    }
+
+    function validateSignature(uint8 functionId, address, bytes32, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        if (functionId == uint8(FunctionId.SIG_VALIDATION)) {
+            return 0xffffffff;
         }
         revert NotImplemented();
     }

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -59,6 +59,10 @@ abstract contract MockBaseUserOpValidationPlugin is IValidation, IValidationHook
         revert NotImplemented();
     }
 
+    function validateSignature(uint8, address, bytes32, bytes calldata) external pure override returns (bytes4) {
+        revert NotImplemented();
+    }
+
     // Empty stubs
     function pluginMetadata() external pure override returns (PluginMetadata memory) {}
 

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -157,20 +157,41 @@ contract SingleOwnerPluginTest is OptimizedTest {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
         // sig check should fail
-        assertEq(plugin.isValidSignature(digest, abi.encodePacked(r, s, v)), bytes4(0xFFFFFFFF));
+        assertEq(
+            plugin.validateSignature(
+                uint8(ISingleOwnerPlugin.FunctionId.SIG_VALIDATION),
+                address(this),
+                digest,
+                abi.encodePacked(r, s, v)
+            ),
+            bytes4(0xFFFFFFFF)
+        );
 
         // transfer ownership to signer
         plugin.transferOwnership(signer);
         assertEq(signer, plugin.owner());
 
         // sig check should pass
-        assertEq(plugin.isValidSignature(digest, abi.encodePacked(r, s, v)), _1271_MAGIC_VALUE);
+        assertEq(
+            plugin.validateSignature(
+                uint8(ISingleOwnerPlugin.FunctionId.SIG_VALIDATION),
+                address(this),
+                digest,
+                abi.encodePacked(r, s, v)
+            ),
+            _1271_MAGIC_VALUE
+        );
     }
 
     function testFuzz_isValidSignatureForContractOwner(bytes32 digest) public {
         vm.startPrank(a);
         plugin.transferOwnership(address(contractOwner));
         bytes memory signature = contractOwner.sign(digest);
-        assertEq(plugin.isValidSignature(digest, signature), _1271_MAGIC_VALUE);
+        assertEq(
+            plugin.validateSignature(
+                uint8(ISingleOwnerPlugin.FunctionId.SIG_VALIDATION), address(this), digest, signature
+            ),
+            _1271_MAGIC_VALUE
+        );
     }
 }


### PR DESCRIPTION
## Motivation

In preparation of multi-validation support, we need the ability to avoid installing execution functions defined by a validation plugin, otherwise there would be a clash when installing multiple instances of the same validation plugin (see #52).

Currently, "ownership" plugins define `isValidSignature` as an execution function. However, logically it makes more sense to put this out in the `IValidation` interface, as identified by this standard improvement proposal: https://github.com/erc6900/resources/issues/20

## Solution

Add a `validateSignature` method to `IValidation` that performs signature validation.

Add a definition of `isValidSignature` to `UpgradeableModularAccount` that switches between installed signature validation plugins.

### Temp changes

To get this change working at this point in the change stack, this PR creates a new field within `AccountStorage` called `signatureValidations`, and a new field in the manifest declaring these functions. Eventually, it would make sense to merge this with multi-validation support, and have some flag in the install flow and/or plugin manifest to indicate signature validation capabilities.

This PR also adds commented-out stubs for adding hooks to the signature validation flow. Because the entire pre-validation hook installation logic needs a revamp (see #52, #62), it isn't introduced here, and is instead punted for a later PR.

Also, it is not yet immediately obvious to me whether or not a functionId is strictly necessary for this workflow. It appears to be necessary to support composable validation ([erc6900/validator-experiments](https://github.com/erc6900/validator-experiments)) and for any sort of tiered auth (https://github.com/erc6900/reference-implementation/pull/41#issuecomment-1997756363), but we may be able to remove this field in the future.

