### PR TITLE
[1/n permissions] chore: remove existing permissions system

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -51,8 +51,7 @@ struct AccountStorage {
     mapping(address => PluginData) pluginData;
     // Execution functions and their associated functions
     mapping(bytes4 => SelectorData) selectorData;
-    mapping(FunctionReference validationFunction => ValidationData) validationData;
-    mapping(address caller => mapping(bytes4 selector => bool)) callPermitted;
+    mapping(FunctionReference => ValidationData) validationData;
     // For ERC165 introspection
     mapping(bytes4 => uint256) supportedIfaces;
 }

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -51,7 +51,7 @@ struct AccountStorage {
     mapping(address => PluginData) pluginData;
     // Execution functions and their associated functions
     mapping(bytes4 => SelectorData) selectorData;
-    mapping(FunctionReference => ValidationData) validationData;
+    mapping(FunctionReference validationFunction => ValidationData) validationData;
     // For ERC165 introspection
     mapping(bytes4 => uint256) supportedIfaces;
 }

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -212,14 +212,6 @@ abstract contract PluginManagerInternals is IPluginManager {
             _setExecutionFunction(selector, isPublic, allowDefaultValidation, plugin);
         }
 
-        // Add installed plugin and selectors this plugin can call
-        length = manifest.permittedExecutionSelectors.length;
-        for (uint256 i = 0; i < length; ++i) {
-            // If there are duplicates, this will just enable the flag again. This is not a problem, since the
-            // boolean will be set to false twice during uninstall, which is fine.
-            _storage.callPermitted[plugin][manifest.permittedExecutionSelectors[i]] = true;
-        }
-
         length = manifest.validationFunctions.length;
         for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mv = manifest.validationFunctions[i];
@@ -311,11 +303,6 @@ abstract contract PluginManagerInternals is IPluginManager {
             _removeValidationFunction(
                 mv.executionSelector, _resolveManifestFunction(mv.associatedFunction, plugin, dependencies)
             );
-        }
-
-        length = manifest.permittedExecutionSelectors.length;
-        for (uint256 i = 0; i < length; ++i) {
-            _storage.callPermitted[plugin][manifest.permittedExecutionSelectors[i]] = false;
         }
 
         length = manifest.executionFunctions.length;

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -555,11 +555,9 @@ contract UpgradeableModularAccount is
         AccountStorage storage _storage = getAccountStorage();
 
         if (
-            msg.sender == address(_ENTRY_POINT) || msg.sender == address(this)
-                || _storage.selectorData[msg.sig].isPublic
-        ) return;
-
-        if (!_storage.callPermitted[msg.sender][msg.sig]) {
+            msg.sender != address(_ENTRY_POINT) && msg.sender != address(this)
+                && !_storage.selectorData[msg.sig].isPublic
+        ) {
             revert ExecFromPluginNotPermitted(msg.sender, msg.sig);
         }
     }

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -73,8 +73,6 @@ struct PluginManifest {
     ManifestAssociatedFunction[] validationFunctions;
     ManifestExecutionHook[] executionHooks;
     uint8[] signatureValidationFunctions;
-    // Plugin execution functions already installed on the MSCA that this plugin will be able to call.
-    bytes4[] permittedExecutionSelectors;
     // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
     // IPlugin's interface ID.
     bytes4[] interfaceIds;

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -11,7 +11,7 @@ import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
-import {IPlugin, PluginManifest} from "../../src/interfaces/IPlugin.sol";
+import {PluginManifest} from "../../src/interfaces/IPlugin.sol";
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
 import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
@@ -262,8 +262,6 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
 
         PluginManifest memory m;
-        m.permittedExecutionSelectors = new bytes4[](1);
-        m.permittedExecutionSelectors[0] = IPlugin.onInstall.selector;
 
         MockPlugin mockPluginWithBadPermittedExec = new MockPlugin(m);
         bytes32 manifestHash = keccak256(abi.encode(mockPluginWithBadPermittedExec.pluginManifest()));

--- a/test/mocks/plugins/PermittedCallMocks.sol
+++ b/test/mocks/plugins/PermittedCallMocks.sol
@@ -22,10 +22,6 @@ contract PermittedCallerPlugin is BasePlugin {
             manifest.executionFunctions[i].isPublic = true;
         }
 
-        // Request permission only for "foo", but not "bar", from ResultCreatorPlugin
-        manifest.permittedExecutionSelectors = new bytes4[](1);
-        manifest.permittedExecutionSelectors[0] = ResultCreatorPlugin.foo.selector;
-
         return manifest;
     }
 

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -138,9 +138,6 @@ contract ResultConsumerPlugin is BasePlugin, IValidation {
             allowDefaultValidation: false
         });
 
-        manifest.permittedExecutionSelectors = new bytes4[](1);
-        manifest.permittedExecutionSelectors[0] = ResultCreatorPlugin.foo.selector;
-
         return manifest;
     }
 


### PR DESCRIPTION
Changelog:
1. Removes `callPermitted` and `permittedExternalCalls` from the account and the plugin manifest