### PR TITLE
[DRAFT] feat: [v0.8-develop, experimental] composable validation

### DIFF
--- a/src/plugins/owner/ISingleOwnerPlugin.sol
+++ b/src/plugins/owner/ISingleOwnerPlugin.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {IValidation} from "../../interfaces/IValidation.sol";
+import {Signer} from "../../validators/ISignatureValidator.sol";
 
 interface ISingleOwnerPlugin is IValidation {
     enum FunctionId {
@@ -11,27 +12,27 @@ interface ISingleOwnerPlugin is IValidation {
 
     /// @notice This event is emitted when ownership of the account changes.
     /// @param account The account whose ownership changed.
-    /// @param previousOwner The address of the previous owner.
-    /// @param newOwner The address of the new owner.
-    event OwnershipTransferred(address indexed account, address indexed previousOwner, address indexed newOwner);
+    /// @param previousOwner The details of the previous owner.
+    /// @param newOwner The details of the new owner.
+    event OwnershipTransferred(address indexed account, Signer previousOwner, Signer newOwner);
 
     error NotAuthorized();
 
     /// @notice Transfer ownership of the account to `newOwner`.
     /// @dev This function is installed on the account as part of plugin installation, and should
     /// only be called from an account.
-    /// @param newOwner The address of the new owner.
-    function transferOwnership(address newOwner) external;
+    /// @param newOwner The details of the new owner.
+    function transferOwnership(Signer calldata newOwner) external;
 
     /// @notice Get the owner of the account.
     /// @dev This function is installed on the account as part of plugin installation, and should
     /// only be called from an account.
-    /// @return The address of the owner.
-    function owner() external view returns (address);
+    /// @return The details of the owner.
+    function owner() external view returns (Signer memory);
 
     /// @notice Get the owner of `account`.
     /// @dev This function is not installed on the account, and can be called by anyone.
     /// @param account The account to get the owner of.
-    /// @return The address of the owner.
-    function ownerOf(address account) external view returns (address);
+    /// @return The details of the owner.
+    function ownerOf(address account) external view returns (Signer memory);
 }

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
-import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {IPluginManager} from "../../interfaces/IPluginManager.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
 import {
     ManifestFunction,
     ManifestAssociatedFunctionType,
@@ -16,9 +13,11 @@ import {
     PluginMetadata,
     SelectorPermission
 } from "../../interfaces/IPlugin.sol";
-import {IStandardExecutor} from "../../interfaces/IStandardExecutor.sol";
 import {IPlugin} from "../../interfaces/IPlugin.sol";
+import {IPluginManager} from "../../interfaces/IPluginManager.sol";
+import {IStandardExecutor} from "../../interfaces/IStandardExecutor.sol";
 import {IValidation} from "../../interfaces/IValidation.sol";
+import {Signer} from "../../validators/ISignatureValidator.sol";
 import {BasePlugin, IERC165} from "../BasePlugin.sol";
 import {ISingleOwnerPlugin} from "./ISingleOwnerPlugin.sol";
 
@@ -39,9 +38,6 @@ import {ISingleOwnerPlugin} from "./ISingleOwnerPlugin.sol";
 /// owner of a modular account may not be another modular account if you want to
 /// send user operations through a bundler.
 contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
-    using ECDSA for bytes32;
-    using MessageHashUtils for bytes32;
-
     string public constant NAME = "Single Owner Plugin";
     string public constant VERSION = "1.0.0";
     string public constant AUTHOR = "ERC-6900 Authors";
@@ -53,14 +49,14 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
     bytes4 internal constant _1271_MAGIC_VALUE = 0x1626ba7e;
     bytes4 internal constant _1271_INVALID = 0xffffffff;
 
-    mapping(address => address) internal _owners;
+    mapping(address => Signer) internal _owners;
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃    Execution functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
     /// @inheritdoc ISingleOwnerPlugin
-    function transferOwnership(address newOwner) external {
+    function transferOwnership(Signer calldata newOwner) external {
         _transferOwnership(newOwner);
     }
 
@@ -70,19 +66,20 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
 
     /// @inheritdoc IPlugin
     function onInstall(bytes calldata data) external override {
-        _transferOwnership(abi.decode(data, (address)));
+        _transferOwnership(abi.decode(data, (Signer)));
     }
 
     /// @inheritdoc IPlugin
     function onUninstall(bytes calldata) external override {
-        _transferOwnership(address(0));
+        Signer memory empty;
+        _transferOwnership(empty);
     }
 
     /// @inheritdoc IValidation
     function validateRuntime(uint8 functionId, address sender, uint256, bytes calldata) external view override {
         if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
             // Validate that the sender is the owner of the account or self.
-            if (sender != _owners[msg.sender] && sender != msg.sender) {
+            if (sender != abi.decode(_owners[msg.sender].data, (address)) && sender != msg.sender) {
                 revert NotAuthorized();
             }
             return;
@@ -98,12 +95,9 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
         returns (uint256)
     {
         if (functionId == uint8(FunctionId.VALIDATION_OWNER_OR_SELF)) {
-            // Validate the user op signature against the owner.
-            (address signer,,) = (userOpHash.toEthSignedMessageHash()).tryRecover(userOp.signature);
-            if (signer == address(0) || signer != _owners[msg.sender]) {
-                return _SIG_VALIDATION_FAILED;
-            }
-            return _SIG_VALIDATION_PASSED;
+            Signer memory signer = _owners[msg.sender];
+            (bool isValid,) = signer.validator.validate(msg.sender, signer.data, userOpHash, userOp.signature);
+            return isValid ? _SIG_VALIDATION_PASSED : _SIG_VALIDATION_FAILED;
         }
         revert NotImplemented();
     }
@@ -126,16 +120,15 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
         returns (bytes4)
     {
         if (functionId == uint8(FunctionId.SIG_VALIDATION)) {
-            if (SignatureChecker.isValidSignatureNow(_owners[msg.sender], digest, signature)) {
-                return _1271_MAGIC_VALUE;
-            }
-            return _1271_INVALID;
+            Signer memory signer = _owners[msg.sender];
+            (bool isValid,) = signer.validator.validate(msg.sender, signer.data, digest, signature);
+            return isValid ? _1271_MAGIC_VALUE : _1271_INVALID;
         }
         revert NotImplemented();
     }
 
     /// @inheritdoc ISingleOwnerPlugin
-    function owner() external view returns (address) {
+    function owner() external view returns (Signer memory) {
         return _owners[msg.sender];
     }
 
@@ -144,7 +137,7 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
     /// @inheritdoc ISingleOwnerPlugin
-    function ownerOf(address account) external view returns (address) {
+    function ownerOf(address account) external view returns (Signer memory) {
         return _owners[account];
     }
 
@@ -218,8 +211,8 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
     // ┃    Internal / Private functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    function _transferOwnership(address newOwner) internal {
-        address previousOwner = _owners[msg.sender];
+    function _transferOwnership(Signer memory newOwner) internal {
+        Signer memory previousOwner = _owners[msg.sender];
         _owners[msg.sender] = newOwner;
         emit OwnershipTransferred(msg.sender, previousOwner, newOwner);
     }

--- a/src/validators/ERC1271Validator.sol
+++ b/src/validators/ERC1271Validator.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
+import {ISignatureValidator} from "./ISignatureValidator.sol";
+
+contract ERC1271Validator is ISignatureValidator {
+    /// @dev Code inherited from function `isValidERC1271SignatureNow` in
+    /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v5.0/contracts/utils/cryptography/SignatureChecker.sol
+    function validate(address, bytes memory signerData, bytes32 hash, bytes memory signature)
+        external
+        view
+        returns (bool isValid, bytes memory result)
+    {
+        address signer = abi.decode(signerData, (address));
+
+        (isValid, result) = signer.staticcall(abi.encodeCall(IERC1271.isValidSignature, (hash, signature)));
+        isValid = (
+            isValid && result.length >= 32
+                && abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector)
+        );
+    }
+
+    function encodeSignerData(address signer) external pure returns (bytes memory data) {
+        data = abi.encode(signer);
+    }
+}

--- a/src/validators/ISignatureValidator.sol
+++ b/src/validators/ISignatureValidator.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {IPlugin} from "../interfaces/IPlugin.sol";
+
+struct Signer {
+    ISignatureValidator validator;
+    bytes data;
+}
+
+interface ISignatureValidator {
+    function validate(address account, bytes memory signerData, bytes32 hash, bytes memory signature)
+        external
+        view
+        returns (bool isValid, bytes memory result);
+}

--- a/src/validators/Secp256k1Validator.sol
+++ b/src/validators/Secp256k1Validator.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import {ISignatureValidator} from "./ISignatureValidator.sol";
+
+contract Secp256k1Validator is ISignatureValidator {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
+
+    function validate(address, bytes memory signerData, bytes32 hash, bytes memory signature)
+        external
+        pure
+        returns (bool isValid, bytes memory result)
+    {
+        bytes32 messageHash = hash.toEthSignedMessageHash();
+        address expectedSigner = abi.decode(signerData, (address));
+
+        address signer = messageHash.recover(signature);
+        isValid = signer == expectedSigner;
+        result = abi.encode(signer);
+    }
+
+    function encodeSignerData(address signer) external pure returns (bytes memory data) {
+        data = abi.encode(signer);
+    }
+}


### PR DESCRIPTION
Not ready for review. Just an illustration of composable validation where we have separation between:

1. Signature validation (stateless)
ECDSA (secp256k1, secp256r1)
BLS (alt_bn128, BLS12-381)
Schnorr
ERC-1271
…

2. Authorization rules
1-of-n
m-of-n
Weighted m-of-n
…

In this scheme plugins define authorization rules, which cannot be composed. However we might want to compose a 1-of-n with one of those owners being an m-of-n (without having to deploy a multisig contract to have it be backed by an ERC-1271 validator).
