### PR TITLE
feat: [v0.8-develop, experimental] default validation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc = '0.8.25'
+solc = '0.8.26'
 via_ir = false
 src = 'src'
 test = 'test'

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -39,6 +39,8 @@ struct SelectorData {
     // Note that even if this is set to true, user op validation will still be required, otherwise anyone could
     // drain the account of native tokens by wasting gas.
     bool isPublic;
+    // Whether or not a shared validation function may be used to validate this function.
+    bool allowSharedValidation;
     // How many times a `PRE_HOOK_ALWAYS_DENY` has been added for this function.
     // Since that is the only type of hook that may overlap, we can use this to track the number of times it has
     // been applied, and whether or not the deny should apply. The size `uint48` was chosen somewhat arbitrarily,
@@ -68,6 +70,8 @@ struct AccountStorage {
     mapping(bytes4 => uint256) supportedIfaces;
     // Installed plugins capable of signature validation.
     EnumerableSet.Bytes32Set signatureValidations;
+    // Todo: merge this with other validation storage?
+    EnumerableSet.Bytes32Set defaultValidations;
 }
 
 // TODO: Change how pre-validation hooks work to allow association with validation, rather than selector.

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -39,8 +39,8 @@ struct SelectorData {
     // Note that even if this is set to true, user op validation will still be required, otherwise anyone could
     // drain the account of native tokens by wasting gas.
     bool isPublic;
-    // Whether or not a shared validation function may be used to validate this function.
-    bool allowSharedValidation;
+    // Whether or not a default validation function may be used to validate this function.
+    bool allowDefaultValidation;
     // How many times a `PRE_HOOK_ALWAYS_DENY` has been added for this function.
     // Since that is the only type of hook that may overlap, we can use this to track the number of times it has
     // been applied, and whether or not the deny should apply. The size `uint48` was chosen somewhat arbitrarily,

--- a/src/account/PluginManager2.sol
+++ b/src/account/PluginManager2.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import {IPlugin} from "../interfaces/IPlugin.sol";
+import {FunctionReference} from "../interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../helpers/FunctionReferenceLib.sol";
+import {AccountStorage, getAccountStorage, toSetValue} from "./AccountStorage.sol";
+
+abstract contract PluginManager2 {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    error DefaultValidationAlreadySet(address plugin, uint8 functionId);
+    error ValidationAlreadySet(bytes4 selector, address plugin, uint8 functionId);
+    error ValidationNotSet(bytes4 selector, address plugin, uint8 functionId);
+
+    function _installValidation(
+        address plugin,
+        uint8 functionId,
+        bool shared,
+        bytes4[] memory selectors,
+        bytes calldata installData
+    ) internal {
+        FunctionReference validationFunction = FunctionReferenceLib.pack(plugin, functionId);
+
+        AccountStorage storage _storage = getAccountStorage();
+
+        if (shared) {
+            if (!_storage.defaultValidations.add(toSetValue(validationFunction))) {
+                revert DefaultValidationAlreadySet(plugin, functionId);
+            }
+        }
+
+        for (uint256 i = 0; i < selectors.length; ++i) {
+            bytes4 selector = selectors[i];
+            if (!_storage.selectorData[selector].validations.add(toSetValue(validationFunction))) {
+                revert ValidationAlreadySet(selector, plugin, functionId);
+            }
+        }
+
+        IPlugin(plugin).onInstall(installData);
+    }
+
+    function _uninstallValidation(
+        address plugin,
+        uint8 functionId,
+        bytes4[] calldata selectors,
+        bytes calldata uninstallData
+    ) internal {
+        FunctionReference validationFunction = FunctionReferenceLib.pack(plugin, functionId);
+
+        AccountStorage storage _storage = getAccountStorage();
+
+        // Ignore return value - remove if present, do nothing otherwise.
+        _storage.defaultValidations.remove(toSetValue(validationFunction));
+
+        for (uint256 i = 0; i < selectors.length; ++i) {
+            bytes4 selector = selectors[i];
+            if (!_storage.selectorData[selector].validations.remove(toSetValue(validationFunction))) {
+                revert ValidationNotSet(selector, plugin, functionId);
+            }
+        }
+
+        IPlugin(plugin).onUninstall(uninstallData);
+    }
+}

--- a/src/account/PluginManager2.sol
+++ b/src/account/PluginManager2.sol
@@ -8,6 +8,7 @@ import {FunctionReference} from "../interfaces/IPluginManager.sol";
 import {FunctionReferenceLib} from "../helpers/FunctionReferenceLib.sol";
 import {AccountStorage, getAccountStorage, toSetValue} from "./AccountStorage.sol";
 
+// Temporary additional functions for a user-controlled install flow for validation functions.
 abstract contract PluginManager2 {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
@@ -18,7 +19,7 @@ abstract contract PluginManager2 {
     function _installValidation(
         address plugin,
         uint8 functionId,
-        bool shared,
+        bool isDefault,
         bytes4[] memory selectors,
         bytes calldata installData
     ) internal {
@@ -26,7 +27,7 @@ abstract contract PluginManager2 {
 
         AccountStorage storage _storage = getAccountStorage();
 
-        if (shared) {
+        if (isDefault) {
             if (!_storage.defaultValidations.add(toSetValue(validationFunction))) {
                 revert DefaultValidationAlreadySet(plugin, functionId);
             }

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -59,7 +59,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
     // Storage update operations
 
-    function _setExecutionFunction(bytes4 selector, bool isPublic, bool allowSharedValidation, address plugin)
+    function _setExecutionFunction(bytes4 selector, bool isPublic, bool allowDefaultValidation, address plugin)
         internal
         notNullPlugin(plugin)
     {
@@ -71,7 +71,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         _selectorData.plugin = plugin;
         _selectorData.isPublic = isPublic;
-        _selectorData.allowSharedValidation = allowSharedValidation;
+        _selectorData.allowDefaultValidation = allowDefaultValidation;
     }
 
     function _removeExecutionFunction(bytes4 selector) internal {
@@ -79,7 +79,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         _selectorData.plugin = address(0);
         _selectorData.isPublic = false;
-        _selectorData.allowSharedValidation = false;
+        _selectorData.allowDefaultValidation = false;
     }
 
     function _addValidationFunction(bytes4 selector, FunctionReference validationFunction)
@@ -223,8 +223,8 @@ abstract contract PluginManagerInternals is IPluginManager {
         for (uint256 i = 0; i < length; ++i) {
             bytes4 selector = manifest.executionFunctions[i].executionSelector;
             bool isPublic = manifest.executionFunctions[i].isPublic;
-            bool allowSharedValidation = manifest.executionFunctions[i].allowSharedValidation;
-            _setExecutionFunction(selector, isPublic, allowSharedValidation, plugin);
+            bool allowDefaultValidation = manifest.executionFunctions[i].allowDefaultValidation;
+            _setExecutionFunction(selector, isPublic, allowDefaultValidation, plugin);
         }
 
         // Add installed plugin and selectors this plugin can call

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -59,7 +59,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
     // Storage update operations
 
-    function _setExecutionFunction(bytes4 selector, bool isPublic, address plugin)
+    function _setExecutionFunction(bytes4 selector, bool isPublic, bool allowSharedValidation, address plugin)
         internal
         notNullPlugin(plugin)
     {
@@ -71,6 +71,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         _selectorData.plugin = plugin;
         _selectorData.isPublic = isPublic;
+        _selectorData.allowSharedValidation = allowSharedValidation;
     }
 
     function _removeExecutionFunction(bytes4 selector) internal {
@@ -78,6 +79,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         _selectorData.plugin = address(0);
         _selectorData.isPublic = false;
+        _selectorData.allowSharedValidation = false;
     }
 
     function _addValidationFunction(bytes4 selector, FunctionReference validationFunction)
@@ -221,7 +223,8 @@ abstract contract PluginManagerInternals is IPluginManager {
         for (uint256 i = 0; i < length; ++i) {
             bytes4 selector = manifest.executionFunctions[i].executionSelector;
             bool isPublic = manifest.executionFunctions[i].isPublic;
-            _setExecutionFunction(selector, isPublic, plugin);
+            bool allowSharedValidation = manifest.executionFunctions[i].allowSharedValidation;
+            _setExecutionFunction(selector, isPublic, allowSharedValidation, plugin);
         }
 
         // Add installed plugin and selectors this plugin can call

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -30,6 +30,7 @@ import {
 } from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
 import {PluginManagerInternals} from "./PluginManagerInternals.sol";
+import {PluginManager2} from "./PluginManager2.sol";
 
 contract UpgradeableModularAccount is
     AccountExecutor,
@@ -41,6 +42,7 @@ contract UpgradeableModularAccount is
     IPluginExecutor,
     IStandardExecutor,
     PluginManagerInternals,
+    PluginManager2,
     UUPSUpgradeable
 {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -325,6 +327,40 @@ contract UpgradeableModularAccount is
         _uninstallPlugin(plugin, manifest, pluginUninstallData);
     }
 
+    /// @notice Initializes the account with a validation function added to the default pool.
+    /// TODO: remove and merge with regular initialization, after we figure out a better install/uninstall workflow
+    /// with user install configs.
+    /// @dev This function is only callable once, and only by the EntryPoint.
+
+    function initializeDefaultValidation(address plugin, uint8 functionId, bytes calldata installData)
+        external
+        initializer
+    {
+        _installValidation(plugin, functionId, true, new bytes4[](0), installData);
+        emit ModularAccountInitialized(_ENTRY_POINT);
+    }
+
+    /// @inheritdoc IPluginManager
+    function installValidation(
+        address plugin,
+        uint8 functionId,
+        bool shared,
+        bytes4[] calldata selectors,
+        bytes calldata installData
+    ) external wrapNativeFunction {
+        _installValidation(plugin, functionId, shared, selectors, installData);
+    }
+
+    /// @inheritdoc IPluginManager
+    function uninstallValidation(
+        address plugin,
+        uint8 functionId,
+        bytes4[] calldata selectors,
+        bytes calldata uninstallData
+    ) external wrapNativeFunction {
+        _uninstallValidation(plugin, functionId, selectors, uninstallData);
+    }
+
     /// @notice ERC165 introspection
     /// @dev returns true for `IERC165.interfaceId` and false for `0xFFFFFFFF`
     /// @param interfaceId interface id to check against
@@ -398,14 +434,29 @@ contract UpgradeableModularAccount is
 
         // Revert if the provided `authorization` less than 21 bytes long, rather than right-padding.
         FunctionReference userOpValidationFunction = FunctionReference.wrap(bytes21(userOp.signature[:21]));
+        bool isSharedValidation = uint8(userOp.signature[21]) == 1;
 
-        if (!getAccountStorage().selectorData[selector].validations.contains(toSetValue(userOpValidationFunction)))
-        {
-            revert UserOpValidationFunctionMissing(selector);
+        // Check that the provided validation function is applicable to the selector
+        if (isSharedValidation) {
+            if (
+                !_sharedValidationAllowed(selector)
+                    || !_storage.defaultValidations.contains(toSetValue(userOpValidationFunction))
+            ) {
+                revert UserOpValidationFunctionMissing(selector);
+            }
+        } else {
+            // Not shared validation, but per-selector
+            if (
+                !getAccountStorage().selectorData[selector].validations.contains(
+                    toSetValue(userOpValidationFunction)
+                )
+            ) {
+                revert UserOpValidationFunctionMissing(selector);
+            }
         }
 
         validationData =
-            _doUserOpValidation(selector, userOpValidationFunction, userOp, userOp.signature[21:], userOpHash);
+            _doUserOpValidation(selector, userOpValidationFunction, userOp, userOp.signature[22:], userOpHash);
     }
 
     // To support gas estimation, we don't fail early when the failure is caused by a signature failure
@@ -572,6 +623,19 @@ contract UpgradeableModularAccount is
 
     // solhint-disable-next-line no-empty-blocks
     function _authorizeUpgrade(address newImplementation) internal override {}
+
+    function _sharedValidationAllowed(bytes4 selector) internal view returns (bool) {
+        if (
+            selector == this.execute.selector || selector == this.executeBatch.selector
+                || selector == this.installPlugin.selector || selector == this.uninstallPlugin.selector
+                || selector == this.installValidation.selector || selector == this.uninstallValidation.selector
+                || selector == this.upgradeToAndCall.selector
+        ) {
+            return true;
+        }
+
+        return getAccountStorage().selectorData[selector].allowSharedValidation;
+    }
 
     function _checkPermittedCallerIfNotFromEP() internal view {
         AccountStorage storage _storage = getAccountStorage();

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -158,6 +158,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc IStandardExecutor
+    /// @notice May be validated by a default validation.
     function execute(address target, uint256 value, bytes calldata data)
         external
         payable
@@ -169,6 +170,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc IStandardExecutor
+    /// @notice May be validated by a default validation function.
     function executeBatch(Call[] calldata calls)
         external
         payable
@@ -303,6 +305,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc IPluginManager
+    /// @notice May be validated by a default validation.
     function installPlugin(
         address plugin,
         bytes32 manifestHash,
@@ -313,6 +316,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc IPluginManager
+    /// @notice May be validated by a default validation.
     function uninstallPlugin(address plugin, bytes calldata config, bytes calldata pluginUninstallData)
         external
         override
@@ -343,6 +347,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc IPluginManager
+    /// @notice May be validated by a default validation.
     function installValidation(
         address plugin,
         uint8 functionId,
@@ -354,6 +359,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc IPluginManager
+    /// @notice May be validated by a default validation.
     function uninstallValidation(
         address plugin,
         uint8 functionId,
@@ -379,6 +385,7 @@ contract UpgradeableModularAccount is
     }
 
     /// @inheritdoc UUPSUpgradeable
+    /// @notice May be validated by a default validation.
     function upgradeToAndCall(address newImplementation, bytes memory data)
         public
         payable

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -79,6 +79,7 @@ contract UpgradeableModularAccount is
     error UnexpectedAggregator(address plugin, uint8 functionId, address aggregator);
     error UnrecognizedFunction(bytes4 selector);
     error UserOpValidationFunctionMissing(bytes4 selector);
+    error ValidationDoesNotApply(bytes4 selector, address plugin, uint8 functionId, bool shared);
 
     // Wraps execution of a native function with runtime validation and hooks
     // Used for upgradeTo, upgradeToAndCall, execute, executeBatch, installPlugin, uninstallPlugin
@@ -281,11 +282,12 @@ contract UpgradeableModularAccount is
         if (_storage.selectorData[execSelector].denyExecutionCount > 0) {
             revert AlwaysDenyRule();
         }
-        if (!_storage.selectorData[execSelector].validations.contains(toSetValue(runtimeValidationFunction))) {
-            revert RuntimeValidationFunctionMissing(execSelector);
-        }
 
-        _doRuntimeValidation(runtimeValidationFunction, data, authorization[21:]);
+        // Check if the runtime validation function is allowed to be called
+        bool isSharedValidation = uint8(authorization[21]) == 1;
+        _checkIfValidationApplies(execSelector, runtimeValidationFunction, isSharedValidation);
+
+        _doRuntimeValidation(runtimeValidationFunction, data, authorization[22:]);
 
         // If runtime validation passes, execute the call
 
@@ -436,24 +438,7 @@ contract UpgradeableModularAccount is
         FunctionReference userOpValidationFunction = FunctionReference.wrap(bytes21(userOp.signature[:21]));
         bool isSharedValidation = uint8(userOp.signature[21]) == 1;
 
-        // Check that the provided validation function is applicable to the selector
-        if (isSharedValidation) {
-            if (
-                !_sharedValidationAllowed(selector)
-                    || !_storage.defaultValidations.contains(toSetValue(userOpValidationFunction))
-            ) {
-                revert UserOpValidationFunctionMissing(selector);
-            }
-        } else {
-            // Not shared validation, but per-selector
-            if (
-                !getAccountStorage().selectorData[selector].validations.contains(
-                    toSetValue(userOpValidationFunction)
-                )
-            ) {
-                revert UserOpValidationFunctionMissing(selector);
-            }
-        }
+        _checkIfValidationApplies(selector, userOpValidationFunction, isSharedValidation);
 
         validationData =
             _doUserOpValidation(selector, userOpValidationFunction, userOp, userOp.signature[22:], userOpHash);
@@ -623,6 +608,28 @@ contract UpgradeableModularAccount is
 
     // solhint-disable-next-line no-empty-blocks
     function _authorizeUpgrade(address newImplementation) internal override {}
+
+    function _checkIfValidationApplies(bytes4 selector, FunctionReference validationFunction, bool shared)
+        internal
+        view
+    {
+        AccountStorage storage _storage = getAccountStorage();
+
+        // Check that the provided validation function is applicable to the selector
+        if (shared) {
+            if (
+                !_sharedValidationAllowed(selector)
+                    || !_storage.defaultValidations.contains(toSetValue(validationFunction))
+            ) {
+                revert UserOpValidationFunctionMissing(selector);
+            }
+        } else {
+            // Not shared validation, but per-selector
+            if (!getAccountStorage().selectorData[selector].validations.contains(toSetValue(validationFunction))) {
+                revert UserOpValidationFunctionMissing(selector);
+            }
+        }
+    }
 
     function _sharedValidationAllowed(bytes4 selector) internal view returns (bool) {
         if (

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -27,8 +27,8 @@ struct ManifestExecutionFunction {
     bytes4 executionSelector;
     // If true, the function won't need runtime validation, and can be called by anyone.
     bool isPublic;
-    // If true, the function can be validated by a shared validation function.
-    bool allowSharedValidation;
+    // If true, the function can be validated by a default validation function.
+    bool allowDefaultValidation;
 }
 
 /// @dev For functions of type `ManifestAssociatedFunctionType.DEPENDENCY`, the MSCA MUST find the plugin address

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -27,6 +27,8 @@ struct ManifestExecutionFunction {
     bytes4 executionSelector;
     // If true, the function won't need runtime validation, and can be called by anyone.
     bool isPublic;
+    // If true, the function can be validated by a shared validation function.
+    bool allowSharedValidation;
 }
 
 /// @dev For functions of type `ManifestAssociatedFunctionType.DEPENDENCY`, the MSCA MUST find the plugin address
@@ -77,15 +79,12 @@ struct PluginMetadata {
 
 /// @dev A struct describing how the plugin should be installed on a modular account.
 struct PluginManifest {
-    // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
-    // IPlugin's interface ID.
-    bytes4[] interfaceIds;
-    // If this plugin depends on other plugins' validation functions, the interface IDs of those plugins MUST be
-    // provided here, with its position in the array matching the `dependencyIndex` members of `ManifestFunction`
-    // structs used in the manifest.
-    bytes4[] dependencyInterfaceIds;
     // Execution functions defined in this plugin to be installed on the MSCA.
     ManifestExecutionFunction[] executionFunctions;
+    ManifestAssociatedFunction[] validationFunctions;
+    ManifestAssociatedFunction[] preValidationHooks;
+    ManifestExecutionHook[] executionHooks;
+    uint8[] signatureValidationFunctions;
     // Plugin execution functions already installed on the MSCA that this plugin will be able to call.
     bytes4[] permittedExecutionSelectors;
     // Boolean to indicate whether the plugin can call any external address.
@@ -94,10 +93,13 @@ struct PluginManifest {
     // plugin MUST still be able to spend up to the balance that it sends to the account in the same call.
     bool canSpendNativeToken;
     ManifestExternalCallPermission[] permittedExternalCalls;
-    ManifestAssociatedFunction[] validationFunctions;
-    ManifestAssociatedFunction[] preValidationHooks;
-    ManifestExecutionHook[] executionHooks;
-    uint8[] signatureValidationFunctions;
+    // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
+    // IPlugin's interface ID.
+    bytes4[] interfaceIds;
+    // If this plugin depends on other plugins' validation functions, the interface IDs of those plugins MUST be
+    // provided here, with its position in the array matching the `dependencyIndex` members of `ManifestFunction`
+    // structs used in the manifest.
+    bytes4[] dependencyInterfaceIds;
 }
 
 interface IPlugin is IERC165 {

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -22,8 +22,40 @@ interface IPluginManager {
         FunctionReference[] calldata dependencies
     ) external;
 
+    /// @notice Temporary install function - pending a different user-supplied install config & manifest validation
+    /// path.
+    /// Installs a validation function across a set of execution selectors, and optionally mark it as a default
+    /// validation.
+    /// TODO: remove or update.
+    /// @dev This does not validate anything against the manifest - the caller must ensure validity.
+    /// @param plugin The plugin to install.
+    /// @param functionId The function ID of the validation function to install.
+    /// @param shared Whether the validation function is shared across all selectors in the default pool.
+    /// @param selectors The selectors to install the validation function for.
+    /// @param installData Optional data to be decoded and used by the plugin to setup initial plugin state.
+    function installValidation(
+        address plugin,
+        uint8 functionId,
+        bool shared,
+        bytes4[] calldata selectors,
+        bytes calldata installData
+    ) external;
+
+    /// @notice Uninstall a validation function from a set of execution selectors.
+    /// TODO: remove or update.
+    /// @param plugin The plugin to uninstall.
+    /// @param functionId The function ID of the validation function to uninstall.
+    /// @param selectors The selectors to uninstall the validation function for.
+    /// @param uninstallData Optional data to be decoded and used by the plugin to clear plugin data for the
+    /// account.
+    function uninstallValidation(
+        address plugin,
+        uint8 functionId,
+        bytes4[] calldata selectors,
+        bytes calldata uninstallData
+    ) external;
+
     /// @notice Uninstall a plugin from the modular account.
-    /// @dev Uninstalling owner plugins outside of a replace operation via executeBatch risks losing the account!
     /// @param plugin The plugin to uninstall.
     /// @param config An optional, implementation-specific field that accounts may use to ensure consistency
     /// guarantees.

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -30,13 +30,13 @@ interface IPluginManager {
     /// @dev This does not validate anything against the manifest - the caller must ensure validity.
     /// @param plugin The plugin to install.
     /// @param functionId The function ID of the validation function to install.
-    /// @param shared Whether the validation function is shared across all selectors in the default pool.
+    /// @param isDefault Whether the validation function applies for all selectors in the default pool.
     /// @param selectors The selectors to install the validation function for.
     /// @param installData Optional data to be decoded and used by the plugin to setup initial plugin state.
     function installValidation(
         address plugin,
         uint8 functionId,
-        bool shared,
+        bool isDefault,
         bytes4[] calldata selectors,
         bytes calldata installData
     ) external;

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -62,17 +62,17 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC1155Receiver {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.onERC721Received.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.onERC1155Received.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
         manifest.executionFunctions[2] = ManifestExecutionFunction({
             executionSelector: this.onERC1155BatchReceived.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         manifest.interfaceIds = new bytes4[](2);

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -59,12 +59,21 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC1155Receiver {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](3);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.onERC721Received.selector, isPublic: true});
-        manifest.executionFunctions[1] =
-            ManifestExecutionFunction({executionSelector: this.onERC1155Received.selector, isPublic: true});
-        manifest.executionFunctions[2] =
-            ManifestExecutionFunction({executionSelector: this.onERC1155BatchReceived.selector, isPublic: true});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.onERC721Received.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
+        manifest.executionFunctions[1] = ManifestExecutionFunction({
+            executionSelector: this.onERC1155Received.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
+        manifest.executionFunctions[2] = ManifestExecutionFunction({
+            executionSelector: this.onERC1155BatchReceived.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
 
         manifest.interfaceIds = new bytes4[](2);
         manifest.interfaceIds[0] = type(IERC721Receiver).interfaceId;

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -43,7 +43,7 @@ contract AccountExecHooksTest is AccountTestBase {
             ManifestExecutionFunction({
                 executionSelector: _EXEC_SELECTOR,
                 isPublic: true,
-                allowSharedValidation: false
+                allowDefaultValidation: false
             })
         );
     }

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -39,7 +39,13 @@ contract AccountExecHooksTest is AccountTestBase {
     function setUp() public {
         _transferOwnershipToTest();
 
-        m1.executionFunctions.push(ManifestExecutionFunction({executionSelector: _EXEC_SELECTOR, isPublic: true}));
+        m1.executionFunctions.push(
+            ManifestExecutionFunction({
+                executionSelector: _EXEC_SELECTOR,
+                isPublic: true,
+                allowSharedValidation: false
+            })
+        );
     }
 
     function test_preExecHook_install() public {

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -59,7 +59,9 @@ contract AccountReturnDataTest is AccountTestBase {
                 account1.execute,
                 (address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()))
             ),
-            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
+            abi.encodePacked(
+                singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER, SELECTOR_ASSOCIATED_VALIDATION
+            )
         );
 
         bytes32 result = abi.decode(abi.decode(returnData, (bytes)), (bytes32));
@@ -83,7 +85,9 @@ contract AccountReturnDataTest is AccountTestBase {
 
         bytes memory retData = account1.executeWithAuthorization(
             abi.encodeCall(account1.executeBatch, (calls)),
-            abi.encodePacked(singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
+            abi.encodePacked(
+                singleOwnerPlugin, ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER, SELECTOR_ASSOCIATED_VALIDATION
+            )
         );
 
         bytes[] memory returnDatas = abi.decode(retData, (bytes[]));

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -97,8 +97,14 @@ contract MultiValidationTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature =
-            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER), r, s, v);
+        userOp.signature = abi.encodePacked(
+            address(validator2),
+            SELECTOR_ASSOCIATED_VALIDATION,
+            uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER),
+            r,
+            s,
+            v
+        );
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -67,13 +67,21 @@ contract MultiValidationTest is AccountTestBase {
         );
         account1.executeWithAuthorization(
             abi.encodeCall(IStandardExecutor.execute, (address(0), 0, "")),
-            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER))
+            abi.encodePacked(
+                address(validator2),
+                uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER),
+                SELECTOR_ASSOCIATED_VALIDATION
+            )
         );
 
         vm.prank(owner2);
         account1.executeWithAuthorization(
             abi.encodeCall(IStandardExecutor.execute, (address(0), 0, "")),
-            abi.encodePacked(address(validator2), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER))
+            abi.encodePacked(
+                address(validator2),
+                uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER),
+                SELECTOR_ASSOCIATED_VALIDATION
+            )
         );
     }
 

--- a/test/account/SharedValidationTest.t.sol
+++ b/test/account/SharedValidationTest.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
+import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
+
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
+import {SharedValidationFactoryFixture} from "../mocks/SharedValidationFactoryFixture.sol";
+
+contract SharedValidationTestTest is AccountTestBase {
+    using MessageHashUtils for bytes32;
+
+    SharedValidationFactoryFixture public sharedValidationFactoryFixture;
+
+    uint256 public constant CALL_GAS_LIMIT = 50000;
+    uint256 public constant VERIFICATION_GAS_LIMIT = 1200000;
+
+    FunctionReference public ownerValidation;
+
+    address public ethRecipient;
+
+    function setUp() public {
+        sharedValidationFactoryFixture = new SharedValidationFactoryFixture(entryPoint, singleOwnerPlugin);
+
+        account1 = UpgradeableModularAccount(payable(sharedValidationFactoryFixture.getAddress(owner1, 0)));
+
+        vm.deal(address(account1), 100 ether);
+
+        ethRecipient = makeAddr("ethRecipient");
+        vm.deal(ethRecipient, 1 wei);
+
+        ownerValidation = FunctionReferenceLib.pack(
+            address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
+        );
+    }
+
+    function test_sharedValidation_simple() public {
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: abi.encodePacked(
+                sharedValidationFactoryFixture,
+                abi.encodeCall(SharedValidationFactoryFixture.createAccount, (owner1, 0))
+            ),
+            callData: abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: "",
+            signature: ""
+        });
+
+        // Generate signature
+        bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
+        userOp.signature = abi.encodePacked(ownerValidation, SHARED_VALIDATION, r, s, v);
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        assertEq(ethRecipient.balance, 2 wei);
+    }
+}

--- a/test/account/SharedValidationTest.t.sol
+++ b/test/account/SharedValidationTest.t.sol
@@ -38,7 +38,7 @@ contract SharedValidationTestTest is AccountTestBase {
         );
     }
 
-    function test_sharedValidation_simple() public {
+    function test_sharedValidation_userOp_simple() public {
         PackedUserOperation memory userOp = PackedUserOperation({
             sender: address(account1),
             nonce: 0,
@@ -63,6 +63,19 @@ contract SharedValidationTestTest is AccountTestBase {
         userOps[0] = userOp;
 
         entryPoint.handleOps(userOps, beneficiary);
+
+        assertEq(ethRecipient.balance, 2 wei);
+    }
+
+    function test_sharedValidation_runtime_simple() public {
+        // Deploy the account first
+        sharedValidationFactoryFixture.createAccount(owner1, 0);
+
+        vm.prank(owner1);
+        account1.executeWithAuthorization(
+            abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            abi.encodePacked(ownerValidation, SHARED_VALIDATION)
+        );
 
         assertEq(ethRecipient.balance, 2 wei);
     }

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -87,7 +87,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, SELECTOR_ASSOCIATED_VALIDATION, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -116,7 +116,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, SELECTOR_ASSOCIATED_VALIDATION, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -142,7 +142,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, SELECTOR_ASSOCIATED_VALIDATION, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -168,7 +168,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, SELECTOR_ASSOCIATED_VALIDATION, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -196,7 +196,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, SELECTOR_ASSOCIATED_VALIDATION, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -227,7 +227,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = abi.encodePacked(ownerValidation, r, s, v);
+        userOp.signature = abi.encodePacked(ownerValidation, SELECTOR_ASSOCIATED_VALIDATION, r, s, v);
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -72,7 +72,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(noHookPlugin.foo.selector);
-        userOp.signature = abi.encodePacked(noHookValidation);
+        userOp.signature = abi.encodePacked(noHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -89,7 +89,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -107,7 +107,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -130,7 +130,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -152,7 +152,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -172,7 +172,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -197,7 +197,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -221,7 +221,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(oneHookPlugin.bar.selector);
-        userOp.signature = abi.encodePacked(oneHookValidation);
+        userOp.signature = abi.encodePacked(oneHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -245,7 +245,7 @@ contract ValidationIntersectionTest is AccountTestBase {
 
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(twoHookPlugin.baz.selector);
-        userOp.signature = abi.encodePacked(twoHookValidation);
+        userOp.signature = abi.encodePacked(twoHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));
@@ -264,7 +264,7 @@ contract ValidationIntersectionTest is AccountTestBase {
         PackedUserOperation memory userOp;
         userOp.callData = bytes.concat(twoHookPlugin.baz.selector);
 
-        userOp.signature = abi.encodePacked(twoHookValidation);
+        userOp.signature = abi.encodePacked(twoHookValidation, SELECTOR_ASSOCIATED_VALIDATION);
         bytes32 uoHash = entryPoint.getUserOpHash(userOp);
 
         vm.prank(address(entryPoint));

--- a/test/mocks/DefaultValidationFactoryFixture.sol
+++ b/test/mocks/DefaultValidationFactoryFixture.sol
@@ -11,7 +11,7 @@ import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
 import {OptimizedTest} from "../utils/OptimizedTest.sol";
 
-contract SharedValidationFactoryFixture is OptimizedTest {
+contract DefaultValidationFactoryFixture is OptimizedTest {
     UpgradeableModularAccount public accountImplementation;
     SingleOwnerPlugin public singleOwnerPlugin;
     bytes32 private immutable _PROXY_BYTECODE_HASH;

--- a/test/mocks/SharedValidationFactoryFixture.sol
+++ b/test/mocks/SharedValidationFactoryFixture.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+
+import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ISingleOwnerPlugin} from "../../src/plugins/owner/ISingleOwnerPlugin.sol";
+import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
+
+import {OptimizedTest} from "../utils/OptimizedTest.sol";
+
+contract SharedValidationFactoryFixture is OptimizedTest {
+    UpgradeableModularAccount public accountImplementation;
+    SingleOwnerPlugin public singleOwnerPlugin;
+    bytes32 private immutable _PROXY_BYTECODE_HASH;
+
+    uint32 public constant UNSTAKE_DELAY = 1 weeks;
+
+    IEntryPoint public entryPoint;
+
+    address public self;
+
+    bytes32 public singleOwnerPluginManifestHash;
+
+    constructor(IEntryPoint _entryPoint, SingleOwnerPlugin _singleOwnerPlugin) {
+        entryPoint = _entryPoint;
+        accountImplementation = _deployUpgradeableModularAccount(_entryPoint);
+        _PROXY_BYTECODE_HASH = keccak256(
+            abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(address(accountImplementation), ""))
+        );
+        singleOwnerPlugin = _singleOwnerPlugin;
+        self = address(this);
+        // The manifest hash is set this way in this factory just for testing purposes.
+        // For production factories the manifest hashes should be passed as a constructor argument.
+        singleOwnerPluginManifestHash = keccak256(abi.encode(singleOwnerPlugin.pluginManifest()));
+    }
+
+    /**
+     * create an account, and return its address.
+     * returns the address even if the account is already deployed.
+     * Note that during user operation execution, this method is called only if the account is not deployed.
+     * This method returns an existing account address so that entryPoint.getSenderAddress() would work even after
+     * account creation
+     */
+    function createAccount(address owner, uint256 salt) public returns (UpgradeableModularAccount) {
+        address addr = Create2.computeAddress(getSalt(owner, salt), _PROXY_BYTECODE_HASH);
+
+        // short circuit if exists
+        if (addr.code.length == 0) {
+            bytes memory pluginInstallData = abi.encode(owner);
+            // not necessary to check return addr since next call will fail if so
+            new ERC1967Proxy{salt: getSalt(owner, salt)}(address(accountImplementation), "");
+
+            // point proxy to actual implementation and init plugins
+            UpgradeableModularAccount(payable(addr)).initializeDefaultValidation(
+                address(singleOwnerPlugin),
+                uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER),
+                pluginInstallData
+            );
+        }
+
+        return UpgradeableModularAccount(payable(addr));
+    }
+
+    /**
+     * calculate the counterfactual address of this account as it would be returned by createAccount()
+     */
+    function getAddress(address owner, uint256 salt) public view returns (address) {
+        return Create2.computeAddress(getSalt(owner, salt), _PROXY_BYTECODE_HASH);
+    }
+
+    function addStake() external payable {
+        entryPoint.addStake{value: msg.value}(UNSTAKE_DELAY);
+    }
+
+    function getSalt(address owner, uint256 salt) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(owner, salt));
+    }
+}

--- a/test/mocks/plugins/BadTransferOwnershipPlugin.sol
+++ b/test/mocks/plugins/BadTransferOwnershipPlugin.sol
@@ -36,7 +36,7 @@ contract BadTransferOwnershipPlugin is BasePlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.evilTransferOwnership.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         manifest.permittedExecutionSelectors = new bytes4[](1);

--- a/test/mocks/plugins/BadTransferOwnershipPlugin.sol
+++ b/test/mocks/plugins/BadTransferOwnershipPlugin.sol
@@ -33,8 +33,11 @@ contract BadTransferOwnershipPlugin is BasePlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.evilTransferOwnership.selector, isPublic: true});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.evilTransferOwnership.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
 
         manifest.permittedExecutionSelectors = new bytes4[](1);
         manifest.permittedExecutionSelectors[0] = ISingleOwnerPlugin.transferOwnership.selector;

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -133,8 +133,11 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.foo.selector, isPublic: false});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.foo.selector,
+            isPublic: false,
+            allowSharedValidation: false
+        });
 
         ManifestFunction memory fooValidationFunction = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.SELF,

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -136,7 +136,7 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: false,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         ManifestFunction memory fooValidationFunction = ManifestFunction({

--- a/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
+++ b/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
@@ -189,7 +189,7 @@ contract EFPCallerPluginAnyExternal is BasePlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.passthroughExecute.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         manifest.permitAnyExternalAddress = true;

--- a/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
+++ b/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
@@ -186,8 +186,11 @@ contract EFPCallerPluginAnyExternal is BasePlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.passthroughExecute.selector, isPublic: true});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.passthroughExecute.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
 
         manifest.permitAnyExternalAddress = true;
 

--- a/test/mocks/plugins/ManifestValidityMocks.sol
+++ b/test/mocks/plugins/ManifestValidityMocks.sol
@@ -26,8 +26,11 @@ contract BadHookMagicValue_ValidationFunction_Plugin is BasePlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.foo.selector, isPublic: false});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.foo.selector,
+            isPublic: false,
+            allowSharedValidation: false
+        });
 
         manifest.validationFunctions = new ManifestAssociatedFunction[](1);
         manifest.validationFunctions[0] = ManifestAssociatedFunction({

--- a/test/mocks/plugins/ManifestValidityMocks.sol
+++ b/test/mocks/plugins/ManifestValidityMocks.sol
@@ -29,7 +29,7 @@ contract BadHookMagicValue_ValidationFunction_Plugin is BasePlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: false,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         manifest.validationFunctions = new ManifestAssociatedFunction[](1);

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -41,12 +41,12 @@ contract ResultCreatorPlugin is BasePlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.bar.selector,
             isPublic: false,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         return manifest;
@@ -117,12 +117,12 @@ contract ResultConsumerPlugin is BasePlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.checkResultEFPFallback.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.checkResultEFPExternal.selector,
             isPublic: true,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         manifest.permittedExecutionSelectors = new bytes4[](1);

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -38,10 +38,16 @@ contract ResultCreatorPlugin is BasePlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.foo.selector, isPublic: true});
-        manifest.executionFunctions[1] =
-            ManifestExecutionFunction({executionSelector: this.bar.selector, isPublic: false});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.foo.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
+        manifest.executionFunctions[1] = ManifestExecutionFunction({
+            executionSelector: this.bar.selector,
+            isPublic: false,
+            allowSharedValidation: false
+        });
 
         return manifest;
     }
@@ -108,10 +114,16 @@ contract ResultConsumerPlugin is BasePlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.checkResultEFPFallback.selector, isPublic: true});
-        manifest.executionFunctions[1] =
-            ManifestExecutionFunction({executionSelector: this.checkResultEFPExternal.selector, isPublic: true});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.checkResultEFPFallback.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
+        manifest.executionFunctions[1] = ManifestExecutionFunction({
+            executionSelector: this.checkResultEFPExternal.selector,
+            isPublic: true,
+            allowSharedValidation: false
+        });
 
         manifest.permittedExecutionSelectors = new bytes4[](1);
         manifest.permittedExecutionSelectors[0] = ResultCreatorPlugin.foo.selector;

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -98,7 +98,7 @@ contract MockUserOpValidationPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: false,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         manifest.validationFunctions = new ManifestAssociatedFunction[](1);
@@ -140,7 +140,7 @@ contract MockUserOpValidation1HookPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.bar.selector,
             isPublic: false,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         ManifestFunction memory userOpValidationFunctionRef = ManifestFunction({
@@ -196,7 +196,7 @@ contract MockUserOpValidation2HookPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.baz.selector,
             isPublic: false,
-            allowSharedValidation: false
+            allowDefaultValidation: false
         });
 
         ManifestFunction memory userOpValidationFunctionRef = ManifestFunction({

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -95,8 +95,11 @@ contract MockUserOpValidationPlugin is MockBaseUserOpValidationPlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.foo.selector, isPublic: false});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.foo.selector,
+            isPublic: false,
+            allowSharedValidation: false
+        });
 
         manifest.validationFunctions = new ManifestAssociatedFunction[](1);
         manifest.validationFunctions[0] = ManifestAssociatedFunction({
@@ -134,8 +137,11 @@ contract MockUserOpValidation1HookPlugin is MockBaseUserOpValidationPlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.bar.selector, isPublic: false});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.bar.selector,
+            isPublic: false,
+            allowSharedValidation: false
+        });
 
         ManifestFunction memory userOpValidationFunctionRef = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.SELF,
