### PR TITLE
feat: [v0.8-develop, experimental] multi validation in user op signature [5/N]

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -20,7 +20,7 @@ abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @inheritdoc IAccountLoupe
-    function getExecutionFunctionHandler(bytes4 selector) external view returns (address plugin) {
+    function getExecutionFunctionHandler(bytes4 selector) external view override returns (address plugin) {
         AccountStorage storage _storage = getAccountStorage();
 
         if (
@@ -36,12 +36,17 @@ abstract contract AccountLoupe is IAccountLoupe {
     }
 
     /// @inheritdoc IAccountLoupe
-    function getValidationFunctions(bytes4 selector) external view returns (FunctionReference[] memory) {
+    function getValidations(bytes4 selector) external view override returns (FunctionReference[] memory) {
         return toFunctionReferenceArray(getAccountStorage().selectorData[selector].validations);
     }
 
     /// @inheritdoc IAccountLoupe
-    function getExecutionHooks(bytes4 selector) external view returns (ExecutionHook[] memory execHooks) {
+    function getExecutionHooks(bytes4 selector)
+        external
+        view
+        override
+        returns (ExecutionHook[] memory execHooks)
+    {
         SelectorData storage selectorData = getAccountStorage().selectorData[selector];
         uint256 executionHooksLength = selectorData.executionHooks.length();
 
@@ -58,6 +63,7 @@ abstract contract AccountLoupe is IAccountLoupe {
     function getPreValidationHooks(bytes4 selector)
         external
         view
+        override
         returns (FunctionReference[] memory preValidationHooks)
     {
         preValidationHooks =
@@ -65,7 +71,7 @@ abstract contract AccountLoupe is IAccountLoupe {
     }
 
     /// @inheritdoc IAccountLoupe
-    function getInstalledPlugins() external view returns (address[] memory pluginAddresses) {
+    function getInstalledPlugins() external view override returns (address[] memory pluginAddresses) {
         pluginAddresses = getAccountStorage().plugins.values();
     }
 }

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -7,13 +7,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {IAccountLoupe, ExecutionHook} from "../interfaces/IAccountLoupe.sol";
 import {FunctionReference, IPluginManager} from "../interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
-import {
-    AccountStorage,
-    getAccountStorage,
-    SelectorData,
-    toFunctionReferenceArray,
-    toExecutionHook
-} from "./AccountStorage.sol";
+import {getAccountStorage, SelectorData, toFunctionReferenceArray, toExecutionHook} from "./AccountStorage.sol";
 
 abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -21,8 +15,6 @@ abstract contract AccountLoupe is IAccountLoupe {
 
     /// @inheritdoc IAccountLoupe
     function getExecutionFunctionHandler(bytes4 selector) external view override returns (address plugin) {
-        AccountStorage storage _storage = getAccountStorage();
-
         if (
             selector == IStandardExecutor.execute.selector || selector == IStandardExecutor.executeBatch.selector
                 || selector == UUPSUpgradeable.upgradeToAndCall.selector
@@ -32,7 +24,7 @@ abstract contract AccountLoupe is IAccountLoupe {
             return address(this);
         }
 
-        return _storage.selectorData[selector].plugin;
+        return getAccountStorage().selectorData[selector].plugin;
     }
 
     /// @inheritdoc IAccountLoupe

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -20,11 +20,7 @@ abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @inheritdoc IAccountLoupe
-    function getExecutionFunctionConfig(bytes4 selector)
-        external
-        view
-        returns (ExecutionFunctionConfig memory config)
-    {
+    function getExecutionFunctionHandler(bytes4 selector) external view returns (address plugin) {
         AccountStorage storage _storage = getAccountStorage();
 
         if (
@@ -33,12 +29,15 @@ abstract contract AccountLoupe is IAccountLoupe {
                 || selector == IPluginManager.installPlugin.selector
                 || selector == IPluginManager.uninstallPlugin.selector
         ) {
-            config.plugin = address(this);
-        } else {
-            config.plugin = _storage.selectorData[selector].plugin;
+            return address(this);
         }
 
-        config.validationFunction = _storage.selectorData[selector].validation;
+        return _storage.selectorData[selector].plugin;
+    }
+
+    /// @inheritdoc IAccountLoupe
+    function getValidationFunctions(bytes4 selector) external view returns (FunctionReference[] memory) {
+        return toFunctionReferenceArray(getAccountStorage().selectorData[selector].validations);
     }
 
     /// @inheritdoc IAccountLoupe

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -45,7 +45,7 @@ struct SelectorData {
     // but it packs alongside `plugin` while still leaving some other space in the slot for future packing.
     uint48 denyExecutionCount;
     // User operation validation and runtime validation share a function reference.
-    FunctionReference validation;
+    EnumerableSet.Bytes32Set validations;
     // The pre validation hooks for this function selector.
     EnumerableSet.Bytes32Set preValidationHooks;
     // The execution hooks for this function selector.

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -86,8 +86,9 @@ abstract contract PluginManagerInternals is IPluginManager {
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
 
-        // Fail on duplicate definitions - otherwise dependencies could shadow non-depdency
-        // validation functions, leading to partial uninstalls.
+        // Fail on duplicate validation functions. Otherwise, dependency validation functions could shadow
+        // non-depdency validation functions. Then, if a either plugin is uninstall, it would cause a partial
+        // uninstall of the other.
         if (!_selectorData.validations.add(toSetValue(validationFunction))) {
             revert ValidationFunctionAlreadySet(selector, validationFunction);
         }

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -268,9 +268,10 @@ contract UpgradeableModularAccount is
         payable
         returns (bytes memory)
     {
-        bytes4 execSelector = bytes4(data[0:4]);
+        bytes4 execSelector = bytes4(data[:4]);
 
-        FunctionReference runtimeValidationFunction = FunctionReference.wrap(bytes21(authorization[0:21]));
+        // Revert if the provided `authorization` less than 21 bytes long, rather than right-padding.
+        FunctionReference runtimeValidationFunction = FunctionReference.wrap(bytes21(authorization[:21]));
 
         AccountStorage storage _storage = getAccountStorage();
 
@@ -395,6 +396,7 @@ contract UpgradeableModularAccount is
             revert AlwaysDenyRule();
         }
 
+        // Revert if the provided `authorization` less than 21 bytes long, rather than right-padding.
         FunctionReference userOpValidationFunction = FunctionReference.wrap(bytes21(userOp.signature[:21]));
 
         if (!getAccountStorage().selectorData[selector].validations.contains(toSetValue(userOpValidationFunction)))
@@ -463,7 +465,7 @@ contract UpgradeableModularAccount is
     ) internal {
         // run all preRuntimeValidation hooks
         EnumerableSet.Bytes32Set storage preRuntimeValidationHooks =
-            getAccountStorage().selectorData[bytes4(callData[0:4])].preValidationHooks;
+            getAccountStorage().selectorData[bytes4(callData[:4])].preValidationHooks;
 
         uint256 preRuntimeValidationHooksLength = preRuntimeValidationHooks.length();
         for (uint256 i = 0; i < preRuntimeValidationHooksLength; ++i) {

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -12,17 +12,16 @@ struct ExecutionHook {
 }
 
 interface IAccountLoupe {
-    /// @notice Config for an execution function, given a selector.
-    struct ExecutionFunctionConfig {
-        address plugin;
-        FunctionReference validationFunction;
-    }
-
-    /// @notice Get the validation functions and plugin address for a selector.
+    /// @notice Get the plugin address for a selector.
     /// @dev If the selector is a native function, the plugin address will be the address of the account.
     /// @param selector The selector to get the configuration for.
-    /// @return The configuration for this selector.
-    function getExecutionFunctionConfig(bytes4 selector) external view returns (ExecutionFunctionConfig memory);
+    /// @return plugin The plugin address for this selector.
+    function getExecutionFunctionHandler(bytes4 selector) external view returns (address plugin);
+
+    /// @notice Get the validation functions for a selector.
+    /// @param selector The selector to get the validation functions for.
+    /// @return The validation functions for this selector.
+    function getValidationFunctions(bytes4 selector) external view returns (FunctionReference[] memory);
 
     /// @notice Get the pre and post execution hooks for a selector.
     /// @param selector The selector to get the hooks for.

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -21,7 +21,7 @@ interface IAccountLoupe {
     /// @notice Get the validation functions for a selector.
     /// @param selector The selector to get the validation functions for.
     /// @return The validation functions for this selector.
-    function getValidationFunctions(bytes4 selector) external view returns (FunctionReference[] memory);
+    function getValidations(bytes4 selector) external view returns (FunctionReference[] memory);
 
     /// @notice Get the pre and post execution hooks for a selector.
     /// @param selector The selector to get the hooks for.

--- a/src/interfaces/IPluginExecutor.sol
+++ b/src/interfaces/IPluginExecutor.sol
@@ -20,4 +20,14 @@ interface IPluginExecutor {
         external
         payable
         returns (bytes memory);
+
+    /// @notice Execute a call using a specified runtime validation, as given in the first 21 bytes of
+    /// `authorization`.
+    /// @param data The calldata to send to the account.
+    /// @param authorization The authorization data to use for the call. The first 21 bytes specifies which runtime
+    /// validation to use, and the rest is sent as a parameter to runtime validation.
+    function executeWithAuthorization(bytes calldata data, bytes calldata authorization)
+        external
+        payable
+        returns (bytes memory);
 }

--- a/src/interfaces/IValidation.sol
+++ b/src/interfaces/IValidation.sol
@@ -23,7 +23,13 @@ interface IValidation is IPlugin {
     /// @param sender The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
-    function validateRuntime(uint8 functionId, address sender, uint256 value, bytes calldata data) external;
+    function validateRuntime(
+        uint8 functionId,
+        address sender,
+        uint256 value,
+        bytes calldata data,
+        bytes calldata authorization
+    ) external;
 
     /// @notice Validates a signature using ERC-1271.
     /// @dev To indicate the entire call should revert, the function MUST revert.

--- a/src/plugins/owner/ISingleOwnerPlugin.sol
+++ b/src/plugins/owner/ISingleOwnerPlugin.sol
@@ -5,7 +5,7 @@ import {IValidation} from "../../interfaces/IValidation.sol";
 
 interface ISingleOwnerPlugin is IValidation {
     enum FunctionId {
-        VALIDATION_OWNER_OR_SELF,
+        VALIDATION_OWNER,
         SIG_VALIDATION
     }
 

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -84,7 +84,7 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
         view
         override
     {
-        if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
+        if (functionId == uint8(FunctionId.VALIDATION_OWNER)) {
             // Validate that the sender is the owner of the account or self.
             if (sender != _owners[msg.sender] && sender != msg.sender) {
                 revert NotAuthorized();
@@ -101,7 +101,7 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
         override
         returns (uint256)
     {
-        if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
+        if (functionId == uint8(FunctionId.VALIDATION_OWNER)) {
             // Validate the user op signature against the owner.
             (address signer,,) = (userOpHash.toEthSignedMessageHash()).tryRecover(userOp.signature);
             if (signer == address(0) || signer != _owners[msg.sender]) {
@@ -158,7 +158,7 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
 
         ManifestFunction memory ownerValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.SELF,
-            functionId: uint8(FunctionId.VALIDATION_OWNER_OR_SELF),
+            functionId: uint8(FunctionId.VALIDATION_OWNER),
             dependencyIndex: 0 // Unused.
         });
         manifest.validationFunctions = new ManifestAssociatedFunction[](5);

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -79,7 +79,11 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
     }
 
     /// @inheritdoc IValidation
-    function validateRuntime(uint8 functionId, address sender, uint256, bytes calldata) external view override {
+    function validateRuntime(uint8 functionId, address sender, uint256, bytes calldata, bytes calldata)
+        external
+        view
+        override
+    {
         if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
             // Validate that the sender is the owner of the account or self.
             if (sender != _owners[msg.sender] && sender != msg.sender) {

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -228,6 +228,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit PluginInstalled(address(mockPlugin1), manifestHash1, new FunctionReference[](0));
 
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(mockPlugin1),
             manifestHash: manifestHash1,
@@ -251,6 +252,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit PluginInstalled(address(mockPlugin1), manifestHash1, new FunctionReference[](0));
 
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(mockPlugin1),
             manifestHash: manifestHash1,
@@ -274,6 +276,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit PluginInstalled(address(mockPlugin2), manifestHash2, new FunctionReference[](0));
 
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(mockPlugin2),
             manifestHash: manifestHash2,
@@ -288,6 +291,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit PluginUninstalled(address(plugin), true);
 
+        vm.prank(address(entryPoint));
         account1.uninstallPlugin(address(plugin), bytes(""), bytes(""));
     }
 }

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -29,7 +29,7 @@ contract AccountLoupeTest is AccountTestBase {
         account1.installPlugin(address(comprehensivePlugin), manifestHash, "", new FunctionReference[](0));
 
         ownerValidation = FunctionReferenceLib.pack(
-            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
         );
     }
 

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -25,6 +25,7 @@ contract AccountLoupeTest is AccountTestBase {
         comprehensivePlugin = new ComprehensivePlugin();
 
         bytes32 manifestHash = keccak256(abi.encode(comprehensivePlugin.pluginManifest()));
+        vm.prank(address(entryPoint));
         account1.installPlugin(address(comprehensivePlugin), manifestHash, "", new FunctionReference[](0));
 
         ownerValidation = FunctionReferenceLib.pack(

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -77,7 +77,7 @@ contract AccountLoupeTest is AccountTestBase {
     }
 
     function test_pluginLoupe_getValidationFunctions() public {
-        FunctionReference[] memory validations = account1.getValidationFunctions(comprehensivePlugin.foo.selector);
+        FunctionReference[] memory validations = account1.getValidations(comprehensivePlugin.foo.selector);
 
         assertEq(validations.length, 1);
         assertEq(
@@ -89,7 +89,7 @@ contract AccountLoupeTest is AccountTestBase {
             )
         );
 
-        validations = account1.getValidationFunctions(account1.execute.selector);
+        validations = account1.getValidations(account1.execute.selector);
 
         assertEq(validations.length, 1);
         assertEq(FunctionReference.unwrap(validations[0]), FunctionReference.unwrap(ownerValidation));

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -59,7 +59,7 @@ contract AccountReturnDataTest is AccountTestBase {
                 account1.execute,
                 (address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()))
             ),
-            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
         );
 
         bytes32 result = abi.decode(abi.decode(returnData, (bytes)), (bytes32));
@@ -83,7 +83,7 @@ contract AccountReturnDataTest is AccountTestBase {
 
         bytes memory retData = account1.executeWithAuthorization(
             abi.encodeCall(account1.executeBatch, (calls)),
-            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
         );
 
         bytes[] memory returnDatas = abi.decode(retData, (bytes[]));

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
+import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
 
 import {
     RegularResultContract,
@@ -26,6 +27,7 @@ contract AccountReturnDataTest is AccountTestBase {
 
         // Add the result creator plugin to the account
         bytes32 resultCreatorManifestHash = keccak256(abi.encode(resultCreatorPlugin.pluginManifest()));
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(resultCreatorPlugin),
             manifestHash: resultCreatorManifestHash,
@@ -34,6 +36,7 @@ contract AccountReturnDataTest is AccountTestBase {
         });
         // Add the result consumer plugin to the account
         bytes32 resultConsumerManifestHash = keccak256(abi.encode(resultConsumerPlugin.pluginManifest()));
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(resultConsumerPlugin),
             manifestHash: resultConsumerManifestHash,
@@ -51,10 +54,15 @@ contract AccountReturnDataTest is AccountTestBase {
 
     // Tests the ability to read the results of contracts called via IStandardExecutor.execute
     function test_returnData_singular_execute() public {
-        bytes memory returnData =
-            account1.execute(address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()));
+        bytes memory returnData = account1.executeWithAuthorization(
+            abi.encodeCall(
+                account1.execute,
+                (address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()))
+            ),
+            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
 
-        bytes32 result = abi.decode(returnData, (bytes32));
+        bytes32 result = abi.decode(abi.decode(returnData, (bytes)), (bytes32));
 
         assertEq(result, keccak256("bar"));
     }
@@ -73,7 +81,12 @@ contract AccountReturnDataTest is AccountTestBase {
             data: abi.encodeCall(RegularResultContract.bar, ())
         });
 
-        bytes[] memory returnDatas = account1.executeBatch(calls);
+        bytes memory retData = account1.executeWithAuthorization(
+            abi.encodeCall(account1.executeBatch, (calls)),
+            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
+
+        bytes[] memory returnDatas = abi.decode(retData, (bytes[]));
 
         bytes32 result1 = abi.decode(returnDatas[0], (bytes32));
         bytes32 result2 = abi.decode(returnDatas[1], (bytes32));

--- a/test/account/ExecuteFromPluginPermissions.t.sol
+++ b/test/account/ExecuteFromPluginPermissions.t.sol
@@ -35,6 +35,7 @@ contract ExecuteFromPluginPermissionsTest is AccountTestBase {
 
         // Add the result creator plugin to the account
         bytes32 resultCreatorManifestHash = keccak256(abi.encode(resultCreatorPlugin.pluginManifest()));
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(resultCreatorPlugin),
             manifestHash: resultCreatorManifestHash,
@@ -43,6 +44,7 @@ contract ExecuteFromPluginPermissionsTest is AccountTestBase {
         });
         // Add the EFP caller plugin to the account
         bytes32 efpCallerManifestHash = keccak256(abi.encode(efpCallerPlugin.pluginManifest()));
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(efpCallerPlugin),
             manifestHash: efpCallerManifestHash,
@@ -53,6 +55,7 @@ contract ExecuteFromPluginPermissionsTest is AccountTestBase {
         // Add the EFP caller plugin with any external permissions to the account
         bytes32 efpCallerAnyExternalManifestHash =
             keccak256(abi.encode(efpCallerPluginAnyExternal.pluginManifest()));
+        vm.prank(address(entryPoint));
         account1.installPlugin({
             plugin: address(efpCallerPluginAnyExternal),
             manifestHash: efpCallerAnyExternalManifestHash,

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -18,6 +18,7 @@ contract ManifestValidityTest is AccountTestBase {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
+        vm.prank(address(entryPoint));
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
         account1.installPlugin({
             plugin: address(plugin),

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -45,8 +45,7 @@ contract MultiValidationTest is AccountTestBase {
         );
         validations[1] =
             FunctionReferenceLib.pack(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER));
-        FunctionReference[] memory validations2 =
-            account1.getValidationFunctions(IStandardExecutor.execute.selector);
+        FunctionReference[] memory validations2 = account1.getValidations(IStandardExecutor.execute.selector);
         assertEq(validations2.length, 2);
         assertEq(FunctionReference.unwrap(validations2[0]), FunctionReference.unwrap(validations[0]));
         assertEq(FunctionReference.unwrap(validations2[1]), FunctionReference.unwrap(validations[1]));

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -41,11 +41,10 @@ contract MultiValidationTest is AccountTestBase {
 
         FunctionReference[] memory validations = new FunctionReference[](2);
         validations[0] = FunctionReferenceLib.pack(
-            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
         );
-        validations[1] = FunctionReferenceLib.pack(
-            address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
-        );
+        validations[1] =
+            FunctionReferenceLib.pack(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER));
         FunctionReference[] memory validations2 =
             account1.getValidationFunctions(IStandardExecutor.execute.selector);
         assertEq(validations2.length, 2);
@@ -69,17 +68,13 @@ contract MultiValidationTest is AccountTestBase {
         );
         account1.executeWithAuthorization(
             abi.encodeCall(IStandardExecutor.execute, (address(0), 0, "")),
-            abi.encodePacked(
-                address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
-            )
+            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER))
         );
 
         vm.prank(owner2);
         account1.executeWithAuthorization(
             abi.encodeCall(IStandardExecutor.execute, (address(0), 0, "")),
-            abi.encodePacked(
-                address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
-            )
+            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER))
         );
     }
 
@@ -103,7 +98,8 @@ contract MultiValidationTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), r, s, v);
+        userOp.signature =
+            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -114,7 +110,8 @@ contract MultiValidationTest is AccountTestBase {
 
         userOp.nonce = 1;
         (v, r, s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), r, s, v);
+        userOp.signature =
+            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), r, s, v);
 
         userOps[0] = userOp;
         vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+
+import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
+import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
+import {FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
+import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
+import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
+
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
+
+contract MultiValidationTest is AccountTestBase {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
+
+    SingleOwnerPlugin public validator2;
+
+    address public owner2;
+    uint256 public owner2Key;
+
+    uint256 public constant CALL_GAS_LIMIT = 50000;
+    uint256 public constant VERIFICATION_GAS_LIMIT = 1200000;
+
+    function setUp() public {
+        validator2 = new SingleOwnerPlugin();
+
+        (owner2, owner2Key) = makeAddrAndKey("owner2");
+    }
+
+    function test_overlappingValidationInstall() public {
+        bytes32 manifestHash = keccak256(abi.encode(validator2.pluginManifest()));
+        vm.prank(address(entryPoint));
+        account1.installPlugin(address(validator2), manifestHash, abi.encode(owner2), new FunctionReference[](0));
+
+        FunctionReference[] memory validations = new FunctionReference[](2);
+        validations[0] = FunctionReferenceLib.pack(
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
+        validations[1] = FunctionReferenceLib.pack(
+            address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
+        FunctionReference[] memory validations2 =
+            account1.getValidationFunctions(IStandardExecutor.execute.selector);
+        assertEq(validations2.length, 2);
+        assertEq(FunctionReference.unwrap(validations2[0]), FunctionReference.unwrap(validations[0]));
+        assertEq(FunctionReference.unwrap(validations2[1]), FunctionReference.unwrap(validations[1]));
+    }
+
+    function test_runtimeValidation_specify() public {
+        test_overlappingValidationInstall();
+
+        // Assert that the runtime validation can be specified.
+
+        vm.prank(owner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
+                address(validator2),
+                0,
+                abi.encodeWithSignature("NotAuthorized()")
+            )
+        );
+        account1.executeWithAuthorization(
+            abi.encodeCall(IStandardExecutor.execute, (address(0), 0, "")),
+            abi.encodePacked(
+                address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            )
+        );
+
+        vm.prank(owner2);
+        account1.executeWithAuthorization(
+            abi.encodeCall(IStandardExecutor.execute, (address(0), 0, "")),
+            abi.encodePacked(
+                address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            )
+        );
+    }
+
+    function test_userOpValidation_specify() public {
+        test_overlappingValidationInstall();
+
+        // Assert that the userOp validation can be specified.
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: "",
+            callData: abi.encodeCall(UpgradeableModularAccount.execute, (address(0), 0, "")),
+            accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: "",
+            signature: ""
+        });
+
+        // Generate signature
+        bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), r, s, v);
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        // Sign with owner 1, expect fail
+
+        userOp.nonce = 1;
+        (v, r, s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), r, s, v);
+
+        userOps[0] = userOp;
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));
+        entryPoint.handleOps(userOps, beneficiary);
+    }
+}

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -233,7 +233,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_installPlugin() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         bytes32 manifestHash = keccak256(abi.encode(tokenReceiverPlugin.pluginManifest()));
 
@@ -253,7 +253,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_installPlugin_ExecuteFromPlugin_PermittedExecSelectorNotInstalled() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         PluginManifest memory m;
         m.permittedExecutionSelectors = new bytes4[](1);
@@ -271,7 +271,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_installPlugin_invalidManifest() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
         IPluginManager(account1).installPlugin({
@@ -283,7 +283,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_installPlugin_interfaceNotSupported() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         address badPlugin = address(1);
         vm.expectRevert(
@@ -298,7 +298,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_installPlugin_alreadyInstalled() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         bytes32 manifestHash = keccak256(abi.encode(tokenReceiverPlugin.pluginManifest()));
         IPluginManager(account1).installPlugin({
@@ -322,7 +322,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_uninstallPlugin_default() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         ComprehensivePlugin plugin = new ComprehensivePlugin();
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
@@ -342,7 +342,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_uninstallPlugin_manifestParameter() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         ComprehensivePlugin plugin = new ComprehensivePlugin();
         bytes memory serializedManifest = abi.encode(plugin.pluginManifest());
@@ -367,7 +367,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_uninstallPlugin_invalidManifestFails() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
 
         ComprehensivePlugin plugin = new ComprehensivePlugin();
         bytes memory serializedManifest = abi.encode(plugin.pluginManifest());
@@ -395,7 +395,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function _installPluginWithExecHooks() internal returns (MockPlugin plugin) {
-        vm.startPrank(owner2);
+        vm.startPrank(address(entryPoint));
 
         plugin = new MockPlugin(manifest);
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
@@ -411,7 +411,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_upgradeToAndCall() public {
-        vm.startPrank(owner1);
+        vm.startPrank(address(entryPoint));
         UpgradeableModularAccount account3 = new UpgradeableModularAccount(entryPoint);
         bytes32 slot = account3.proxiableUUID();
 
@@ -427,7 +427,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     function test_transferOwnership() public {
         assertEq(singleOwnerPlugin.ownerOf(address(account1)), owner1);
 
-        vm.prank(owner1);
+        vm.prank(address(entryPoint));
         account1.execute(
             address(singleOwnerPlugin), 0, abi.encodeCall(SingleOwnerPlugin.transferOwnership, (owner2))
         );

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -63,7 +63,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         counter.increment(); // amoritze away gas cost of zero->nonzero transition
 
         ownerValidation = FunctionReferenceLib.pack(
-            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
         );
     }
 

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -10,7 +10,7 @@ import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
 import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
+import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
 import {IPlugin, PluginManifest} from "../../src/interfaces/IPlugin.sol";
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
 import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
@@ -39,6 +39,8 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     Counter public counter;
     PluginManifest public manifest;
 
+    FunctionReference public ownerValidation;
+
     uint256 public constant CALL_GAS_LIMIT = 50000;
     uint256 public constant VERIFICATION_GAS_LIMIT = 1200000;
 
@@ -59,6 +61,10 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         vm.deal(ethRecipient, 1 wei);
         counter = new Counter();
         counter.increment(); // amoritze away gas cost of zero->nonzero transition
+
+        ownerValidation = FunctionReferenceLib.pack(
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+        );
     }
 
     function test_deployAccount() public {
@@ -81,7 +87,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -110,7 +116,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -136,7 +142,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -162,7 +168,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -190,7 +196,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -221,7 +227,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {FunctionReference} from "../../src/helpers/FunctionReferenceLib.sol";
+import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
 
 import {
     MockBaseUserOpValidationPlugin,
@@ -21,10 +21,29 @@ contract ValidationIntersectionTest is AccountTestBase {
     MockUserOpValidation1HookPlugin public oneHookPlugin;
     MockUserOpValidation2HookPlugin public twoHookPlugin;
 
+    FunctionReference public noHookValidation;
+    FunctionReference public oneHookValidation;
+    FunctionReference public twoHookValidation;
+
     function setUp() public {
         noHookPlugin = new MockUserOpValidationPlugin();
         oneHookPlugin = new MockUserOpValidation1HookPlugin();
         twoHookPlugin = new MockUserOpValidation2HookPlugin();
+
+        noHookValidation = FunctionReferenceLib.pack({
+            addr: address(noHookPlugin),
+            functionId: uint8(MockBaseUserOpValidationPlugin.FunctionId.USER_OP_VALIDATION)
+        });
+
+        oneHookValidation = FunctionReferenceLib.pack({
+            addr: address(oneHookPlugin),
+            functionId: uint8(MockBaseUserOpValidationPlugin.FunctionId.USER_OP_VALIDATION)
+        });
+
+        twoHookValidation = FunctionReferenceLib.pack({
+            addr: address(twoHookPlugin),
+            functionId: uint8(MockBaseUserOpValidationPlugin.FunctionId.USER_OP_VALIDATION)
+        });
 
         vm.startPrank(address(entryPoint));
         account1.installPlugin({
@@ -53,6 +72,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(noHookPlugin.foo.selector);
+        userOp.signature = abi.encodePacked(noHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -69,6 +89,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -86,6 +107,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -108,6 +130,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -129,6 +152,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -148,6 +172,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -172,6 +197,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -195,6 +221,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
+        userOp.signature = abi.encodePacked(oneHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -218,6 +245,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(twoHookPlugin.baz.selector);
+        userOp.signature = abi.encodePacked(twoHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -236,6 +264,7 @@ contract ValidationIntersectionTest is AccountTestBase {
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(twoHookPlugin.baz.selector);
 
+        userOp.signature = abi.encodePacked(twoHookValidation);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -26,7 +26,7 @@ contract ValidationIntersectionTest is AccountTestBase {
         oneHookPlugin = new MockUserOpValidation1HookPlugin();
         twoHookPlugin = new MockUserOpValidation2HookPlugin();
 
-        vm.startPrank(address(owner1));
+        vm.startPrank(address(entryPoint));
         account1.installPlugin({
             plugin: address(noHookPlugin),
             manifestHash: keccak256(abi.encode(noHookPlugin.pluginManifest())),

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -84,7 +84,11 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
         revert NotImplemented();
     }
 
-    function validateRuntime(uint8 functionId, address, uint256, bytes calldata) external pure override {
+    function validateRuntime(uint8 functionId, address, uint256, bytes calldata, bytes calldata)
+        external
+        pure
+        override
+    {
         if (functionId == uint8(FunctionId.VALIDATION)) {
             return;
         }

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -71,7 +71,7 @@ abstract contract MockBaseUserOpValidationPlugin is IValidation, IValidationHook
         revert NotImplemented();
     }
 
-    function validateRuntime(uint8, address, uint256, bytes calldata) external pure override {
+    function validateRuntime(uint8, address, uint256, bytes calldata, bytes calldata) external pure override {
         revert NotImplemented();
     }
 }

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -114,11 +114,11 @@ contract SingleOwnerPluginTest is OptimizedTest {
         assertEq(address(0), plugin.owner());
         plugin.transferOwnership(owner1);
         assertEq(owner1, plugin.owner());
-        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, "");
+        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, "", "");
 
         vm.startPrank(b);
         vm.expectRevert(ISingleOwnerPlugin.NotAuthorized.selector);
-        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, "");
+        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, "", "");
     }
 
     function testFuzz_validateUserOpSig(string memory salt, PackedUserOperation memory userOp) public {

--- a/test/plugin/SingleOwnerPlugin.t.sol
+++ b/test/plugin/SingleOwnerPlugin.t.sol
@@ -114,11 +114,11 @@ contract SingleOwnerPluginTest is OptimizedTest {
         assertEq(address(0), plugin.owner());
         plugin.transferOwnership(owner1);
         assertEq(owner1, plugin.owner());
-        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, "", "");
+        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), owner1, 0, "", "");
 
         vm.startPrank(b);
         vm.expectRevert(ISingleOwnerPlugin.NotAuthorized.selector);
-        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), owner1, 0, "", "");
+        plugin.validateRuntime(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), owner1, 0, "", "");
     }
 
     function testFuzz_validateUserOpSig(string memory salt, PackedUserOperation memory userOp) public {
@@ -133,9 +133,8 @@ contract SingleOwnerPluginTest is OptimizedTest {
         userOp.signature = abi.encodePacked(r, s, v);
 
         // sig check should fail
-        uint256 success = plugin.validateUserOp(
-            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), userOp, userOpHash
-        );
+        uint256 success =
+            plugin.validateUserOp(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), userOp, userOpHash);
         assertEq(success, 1);
 
         // transfer ownership to signer
@@ -143,9 +142,7 @@ contract SingleOwnerPluginTest is OptimizedTest {
         assertEq(signer, plugin.owner());
 
         // sig check should pass
-        success = plugin.validateUserOp(
-            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF), userOp, userOpHash
-        );
+        success = plugin.validateUserOp(uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), userOp, userOpHash);
         assertEq(success, 0);
     }
 

--- a/test/plugin/TokenReceiverPlugin.t.sol
+++ b/test/plugin/TokenReceiverPlugin.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
@@ -15,6 +15,7 @@ import {MockERC1155} from "../mocks/MockERC1155.sol";
 import {OptimizedTest} from "../utils/OptimizedTest.sol";
 
 contract TokenReceiverPluginTest is OptimizedTest, IERC1155Receiver {
+    EntryPoint public entryPoint;
     UpgradeableModularAccount public acct;
     TokenReceiverPlugin public plugin;
 
@@ -32,7 +33,8 @@ contract TokenReceiverPluginTest is OptimizedTest, IERC1155Receiver {
     uint256 internal constant _BATCH_TOKEN_IDS = 5;
 
     function setUp() public {
-        MSCAFactoryFixture factory = new MSCAFactoryFixture(IEntryPoint(address(0)), _deploySingleOwnerPlugin());
+        entryPoint = new EntryPoint();
+        MSCAFactoryFixture factory = new MSCAFactoryFixture(entryPoint, _deploySingleOwnerPlugin());
 
         acct = factory.createAccount(address(this), 0);
         plugin = _deployTokenReceiverPlugin();
@@ -53,6 +55,7 @@ contract TokenReceiverPluginTest is OptimizedTest, IERC1155Receiver {
     function _initPlugin() internal {
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
+        vm.prank(address(entryPoint));
         acct.installPlugin(address(plugin), manifestHash, "", new FunctionReference[](0));
     }
 

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
 import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
 import {OptimizedTest} from "./OptimizedTest.sol";
@@ -37,8 +38,16 @@ abstract contract AccountTestBase is OptimizedTest {
     function _transferOwnershipToTest() internal {
         // Transfer ownership to test contract for easier invocation.
         vm.prank(owner1);
-        account1.execute(
-            address(singleOwnerPlugin), 0, abi.encodeCall(SingleOwnerPlugin.transferOwnership, (address(this)))
+        account1.executeWithAuthorization(
+            abi.encodeCall(
+                account1.execute,
+                (
+                    address(singleOwnerPlugin),
+                    0,
+                    abi.encodeCall(SingleOwnerPlugin.transferOwnership, (address(this)))
+                )
+            ),
+            abi.encodePacked(address(singleOwnerPlugin), ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
         );
     }
 

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -47,7 +47,7 @@ abstract contract AccountTestBase is OptimizedTest {
                     abi.encodeCall(SingleOwnerPlugin.transferOwnership, (address(this)))
                 )
             ),
-            abi.encodePacked(address(singleOwnerPlugin), ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER_OR_SELF)
+            abi.encodePacked(address(singleOwnerPlugin), ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
         );
     }
 


### PR DESCRIPTION
## Motivation

As described in https://github.com/erc6900/resources/issues/4, supporting multiple validation functions has been a long-standing goal of ERC-6900.

## Solution

This PR implements switching between different validation functions using a field in the user op signature for user op validation, and a calldata field for runtime validation.

It also lays the groundwork for, but does not implement, associating pre-validation hooks with validators, and per-hook/per-validation auth data (https://github.com/erc6900/resources/issues/32).

To avoid needing a "default" or "primary" validation per selector, like in #52, this PR also changes the default auth flow through accounts. Previously, there were three validation flows through the account:
- User op validation (+ any pre-validation hooks): runs through `validateUserOp` called by EntryPoint
- Runtime validation (+ any pre-validation hooks): runs through fallback & native functions
- Authorized caller check: runs through `executeFromPlugin`

This PR keeps the user op validation flow, and reorganizes the auth flows of the latter two:
- Runtime validation (+ any pre-validation hooks): runs through `executeWithAuthrization`
- Authorized caller check: runs through fallback & native functions

Note that the `isPublic` property of an execution function, introduced earlier in the stack at #61, is still applied when calling functions through the fallback and native function paths.

By making this organizational change, this solution does not require a "default" or "primary" validation per selector. Whenever a validation function needs to run, it is specified by the caller and checked by the account to be an installed validator for the given function.

## Future work

The validation encoded in the user op signature (currently 21 bytes) would easily fit within the key portion of the user op nonce (24 bytes). However, due to potential future changes to how we identify validation functions likely coming with composable validation (https://github.com/erc6900/resources/issues/36) and user-supplied install configs (https://github.com/erc6900/resources/issues/9), I've avoided making that optimization for the time being. We should revisit the possibility of optimizing this once those are addressed.

Additionally, this PR does not make changes to pre-validation hook associations, which I believe multi-validation makes necessary. See #52 for more info on this.

