### PR TITLE
feat: Add various native function checks for plugin installation

### DIFF
--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.sol";
+import {IAggregator} from "@eth-infinitism/account-abstraction/interfaces/IAggregator.sol";
+import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
+
+import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
+import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
+import {IPlugin} from "../interfaces/IPlugin.sol";
+import {IPluginExecutor} from "../interfaces/IPluginExecutor.sol";
+import {IPluginManager} from "../interfaces/IPluginManager.sol";
+import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
+import {IValidation} from "../interfaces/IValidation.sol";
+import {IValidationHook} from "../interfaces/IValidationHook.sol";
+
+/// @dev Library to help to check if a selector is a know function selector of the modular account or ERC-4337
+/// contract.
+library KnownSelectors {
+    function isNativeFunction(bytes4 selector) internal pure returns (bool) {
+        return
+        // check against IAccount methods
+        selector == IAccount.validateUserOp.selector
+        // check against IPluginManager methods
+        || selector == IPluginManager.installPlugin.selector || selector == IPluginManager.uninstallPlugin.selector
+        // check against IERC165 methods
+        || selector == IERC165.supportsInterface.selector
+        // check against UUPSUpgradeable methods
+        || selector == UUPSUpgradeable.proxiableUUID.selector
+            || selector == UUPSUpgradeable.upgradeToAndCall.selector
+        // check against IStandardExecutor methods
+        || selector == IStandardExecutor.execute.selector || selector == IStandardExecutor.executeBatch.selector
+        // check against IPluginExecutor methods
+        || selector == IPluginExecutor.executeFromPlugin.selector
+            || selector == IPluginExecutor.executeFromPluginExternal.selector
+            || selector == IPluginExecutor.executeWithAuthorization.selector
+        // check against IAccountLoupe methods
+        || selector == IAccountLoupe.getExecutionFunctionHandler.selector
+            || selector == IAccountLoupe.getValidations.selector
+            || selector == IAccountLoupe.getExecutionHooks.selector
+            || selector == IAccountLoupe.getPreValidationHooks.selector
+            || selector == IAccountLoupe.getInstalledPlugins.selector;
+    }
+
+    function isErc4337Function(bytes4 selector) internal pure returns (bool) {
+        return selector == IAggregator.validateSignatures.selector
+            || selector == IAggregator.validateUserOpSignature.selector
+            || selector == IAggregator.aggregateSignatures.selector
+            || selector == IPaymaster.validatePaymasterUserOp.selector || selector == IPaymaster.postOp.selector;
+    }
+
+    function isIPluginFunction(bytes4 selector) internal pure returns (bool) {
+        return selector == IPlugin.onInstall.selector || selector == IPlugin.onUninstall.selector
+            || selector == IPlugin.pluginManifest.selector || selector == IPlugin.pluginMetadata.selector
+            || selector == IExecutionHook.preExecutionHook.selector
+            || selector == IExecutionHook.postExecutionHook.selector || selector == IValidation.validateUserOp.selector
+            || selector == IValidation.validateRuntime.selector || selector == IValidation.validateSignature.selector
+            || selector == IValidationHook.preUserOpValidationHook.selector
+            || selector == IValidationHook.preRuntimeValidationHook.selector;
+    }
+}

--- a/test/libraries/KnowSelectors.t.sol
+++ b/test/libraries/KnowSelectors.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.sol";
+import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
+
+import {KnownSelectors} from "../../src/helpers/KnownSelectors.sol";
+import {IPlugin} from "../../src/interfaces/IPlugin.sol";
+
+contract KnownSelectorsTest is Test {
+    function test_isNativeFunction() public {
+        assertTrue(KnownSelectors.isNativeFunction(IAccount.validateUserOp.selector));
+    }
+
+    function test_isErc4337Function() public {
+        assertTrue(KnownSelectors.isErc4337Function(IPaymaster.validatePaymasterUserOp.selector));
+    }
+
+    function test_isIPluginFunction() public {
+        assertTrue(KnownSelectors.isIPluginFunction(IPlugin.pluginMetadata.selector));
+    }
+}


### PR DESCRIPTION

ERC-6900 forbids native function selector collision. This PR adds code to prevent plugins install selectors that are native to the account, ERC-4337 selectors, or selectors should only exist on Plugins.

>If the function selector has already been added or matches the selector of a native function, the function SHOULD revert.
