### PR TITLE
[3/n permissions] feat: add execute user op

### DIFF
--- a/src/account/PluginManager2.sol
+++ b/src/account/PluginManager2.sol
@@ -7,6 +7,7 @@ import {IPlugin} from "../interfaces/IPlugin.sol";
 import {FunctionReference} from "../interfaces/IPluginManager.sol";
 import {FunctionReferenceLib} from "../helpers/FunctionReferenceLib.sol";
 import {AccountStorage, getAccountStorage, toSetValue, toFunctionReference} from "./AccountStorage.sol";
+import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
 
 abstract contract PluginManager2 {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -15,13 +16,15 @@ abstract contract PluginManager2 {
     error ValidationAlreadySet(bytes4 selector, FunctionReference validationFunction);
     error PreValidationAlreadySet(FunctionReference validationFunction, FunctionReference preValidationFunction);
     error ValidationNotSet(bytes4 selector, FunctionReference validationFunction);
+    error PermissionAlreadySet(FunctionReference validationFunction, ExecutionHook hook);
 
     function _installValidation(
         FunctionReference validationFunction,
         bool shared,
         bytes4[] memory selectors,
         bytes calldata installData,
-        bytes memory preValidationHooks
+        bytes memory preValidationHooks,
+        bytes memory permissionHooks
     )
         // TODO: flag for signature validation
         internal
@@ -50,6 +53,26 @@ abstract contract PluginManager2 {
             }
         }
 
+        if (permissionHooks.length > 0) {
+            (ExecutionHook[] memory permissionFunctions, bytes[] memory initDatas) =
+                abi.decode(permissionHooks, (ExecutionHook[], bytes[]));
+
+            for (uint256 i = 0; i < permissionFunctions.length; ++i) {
+                ExecutionHook memory permissionFunction = permissionFunctions[i];
+
+                if (
+                    !_storage.validationData[validationFunction].permissionHooks.add(toSetValue(permissionFunction))
+                ) {
+                    revert PermissionAlreadySet(validationFunction, permissionFunction);
+                }
+
+                if (initDatas[i].length > 0) {
+                    (address executionPlugin,) = FunctionReferenceLib.unpack(permissionFunction.hookFunction);
+                    IPlugin(executionPlugin).onInstall(initDatas[i]);
+                }
+            }
+        }
+
         if (shared) {
             if (_storage.validationData[validationFunction].isShared) {
                 revert DefaultValidationAlreadySet(validationFunction);
@@ -74,24 +97,43 @@ abstract contract PluginManager2 {
         FunctionReference validationFunction,
         bytes4[] calldata selectors,
         bytes calldata uninstallData,
-        bytes calldata preValidationHookUninstallData
+        bytes calldata preValidationHookUninstallData,
+        bytes calldata permissionHookUninstallData
     ) internal {
         AccountStorage storage _storage = getAccountStorage();
 
         _storage.validationData[validationFunction].isShared = false;
         _storage.validationData[validationFunction].isSignatureValidation = false;
 
-        bytes[] memory preValidationHookUninstallDatas = abi.decode(preValidationHookUninstallData, (bytes[]));
+        {
+            bytes[] memory preValidationHookUninstallDatas = abi.decode(preValidationHookUninstallData, (bytes[]));
 
-        // Clear pre validation hooks
-        EnumerableSet.Bytes32Set storage preValidationHooks =
-            _storage.validationData[validationFunction].preValidationHooks;
-        while (preValidationHooks.length() > 0) {
-            FunctionReference preValidationFunction = toFunctionReference(preValidationHooks.at(0));
-            preValidationHooks.remove(toSetValue(preValidationFunction));
-            (address preValidationPlugin,) = FunctionReferenceLib.unpack(preValidationFunction);
-            if (preValidationHookUninstallDatas[0].length > 0) {
-                IPlugin(preValidationPlugin).onUninstall(preValidationHookUninstallDatas[0]);
+            // Clear pre validation hooks
+            EnumerableSet.Bytes32Set storage preValidationHooks =
+                _storage.validationData[validationFunction].preValidationHooks;
+            while (preValidationHooks.length() > 0) {
+                FunctionReference preValidationFunction = toFunctionReference(preValidationHooks.at(0));
+                preValidationHooks.remove(toSetValue(preValidationFunction));
+                (address preValidationPlugin,) = FunctionReferenceLib.unpack(preValidationFunction);
+                if (preValidationHookUninstallDatas[0].length > 0) {
+                    IPlugin(preValidationPlugin).onUninstall(preValidationHookUninstallDatas[0]);
+                }
+            }
+        }
+
+        {
+            bytes[] memory permissionHookUninstallDatas = abi.decode(permissionHookUninstallData, (bytes[]));
+
+            // Clear permission hooks
+            EnumerableSet.Bytes32Set storage permissionHooks =
+                _storage.validationData[validationFunction].permissionHooks;
+            while (permissionHooks.length() > 0) {
+                FunctionReference permissionHook = toFunctionReference(permissionHooks.at(0));
+                permissionHooks.remove(toSetValue(permissionHook));
+                (address permissionHookPlugin,) = FunctionReferenceLib.unpack(permissionHook);
+                if (permissionHookUninstallDatas[0].length > 0) {
+                    IPlugin(permissionHookPlugin).onUninstall(permissionHookUninstallDatas[0]);
+                }
             }
         }
 

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -379,10 +379,10 @@ contract UpgradeableModularAccount is
         // call isn't to `executeUserOp`
         // This check must be here because if context isn't passed, we wouldn't be able to get the exec hooks
         // associated with the validator
-        if (getAccountStorage().validationData[userOpValidationFunction].requireUOHookCount > 0) {
-            /**
-             * && msg.sig != this.executeUserOp.selector
-             */
+        if (
+            getAccountStorage().validationData[userOpValidationFunction].requireUOHookCount > 0
+                && bytes4(userOp.callData[:4]) != this.executeUserOp.selector
+        ) {
             revert RequireUserOperationContext();
         }
 

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -32,12 +32,15 @@ interface IPluginManager {
     /// @param shared Whether the validation function is shared across all selectors in the default pool.
     /// @param selectors The selectors to install the validation function for.
     /// @param installData Optional data to be decoded and used by the plugin to setup initial plugin state.
+    /// @param preValidationHooks Optional pre-validation hooks to install for the validation function.
+    /// @param permissionHooks Optional permission hooks to install for the validation function.
     function installValidation(
         FunctionReference validationFunction,
         bool shared,
         bytes4[] memory selectors,
         bytes calldata installData,
-        bytes calldata preValidationHooks
+        bytes calldata preValidationHooks,
+        bytes calldata permissionHooks
     ) external;
 
     /// @notice Uninstall a validation function from a set of execution selectors.
@@ -46,11 +49,15 @@ interface IPluginManager {
     /// @param selectors The selectors to uninstall the validation function for.
     /// @param uninstallData Optional data to be decoded and used by the plugin to clear plugin data for the
     /// account.
+    /// @param preValidationHookUninstallData Optional data to be decoded and used by the plugin to clear account
+    /// data
+    /// @param permissionHookUninstallData Optional data to be decoded and used by the plugin to clear account data
     function uninstallValidation(
         FunctionReference validationFunction,
         bytes4[] calldata selectors,
         bytes calldata uninstallData,
-        bytes calldata preValidationHookUninstallData
+        bytes calldata preValidationHookUninstallData,
+        bytes calldata permissionHookUninstallData
     ) external;
 
     /// @notice Uninstall a plugin from the modular account.

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -43,7 +43,12 @@ contract AccountLoupeTest is AccountTestBase {
         bytes[] memory installDatas = new bytes[](2);
         vm.prank(address(entryPoint));
         account1.installValidation(
-            ownerValidation, true, new bytes4[](0), bytes(""), abi.encode(preValidationHooks, installDatas)
+            ownerValidation,
+            true,
+            new bytes4[](0),
+            bytes(""),
+            abi.encode(preValidationHooks, installDatas),
+            bytes("")
         );
     }
 

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -67,7 +67,12 @@ contract ValidationIntersectionTest is AccountTestBase {
         });
         bytes[] memory installDatas = new bytes[](1);
         account1.installValidation(
-            oneHookValidation, true, new bytes4[](0), bytes(""), abi.encode(preValidationHooks, installDatas)
+            oneHookValidation,
+            true,
+            new bytes4[](0),
+            bytes(""),
+            abi.encode(preValidationHooks, installDatas),
+            bytes("")
         );
         account1.installPlugin({
             plugin: address(twoHookPlugin),
@@ -87,7 +92,12 @@ contract ValidationIntersectionTest is AccountTestBase {
         });
         installDatas = new bytes[](2);
         account1.installValidation(
-            twoHookValidation, true, new bytes4[](0), bytes(""), abi.encode(preValidationHooks, installDatas)
+            twoHookValidation,
+            true,
+            new bytes4[](0),
+            bytes(""),
+            abi.encode(preValidationHooks, installDatas),
+            bytes("")
         );
         vm.stopPrank();
     }


### PR DESCRIPTION
changes:
1. Add executeUserOp
2. If hooks require UO context, enforce that calls are made to `executeUserOp` in UO validation
3. Send `abi.encode(PackedUserOperation)` if UO context is required, else send `abi.encodePacked(msg.sender, msg.value, msg.data)`
4. Add permission hook installation/uninstallation via `installValidation` and `uninstallValidation`