### PR TITLE
style: [v0.8-develop] propose renaming default to global

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -19,15 +19,15 @@ struct SelectorData {
     // Note that even if this is set to true, user op validation will still be required, otherwise anyone could
     // drain the account of native tokens by wasting gas.
     bool isPublic;
-    // Whether or not a default validation function may be used to validate this function.
-    bool allowDefaultValidation;
+    // Whether or not a global validation function may be used to validate this function.
+    bool allowGlobalValidation;
     // The execution hooks for this function selector.
     EnumerableSet.Bytes32Set executionHooks;
 }
 
 struct ValidationData {
-    // Whether or not this validation can be used as a default validation function.
-    bool isDefault;
+    // Whether or not this validation can be used as a global validation function.
+    bool isGlobal;
     // Whether or not this validation is a signature validator.
     bool isSignatureValidation;
     // How many execution hooks require the UO context.

--- a/src/account/PluginManager2.sol
+++ b/src/account/PluginManager2.sol
@@ -16,7 +16,7 @@ abstract contract PluginManager2 {
     // Index marking the start of the data for the validation function.
     uint8 internal constant _RESERVED_VALIDATION_DATA_INDEX = 255;
 
-    error DefaultValidationAlreadySet(FunctionReference validationFunction);
+    error GlobalValidationAlreadySet(FunctionReference validationFunction);
     error PreValidationAlreadySet(FunctionReference validationFunction, FunctionReference preValidationFunction);
     error ValidationAlreadySet(bytes4 selector, FunctionReference validationFunction);
     error ValidationNotSet(bytes4 selector, FunctionReference validationFunction);
@@ -25,7 +25,7 @@ abstract contract PluginManager2 {
 
     function _installValidation(
         FunctionReference validationFunction,
-        bool isDefault,
+        bool isGlobal,
         bytes4[] memory selectors,
         bytes calldata installData,
         bytes memory preValidationHooks,
@@ -80,11 +80,11 @@ abstract contract PluginManager2 {
             }
         }
 
-        if (isDefault) {
-            if (_storage.validationData[validationFunction].isDefault) {
-                revert DefaultValidationAlreadySet(validationFunction);
+        if (isGlobal) {
+            if (_storage.validationData[validationFunction].isGlobal) {
+                revert GlobalValidationAlreadySet(validationFunction);
             }
-            _storage.validationData[validationFunction].isDefault = true;
+            _storage.validationData[validationFunction].isGlobal = true;
         }
 
         for (uint256 i = 0; i < selectors.length; ++i) {
@@ -108,7 +108,7 @@ abstract contract PluginManager2 {
     ) internal {
         AccountStorage storage _storage = getAccountStorage();
 
-        _storage.validationData[validationFunction].isDefault = false;
+        _storage.validationData[validationFunction].isGlobal = false;
         _storage.validationData[validationFunction].isSignatureValidation = false;
 
         {

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -33,7 +33,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
     // Storage update operations
 
-    function _setExecutionFunction(bytes4 selector, bool isPublic, bool allowDefaultValidation, address plugin)
+    function _setExecutionFunction(bytes4 selector, bool isPublic, bool allowGlobalValidation, address plugin)
         internal
     {
         SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
@@ -64,7 +64,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         _selectorData.plugin = plugin;
         _selectorData.isPublic = isPublic;
-        _selectorData.allowDefaultValidation = allowDefaultValidation;
+        _selectorData.allowGlobalValidation = allowGlobalValidation;
     }
 
     function _removeExecutionFunction(bytes4 selector) internal {
@@ -72,7 +72,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         _selectorData.plugin = address(0);
         _selectorData.isPublic = false;
-        _selectorData.allowDefaultValidation = false;
+        _selectorData.allowGlobalValidation = false;
     }
 
     function _addValidationFunction(address plugin, ManifestValidation memory mv) internal {
@@ -81,7 +81,7 @@ abstract contract PluginManagerInternals is IPluginManager {
         FunctionReference validationFunction = FunctionReferenceLib.pack(plugin, mv.functionId);
 
         if (mv.isDefault) {
-            _storage.validationData[validationFunction].isDefault = true;
+            _storage.validationData[validationFunction].isGlobal = true;
         }
 
         if (mv.isSignatureValidation) {
@@ -101,7 +101,7 @@ abstract contract PluginManagerInternals is IPluginManager {
 
         FunctionReference validationFunction = FunctionReferenceLib.pack(plugin, mv.functionId);
 
-        _storage.validationData[validationFunction].isDefault = false;
+        _storage.validationData[validationFunction].isGlobal = false;
         _storage.validationData[validationFunction].isSignatureValidation = false;
 
         // Clear the selectors
@@ -168,8 +168,8 @@ abstract contract PluginManagerInternals is IPluginManager {
         for (uint256 i = 0; i < length; ++i) {
             bytes4 selector = manifest.executionFunctions[i].executionSelector;
             bool isPublic = manifest.executionFunctions[i].isPublic;
-            bool allowDefaultValidation = manifest.executionFunctions[i].allowDefaultValidation;
-            _setExecutionFunction(selector, isPublic, allowDefaultValidation, plugin);
+            bool allowGlobalValidation = manifest.executionFunctions[i].allowGlobalValidation;
+            _setExecutionFunction(selector, isPublic, allowGlobalValidation, plugin);
         }
 
         length = manifest.validationFunctions.length;

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -9,8 +9,8 @@ struct ManifestExecutionFunction {
     bytes4 executionSelector;
     // If true, the function won't need runtime validation, and can be called by anyone.
     bool isPublic;
-    // If true, the function can be validated by a default validation function.
-    bool allowDefaultValidation;
+    // If true, the function can be validated by a global validation function.
+    bool allowGlobalValidation;
 }
 
 // todo: do we need these at all? Or do we fully switch to `installValidation`?

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -17,19 +17,19 @@ interface IPluginManager {
 
     /// @notice Temporary install function - pending a different user-supplied install config & manifest validation
     /// path.
-    /// Installs a validation function across a set of execution selectors, and optionally mark it as a default
+    /// Installs a validation function across a set of execution selectors, and optionally mark it as a global
     /// validation.
     /// TODO: remove or update.
     /// @dev This does not validate anything against the manifest - the caller must ensure validity.
     /// @param validationFunction The validation function to install.
-    /// @param isDefault Whether the validation function applies for all selectors in the default pool.
+    /// @param isGlobal Whether the validation function applies for all selectors in the global pool.
     /// @param selectors The selectors to install the validation function for.
     /// @param installData Optional data to be decoded and used by the plugin to setup initial plugin state.
     /// @param preValidationHooks Optional pre-validation hooks to install for the validation function.
     /// @param permissionHooks Optional permission hooks to install for the validation function.
     function installValidation(
         FunctionReference validationFunction,
-        bool isDefault,
+        bool isGlobal,
         bytes4[] memory selectors,
         bytes calldata installData,
         bytes calldata preValidationHooks,

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -62,17 +62,17 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC1155Receiver {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.onERC721Received.selector,
             isPublic: true,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.onERC1155Received.selector,
             isPublic: true,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
         manifest.executionFunctions[2] = ManifestExecutionFunction({
             executionSelector: this.onERC1155BatchReceived.selector,
             isPublic: true,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         manifest.interfaceIds = new bytes4[](2);

--- a/src/plugins/owner/SingleOwnerPlugin.sol
+++ b/src/plugins/owner/SingleOwnerPlugin.sol
@@ -151,7 +151,7 @@ contract SingleOwnerPlugin is ISingleOwnerPlugin, BasePlugin {
     function pluginManifest() external pure override returns (PluginManifest memory) {
         PluginManifest memory manifest;
 
-        // TODO: use default validation instead
+        // TODO: use global validation instead
         bytes4[] memory accountSelectors = new bytes4[](5);
         accountSelectors[0] = IStandardExecutor.execute.selector;
         accountSelectors[1] = IStandardExecutor.executeBatch.selector;

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -36,7 +36,7 @@ contract AccountExecHooksTest is AccountTestBase {
             ManifestExecutionFunction({
                 executionSelector: _EXEC_SELECTOR,
                 isPublic: true,
-                allowDefaultValidation: false
+                allowGlobalValidation: false
             })
         );
     }

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -7,19 +7,19 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
-import {DefaultValidationFactoryFixture} from "../mocks/DefaultValidationFactoryFixture.sol";
+import {GlobalValidationFactoryFixture} from "../mocks/GlobalValidationFactoryFixture.sol";
 
-contract DefaultValidationTest is AccountTestBase {
+contract GlobalValidationTest is AccountTestBase {
     using MessageHashUtils for bytes32;
 
-    DefaultValidationFactoryFixture public defaultValidationFactoryFixture;
+    GlobalValidationFactoryFixture public globalValidationFactoryFixture;
 
     address public ethRecipient;
 
     function setUp() public {
-        defaultValidationFactoryFixture = new DefaultValidationFactoryFixture(entryPoint, singleOwnerPlugin);
+        globalValidationFactoryFixture = new GlobalValidationFactoryFixture(entryPoint, singleOwnerPlugin);
 
-        account1 = UpgradeableModularAccount(payable(defaultValidationFactoryFixture.getAddress(owner1, 0)));
+        account1 = UpgradeableModularAccount(payable(globalValidationFactoryFixture.getAddress(owner1, 0)));
 
         vm.deal(address(account1), 100 ether);
 
@@ -27,13 +27,13 @@ contract DefaultValidationTest is AccountTestBase {
         vm.deal(ethRecipient, 1 wei);
     }
 
-    function test_defaultValidation_userOp_simple() public {
+    function test_globalValidation_userOp_simple() public {
         PackedUserOperation memory userOp = PackedUserOperation({
             sender: address(account1),
             nonce: 0,
             initCode: abi.encodePacked(
-                defaultValidationFactoryFixture,
-                abi.encodeCall(DefaultValidationFactoryFixture.createAccount, (owner1, 0))
+                globalValidationFactoryFixture,
+                abi.encodeCall(globalValidationFactoryFixture.createAccount, (owner1, 0))
             ),
             callData: abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
@@ -46,7 +46,7 @@ contract DefaultValidationTest is AccountTestBase {
         // Generate signature
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-        userOp.signature = _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, abi.encodePacked(r, s, v));
+        userOp.signature = _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -56,14 +56,14 @@ contract DefaultValidationTest is AccountTestBase {
         assertEq(ethRecipient.balance, 2 wei);
     }
 
-    function test_defaultValidation_runtime_simple() public {
+    function test_globalValidation_runtime_simple() public {
         // Deploy the account first
-        defaultValidationFactoryFixture.createAccount(owner1, 0);
+        globalValidationFactoryFixture.createAccount(owner1, 0);
 
         vm.prank(owner1);
         account1.executeWithAuthorization(
             abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, "")
         );
 
         assertEq(ethRecipient.balance, 2 wei);

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -37,9 +37,8 @@ contract PerHookDataTest is CustomValidationTestBase {
         PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
         preValidationHookData[0] = PreValidationHookData({index: 0, validationData: abi.encodePacked(_counter)});
 
-        userOp.signature = _encodeSignature(
-            _ownerValidation, DEFAULT_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v)
-        );
+        userOp.signature =
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -60,9 +59,8 @@ contract PerHookDataTest is CustomValidationTestBase {
             validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
         });
 
-        userOp.signature = _encodeSignature(
-            _ownerValidation, DEFAULT_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v)
-        );
+        userOp.signature =
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -82,7 +80,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         (PackedUserOperation memory userOp, bytes32 userOpHash) = _getCounterUserOP();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
 
-        userOp.signature = _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, abi.encodePacked(r, s, v));
+        userOp.signature = _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -106,9 +104,8 @@ contract PerHookDataTest is CustomValidationTestBase {
         preValidationHookData[0] = PreValidationHookData({index: 0, validationData: abi.encodePacked(_counter)});
         preValidationHookData[1] = PreValidationHookData({index: 1, validationData: abi.encodePacked(_counter)});
 
-        userOp.signature = _encodeSignature(
-            _ownerValidation, DEFAULT_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v)
-        );
+        userOp.signature =
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -145,9 +142,8 @@ contract PerHookDataTest is CustomValidationTestBase {
         PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
         preValidationHookData[0] = PreValidationHookData({index: 0, validationData: abi.encodePacked(beneficiary)});
 
-        userOp.signature = _encodeSignature(
-            _ownerValidation, DEFAULT_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v)
-        );
+        userOp.signature =
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -170,9 +166,8 @@ contract PerHookDataTest is CustomValidationTestBase {
         PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
         preValidationHookData[0] = PreValidationHookData({index: 0, validationData: ""});
 
-        userOp.signature = _encodeSignature(
-            _ownerValidation, DEFAULT_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v)
-        );
+        userOp.signature =
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -200,7 +195,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 UpgradeableModularAccount.execute,
                 (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, preValidationHookData, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
 
         assertEq(_counter.number(), 1);
@@ -227,7 +222,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 UpgradeableModularAccount.execute,
                 (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, preValidationHookData, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
     }
 
@@ -246,7 +241,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 UpgradeableModularAccount.execute,
                 (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, "")
         );
     }
 
@@ -264,7 +259,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 UpgradeableModularAccount.execute,
                 (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, preValidationHookData, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
     }
 
@@ -285,7 +280,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithAuthorization(
             abi.encodeCall(UpgradeableModularAccount.execute, (beneficiary, 1 wei, "")),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, preValidationHookData, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
     }
 
@@ -300,7 +295,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 UpgradeableModularAccount.execute,
                 (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, preValidationHookData, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
     }
 

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -10,20 +10,20 @@ import {IStandardExecutor, Call} from "../../src/interfaces/IStandardExecutor.so
 import {FunctionReference, FunctionReferenceLib} from "../../src/helpers/FunctionReferenceLib.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
-import {DefaultValidationFactoryFixture} from "../mocks/DefaultValidationFactoryFixture.sol";
+import {GlobalValidationFactoryFixture} from "../mocks/GlobalValidationFactoryFixture.sol";
 import {ComprehensivePlugin} from "../mocks/plugins/ComprehensivePlugin.sol";
 
 contract SelfCallAuthorizationTest is AccountTestBase {
-    DefaultValidationFactoryFixture public defaultValidationFactoryFixture;
+    GlobalValidationFactoryFixture public globalValidationFactoryFixture;
 
     ComprehensivePlugin public comprehensivePlugin;
 
     FunctionReference public comprehensivePluginValidation;
 
     function setUp() public {
-        defaultValidationFactoryFixture = new DefaultValidationFactoryFixture(entryPoint, singleOwnerPlugin);
+        globalValidationFactoryFixture = new GlobalValidationFactoryFixture(entryPoint, singleOwnerPlugin);
 
-        account1 = UpgradeableModularAccount(payable(defaultValidationFactoryFixture.createAccount(owner1, 0)));
+        account1 = UpgradeableModularAccount(payable(globalValidationFactoryFixture.createAccount(owner1, 0)));
 
         vm.deal(address(account1), 100 ether);
 
@@ -41,7 +41,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     }
 
     function test_selfCallFails_userOp() public {
-        // Uses default validation
+        // Uses global validation
         _runUserOp(
             abi.encodeCall(ComprehensivePlugin.foo, ()),
             abi.encodeWithSelector(
@@ -57,7 +57,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     }
 
     function test_selfCallFails_execUserOp() public {
-        // Uses default validation
+        // Uses global validation
         _runUserOp(
             abi.encodePacked(IAccountExecute.executeUserOp.selector, abi.encodeCall(ComprehensivePlugin.foo, ())),
             abi.encodeWithSelector(
@@ -73,7 +73,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     }
 
     function test_selfCallFails_runtime() public {
-        // Uses default validation
+        // Uses global validation
         _runtimeCall(
             abi.encodeCall(ComprehensivePlugin.foo, ()),
             abi.encodeWithSelector(
@@ -84,7 +84,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     }
 
     function test_selfCallPrivilegeEscalation_prevented_userOp() public {
-        // Using default validation, self-call bypasses custom validation needed for ComprehensivePlugin.foo
+        // Using global validation, self-call bypasses custom validation needed for ComprehensivePlugin.foo
         _runUserOp(
             abi.encodeCall(
                 UpgradeableModularAccount.execute,
@@ -116,7 +116,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     }
 
     function test_selfCallPrivilegeEscalation_prevented_execUserOp() public {
-        // Using default validation, self-call bypasses custom validation needed for ComprehensivePlugin.foo
+        // Using global validation, self-call bypasses custom validation needed for ComprehensivePlugin.foo
         _runUserOp(
             abi.encodePacked(
                 IAccountExecute.executeUserOp.selector,
@@ -153,7 +153,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     }
 
     function test_selfCallPrivilegeEscalation_prevented_runtime() public {
-        // Using default validation, self-call bypasses custom validation needed for ComprehensivePlugin.foo
+        // Using global validation, self-call bypasses custom validation needed for ComprehensivePlugin.foo
         _runtimeCall(
             abi.encodeCall(
                 UpgradeableModularAccount.execute,
@@ -312,7 +312,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 UpgradeableModularAccount.installValidation,
                 (comprehensivePluginValidation, false, selectors, "", "", "")
             ),
-            _encodeSignature(_ownerValidation, DEFAULT_VALIDATION, "")
+            _encodeSignature(_ownerValidation, GLOBAL_VALIDATION, "")
         );
     }
 

--- a/test/mocks/GlobalValidationFactoryFixture.sol
+++ b/test/mocks/GlobalValidationFactoryFixture.sol
@@ -12,7 +12,7 @@ import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 
 import {OptimizedTest} from "../utils/OptimizedTest.sol";
 
-contract DefaultValidationFactoryFixture is OptimizedTest {
+contract GlobalValidationFactoryFixture is OptimizedTest {
     UpgradeableModularAccount public accountImplementation;
     SingleOwnerPlugin public singleOwnerPlugin;
     bytes32 private immutable _PROXY_BYTECODE_HASH;

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -137,7 +137,7 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: false,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         bytes4[] memory validationSelectors = new bytes4[](1);

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -44,12 +44,12 @@ contract ResultCreatorPlugin is BasePlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: true,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.bar.selector,
             isPublic: false,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         return manifest;
@@ -131,12 +131,12 @@ contract ResultConsumerPlugin is BasePlugin, IValidation {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.checkResultFallback.selector,
             isPublic: true,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.checkResultExecuteWithAuthorization.selector,
             isPublic: true,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         return manifest;

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -100,7 +100,7 @@ contract MockUserOpValidationPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.foo.selector,
             isPublic: false,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         bytes4[] memory validationSelectors = new bytes4[](1);
@@ -143,7 +143,7 @@ contract MockUserOpValidation1HookPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.bar.selector,
             isPublic: false,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         bytes4[] memory validationSelectors = new bytes4[](1);
@@ -189,7 +189,7 @@ contract MockUserOpValidation2HookPlugin is MockBaseUserOpValidationPlugin {
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.baz.selector,
             isPublic: false,
-            allowDefaultValidation: false
+            allowGlobalValidation: false
         });
 
         bytes4[] memory validationSelectors = new bytes4[](1);

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -33,7 +33,7 @@ abstract contract AccountTestBase is OptimizedTest {
     FunctionReference internal _ownerValidation;
 
     uint8 public constant SELECTOR_ASSOCIATED_VALIDATION = 0;
-    uint8 public constant DEFAULT_VALIDATION = 1;
+    uint8 public constant GLOBAL_VALIDATION = 1;
 
     uint256 public constant CALL_GAS_LIMIT = 100000;
     uint256 public constant VERIFICATION_GAS_LIMIT = 1200000;
@@ -102,7 +102,7 @@ abstract contract AccountTestBase is OptimizedTest {
             FunctionReferenceLib.pack(
                 address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
             ),
-            DEFAULT_VALIDATION,
+            GLOBAL_VALIDATION,
             abi.encodePacked(r, s, v)
         );
 
@@ -157,7 +157,7 @@ abstract contract AccountTestBase is OptimizedTest {
                 FunctionReferenceLib.pack(
                     address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
                 ),
-                DEFAULT_VALIDATION,
+                GLOBAL_VALIDATION,
                 ""
             )
         );
@@ -174,7 +174,7 @@ abstract contract AccountTestBase is OptimizedTest {
                 FunctionReferenceLib.pack(
                     address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.VALIDATION_OWNER)
                 ),
-                DEFAULT_VALIDATION,
+                GLOBAL_VALIDATION,
                 ""
             )
         );
@@ -210,11 +210,11 @@ abstract contract AccountTestBase is OptimizedTest {
     // helper function to encode a signature, according to the per-hook and per-validation data format.
     function _encodeSignature(
         FunctionReference validationFunction,
-        uint8 defaultOrNot,
+        uint8 globalOrNot,
         PreValidationHookData[] memory preValidationHookData,
         bytes memory validationData
     ) internal pure returns (bytes memory) {
-        bytes memory sig = abi.encodePacked(validationFunction, defaultOrNot);
+        bytes memory sig = abi.encodePacked(validationFunction, globalOrNot);
 
         for (uint256 i = 0; i < preValidationHookData.length; ++i) {
             sig = abi.encodePacked(
@@ -233,13 +233,13 @@ abstract contract AccountTestBase is OptimizedTest {
     }
 
     // overload for the case where there are no pre-validation hooks
-    function _encodeSignature(
-        FunctionReference validationFunction,
-        uint8 defaultOrNot,
-        bytes memory validationData
-    ) internal pure returns (bytes memory) {
+    function _encodeSignature(FunctionReference validationFunction, uint8 globalOrNot, bytes memory validationData)
+        internal
+        pure
+        returns (bytes memory)
+    {
         PreValidationHookData[] memory emptyPreValidationHookData = new PreValidationHookData[](0);
-        return _encodeSignature(validationFunction, defaultOrNot, emptyPreValidationHookData, validationData);
+        return _encodeSignature(validationFunction, globalOrNot, emptyPreValidationHookData, validationData);
     }
 
     // helper function to pack validation data with an index, according to the sparse calldata segment spec.


### PR DESCRIPTION
## Motivation

As discussed in the working group sync, the default validation PR #63, and other [PR comments](https://github.com/erc6900/reference-implementation/pull/64#discussion_r1647578066), we may want to avoid using the term "default" when discussing default validation. Specifically, default implies that there is one specific validation used across many execution functions, and that it will be selected automatically, which are not the case.

## Proposed Solution

One possible rename is to convert it to the term "global". This gets rid of the downsides of the term "default". However, it may carry the connotation that a "global" validation function applies to all functions, but in reality, a function must opt in to this validation.

Putting up this PR to discuss the proposed name change. Personally I'm OK with either.