@@ -187,8 +193,11 @@ contract MockUserOpValidation2HookPlugin is MockBaseUserOpValidationPlugin {
         PluginManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
-        manifest.executionFunctions[0] =
-            ManifestExecutionFunction({executionSelector: this.baz.selector, isPublic: false});
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.baz.selector,
+            isPublic: false,
+            allowSharedValidation: false
+        });
 
         ManifestFunction memory userOpValidationFunctionRef = ManifestFunction({
             functionType: ManifestAssociatedFunctionType.SELF,

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -24,7 +24,7 @@ abstract contract AccountTestBase is OptimizedTest {
     UpgradeableModularAccount public account1;
 
     uint8 public constant SELECTOR_ASSOCIATED_VALIDATION = 0;
-    uint8 public constant SHARED_VALIDATION = 1;
+    uint8 public constant DEFAULT_VALIDATION = 1;
 
     constructor() {
         entryPoint = new EntryPoint();

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -23,6 +23,9 @@ abstract contract AccountTestBase is OptimizedTest {
     uint256 public owner1Key;
     UpgradeableModularAccount public account1;
 
+    uint8 public constant SELECTOR_ASSOCIATED_VALIDATION = 0;
+    uint8 public constant SHARED_VALIDATION = 1;
+
     constructor() {
         entryPoint = new EntryPoint();
         (owner1, owner1Key) = makeAddrAndKey("owner1");

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -50,7 +50,11 @@ abstract contract AccountTestBase is OptimizedTest {
                     abi.encodeCall(SingleOwnerPlugin.transferOwnership, (address(this)))
                 )
             ),
-            abi.encodePacked(address(singleOwnerPlugin), ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
+            abi.encodePacked(
+                address(singleOwnerPlugin),
+                ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER,
+                SELECTOR_ASSOCIATED_VALIDATION
+            )
         );
     }
 


### PR DESCRIPTION
## Motivation

https://github.com/erc6900/resources/issues/37

By introducing a "default" validation function pool, we can reduce plugin installation costs, particularly for ownership plugins, by allowing execution functions to opt-in to a default validation pool.

This also addresses some incompatibilities between ownership plugins and semi-modular accounts, by removing the need for a plugin to know each native function implemented by an account.

## Solution

While the motivation is clear, I think there are a lot of possible ways to address the issue. This is one example of how we can address it.

This PR does the following:
- Adds a new field to execution functions called `allowDefaultValidation`, indicating whether the defining plugin believes it should be accessible by any validation added to the "pool of default validation functions".
- This is set by the implementing plugin, rather than the end user, because the function implementation will _probably_ be aware of the differences between a function that "just needs any user-controlled validation applied to it", and a function that needs a specific type of validation function. Examples include limiting social account recovery to only it's own validation method, while something like modifying a subscription payment plugin's subscriptions could be done by any "owner" validation.
   - I think this is the part of the design I have the least confidence in – there may be a reason for the end users to decide whether an execution function should be a part of the default pool or not. Of course, the entire install flow may be changed with https://github.com/erc6900/resources/issues/9 so it's hard to tell how it will look now.
- The option to mark a validation function as in the pool of defaults or not, however, is _not_ left up to the plugin - this is set by the user.
   - To accomplish this, this PR adds temporary extra plugin management functions called `installValidation`/`uninstallValidation`, that does a reduced-scope version of `installPlugin` for only a specific validation function. The user is able to control the domain of this validation function by specifying individual selectors, and whether or not the plugin should be in the default pool.
- This PR also adds a new factory and a test specifically for the default validation workflows.

### New Todos
- Consolidate old tests & test base to use default validation. This is blocked on the install/uninstall plugin revamp