### PR TITLE
style: [v0.8-develop] linter and fmt update

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -47,6 +47,9 @@ depth = 32
 [fmt]
 line_length = 115
 wrap_comments = true
+sort_imports = true
+number_underscore = "thousands"
+int_types = "long"
 
 [rpc_endpoints]
 mainnet = "${RPC_URL_MAINNET}"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "scripts": {
     "lint": "pnpm lint:src && pnpm lint:test",
-    "lint:src": "solhint -c .solhint-src.json './src/**/*.sol'",
-    "lint:test": "solhint -c .solhint-test.json './test/**/*.sol'"
+    "lint:src": "solhint --max-warnings 0 -c .solhint-src.json './src/**/*.sol'",
+    "lint:test": "solhint --max-warnings 0 -c .solhint-test.json './test/**/*.sol'"
   }
 }

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.25;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
-import {IAccountLoupe, ExecutionHook} from "../interfaces/IAccountLoupe.sol";
-import {PluginEntity, IPluginManager} from "../interfaces/IPluginManager.sol";
+import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import {ExecutionHook, IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
+import {IPluginManager, PluginEntity} from "../interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 import {getAccountStorage, toExecutionHook, toSelector} from "./AccountStorage.sol";
 

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
 import {PluginEntity} from "../interfaces/IPluginManager.sol";

--- a/src/account/PluginManager2.sol
+++ b/src/account/PluginManager2.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.25;
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {IPlugin} from "../interfaces/IPlugin.sol";
-import {PluginEntity, ValidationConfig} from "../interfaces/IPluginManager.sol";
 import {PluginEntityLib} from "../helpers/PluginEntityLib.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
-import {ValidationData, getAccountStorage, toSetValue} from "./AccountStorage.sol";
+
 import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
+import {IPlugin} from "../interfaces/IPlugin.sol";
+import {PluginEntity, ValidationConfig} from "../interfaces/IPluginManager.sol";
+import {ValidationData, getAccountStorage, toSetValue} from "./AccountStorage.sol";
 
 // Temporary additional functions for a user-controlled install flow for validation functions.
 abstract contract PluginManager2 {

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -2,15 +2,16 @@
 pragma solidity ^0.8.25;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
-import {PluginEntityLib} from "../helpers/PluginEntityLib.sol";
-import {IPlugin, ManifestExecutionHook, ManifestValidation, PluginManifest} from "../interfaces/IPlugin.sol";
-import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
-import {PluginEntity, IPluginManager} from "../interfaces/IPluginManager.sol";
+import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 import {KnownSelectors} from "../helpers/KnownSelectors.sol";
-import {AccountStorage, getAccountStorage, SelectorData, toSetValue} from "./AccountStorage.sol";
+import {PluginEntityLib} from "../helpers/PluginEntityLib.sol";
+import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
+import {IPlugin, ManifestExecutionHook, ManifestValidation, PluginManifest} from "../interfaces/IPlugin.sol";
+import {IPluginManager, PluginEntity} from "../interfaces/IPluginManager.sol";
+import {AccountStorage, SelectorData, getAccountStorage, toSetValue} from "./AccountStorage.sol";
 
 abstract contract PluginManagerInternals is IPluginManager {
     using EnumerableSet for EnumerableSet.Bytes32Set;

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -2,30 +2,35 @@
 pragma solidity ^0.8.25;
 
 import {BaseAccount} from "@eth-infinitism/account-abstraction/core/BaseAccount.sol";
+
+import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IAccountExecute.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
-import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IAccountExecute.sol";
+
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {PluginEntityLib} from "../helpers/PluginEntityLib.sol";
-import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
+
 import {SparseCalldataSegmentLib} from "../helpers/SparseCalldataSegmentLib.sol";
+import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationResHelpers.sol";
+
+import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
 import {IPlugin, PluginManifest} from "../interfaces/IPlugin.sol";
+import {IPluginManager, PluginEntity, ValidationConfig} from "../interfaces/IPluginManager.sol";
+import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 import {IValidation} from "../interfaces/IValidation.sol";
 import {IValidationHook} from "../interfaces/IValidationHook.sol";
-import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
-import {PluginEntity, IPluginManager, ValidationConfig} from "../interfaces/IPluginManager.sol";
-import {IStandardExecutor, Call} from "../interfaces/IStandardExecutor.sol";
 import {AccountExecutor} from "./AccountExecutor.sol";
 import {AccountLoupe} from "./AccountLoupe.sol";
-import {AccountStorage, getAccountStorage, toSetValue, toExecutionHook} from "./AccountStorage.sol";
+import {AccountStorage, getAccountStorage, toExecutionHook, toSetValue} from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
-import {PluginManagerInternals} from "./PluginManagerInternals.sol";
+
 import {PluginManager2} from "./PluginManager2.sol";
+import {PluginManagerInternals} from "./PluginManagerInternals.sol";
 
 contract UpgradeableModularAccount is
     AccountExecutor,

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.sol";
 import {IAggregator} from "@eth-infinitism/account-abstraction/interfaces/IAggregator.sol";
 import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";

--- a/src/plugins/BasePlugin.sol
+++ b/src/plugins/BasePlugin.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IAccountExecute.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {IPlugin} from "../interfaces/IPlugin.sol";
 

--- a/src/plugins/ERC20TokenLimitPlugin.sol
+++ b/src/plugins/ERC20TokenLimitPlugin.sol
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {UserOperationLib} from "@eth-infinitism/account-abstraction/core/UserOperationLib.sol";
-import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {
-    SetValue,
-    AssociatedLinkedListSet,
-    AssociatedLinkedListSetLib
-} from "@modular-account-libs/libraries/AssociatedLinkedListSetLib.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {PluginManifest, PluginMetadata} from "../interfaces/IPlugin.sol";
-import {IStandardExecutor, Call} from "../interfaces/IStandardExecutor.sol";
-import {IPlugin} from "../interfaces/IPlugin.sol";
+import {
+    AssociatedLinkedListSet,
+    AssociatedLinkedListSetLib,
+    SetValue
+} from "@modular-account-libs/libraries/AssociatedLinkedListSetLib.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
+import {PluginManifest, PluginMetadata} from "../interfaces/IPlugin.sol";
+import {IPlugin} from "../interfaces/IPlugin.sol";
+import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
+
 import {BasePlugin, IERC165} from "./BasePlugin.sol";
 
 /// @title ERC20 Token Limit Plugin

--- a/src/plugins/NativeTokenLimitPlugin.sol
+++ b/src/plugins/NativeTokenLimitPlugin.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {UserOperationLib} from "@eth-infinitism/account-abstraction/core/UserOperationLib.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {PluginManifest, PluginMetadata} from "../interfaces/IPlugin.sol";
-import {IStandardExecutor, Call} from "../interfaces/IStandardExecutor.sol";
-import {IPlugin} from "../interfaces/IPlugin.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
+import {PluginManifest, PluginMetadata} from "../interfaces/IPlugin.sol";
+import {IPlugin} from "../interfaces/IPlugin.sol";
+import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
+
 import {IValidationHook} from "../interfaces/IValidationHook.sol";
 import {BasePlugin, IERC165} from "./BasePlugin.sol";
 

--- a/src/plugins/TokenReceiverPlugin.sol
+++ b/src/plugins/TokenReceiverPlugin.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 import {IPlugin, ManifestExecutionFunction, PluginManifest, PluginMetadata} from "../interfaces/IPlugin.sol";
 import {BasePlugin} from "./BasePlugin.sol";
@@ -12,9 +12,9 @@ import {BasePlugin} from "./BasePlugin.sol";
 /// @notice This plugin allows modular accounts to receive various types of tokens by implementing
 /// required token receiver interfaces.
 contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC1155Receiver {
-    string public constant NAME = "Token Receiver Plugin";
-    string public constant VERSION = "1.0.0";
-    string public constant AUTHOR = "ERC-6900 Authors";
+    string internal constant _NAME = "Token Receiver Plugin";
+    string internal constant _VERSION = "1.0.0";
+    string internal constant _AUTHOR = "ERC-6900 Authors";
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃    Execution functions    ┃
@@ -85,9 +85,9 @@ contract TokenReceiverPlugin is BasePlugin, IERC721Receiver, IERC1155Receiver {
     /// @inheritdoc IPlugin
     function pluginMetadata() external pure virtual override returns (PluginMetadata memory) {
         PluginMetadata memory metadata;
-        metadata.name = NAME;
-        metadata.version = VERSION;
-        metadata.author = AUTHOR;
+        metadata.name = _NAME;
+        metadata.version = _VERSION;
+        metadata.author = _AUTHOR;
         return metadata;
     }
 }

--- a/src/plugins/validation/SingleSignerValidation.sol
+++ b/src/plugins/validation/SingleSignerValidation.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 import {IPlugin, PluginManifest, PluginMetadata} from "../../interfaces/IPlugin.sol";
@@ -28,9 +28,9 @@ contract SingleSignerValidation is ISingleSignerValidation, BasePlugin {
     using ECDSA for bytes32;
     using MessageHashUtils for bytes32;
 
-    string public constant NAME = "SingleSigner Validation";
-    string public constant VERSION = "1.0.0";
-    string public constant AUTHOR = "ERC-6900 Authors";
+    string internal constant _NAME = "SingleSigner Validation";
+    string internal constant _VERSION = "1.0.0";
+    string internal constant _AUTHOR = "ERC-6900 Authors";
 
     uint256 internal constant _SIG_VALIDATION_PASSED = 0;
     uint256 internal constant _SIG_VALIDATION_FAILED = 1;
@@ -42,32 +42,8 @@ contract SingleSignerValidation is ISingleSignerValidation, BasePlugin {
     mapping(uint32 entityId => mapping(address account => address)) public signer;
 
     /// @inheritdoc ISingleSignerValidation
-    function signerOf(uint32 entityId, address account) external view returns (address) {
-        return signer[entityId][account];
-    }
-
-    /// @inheritdoc ISingleSignerValidation
     function transferSigner(uint32 entityId, address newSigner) external {
         _transferSigner(entityId, newSigner);
-    }
-
-    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    // ┃    Plugin interface functions    ┃
-    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-    /// @inheritdoc IPlugin
-    function pluginManifest() external pure override returns (PluginManifest memory) {
-        PluginManifest memory manifest;
-        return manifest;
-    }
-
-    /// @inheritdoc IPlugin
-    function pluginMetadata() external pure virtual override returns (PluginMetadata memory) {
-        PluginMetadata memory metadata;
-        metadata.name = NAME;
-        metadata.version = VERSION;
-        metadata.author = AUTHOR;
-        return metadata;
     }
 
     /// @inheritdoc IPlugin
@@ -81,6 +57,11 @@ contract SingleSignerValidation is ISingleSignerValidation, BasePlugin {
         // ToDo: what does it mean in the world of composable validation world to uninstall one type of validation
         // We can either get rid of all SingleSigner signers. What about the nested ones?
         _transferSigner(abi.decode(data, (uint32)), address(0));
+    }
+
+    /// @inheritdoc ISingleSignerValidation
+    function signerOf(uint32 entityId, address account) external view returns (address) {
+        return signer[entityId][account];
     }
 
     /// @inheritdoc IValidation
@@ -131,6 +112,25 @@ contract SingleSignerValidation is ISingleSignerValidation, BasePlugin {
             return _1271_MAGIC_VALUE;
         }
         return _1271_INVALID;
+    }
+
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃    Plugin interface functions    ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+    /// @inheritdoc IPlugin
+    function pluginManifest() external pure override returns (PluginManifest memory) {
+        PluginManifest memory manifest;
+        return manifest;
+    }
+
+    /// @inheritdoc IPlugin
+    function pluginMetadata() external pure virtual override returns (PluginMetadata memory) {
+        PluginMetadata memory metadata;
+        metadata.name = _NAME;
+        metadata.version = _VERSION;
+        metadata.author = _AUTHOR;
+        return metadata;
     }
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/src/samples/permissionhooks/AllowlistPlugin.sol
+++ b/src/samples/permissionhooks/AllowlistPlugin.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.25;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {PluginMetadata, PluginManifest} from "../../interfaces/IPlugin.sol";
+import {PluginManifest, PluginMetadata} from "../../interfaces/IPlugin.sol";
+
+import {Call, IStandardExecutor} from "../../interfaces/IStandardExecutor.sol";
 import {IValidationHook} from "../../interfaces/IValidationHook.sol";
-import {IStandardExecutor, Call} from "../../interfaces/IStandardExecutor.sol";
 import {BasePlugin} from "../../plugins/BasePlugin.sol";
 
 contract AllowlistPlugin is IValidationHook, BasePlugin {

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
+import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
 import {
     IPlugin,
-    ManifestExecutionHook,
     ManifestExecutionFunction,
+    ManifestExecutionHook,
     PluginManifest
 } from "../../src/interfaces/IPlugin.sol";
-import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
 
 import {MockPlugin} from "../mocks/MockPlugin.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -6,8 +6,8 @@ import {Call} from "../../src/interfaces/IStandardExecutor.sol";
 
 import {
     RegularResultContract,
-    ResultCreatorPlugin,
-    ResultConsumerPlugin
+    ResultConsumerPlugin,
+    ResultCreatorPlugin
 } from "../mocks/plugins/ReturnDataPluginMocks.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";

--- a/test/account/DirectCallsFromPlugin.t.sol
+++ b/test/account/DirectCallsFromPlugin.t.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.8.19;
 
-import {DirectCallPlugin} from "../mocks/plugins/DirectCallPlugin.sol";
-import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
-import {IStandardExecutor, Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {PluginEntityLib, PluginEntity} from "../../src/helpers/PluginEntityLib.sol";
-import {ValidationConfig, ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
+import {ValidationConfig, ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
+import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
+import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
+import {DirectCallPlugin} from "../mocks/plugins/DirectCallPlugin.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.21;
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {PluginEntity} from "../../src/interfaces/IPluginManager.sol";
-import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
+
 import {PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
+import {PluginEntity} from "../../src/interfaces/IPluginManager.sol";
+import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.25;
 
-import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
 
-import {MockAccessControlHookPlugin} from "../mocks/plugins/MockAccessControlHookPlugin.sol";
 import {Counter} from "../mocks/Counter.sol";
+import {MockAccessControlHookPlugin} from "../mocks/plugins/MockAccessControlHookPlugin.sol";
 import {CustomValidationTestBase} from "../utils/CustomValidationTestBase.sol";
 
 contract PerHookDataTest is CustomValidationTestBase {

--- a/test/account/PermittedCallPermissions.t.sol
+++ b/test/account/PermittedCallPermissions.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.19;
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
-import {ResultCreatorPlugin} from "../mocks/plugins/ReturnDataPluginMocks.sol";
 import {PermittedCallerPlugin} from "../mocks/plugins/PermittedCallMocks.sol";
+import {ResultCreatorPlugin} from "../mocks/plugins/ReturnDataPluginMocks.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
 contract PermittedCallPermissionsTest is AccountTestBase {

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -6,12 +6,13 @@ import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntry
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {IStandardExecutor, Call} from "../../src/interfaces/IStandardExecutor.sol";
+
 import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
+import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 
-import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {ComprehensivePlugin} from "../mocks/plugins/ComprehensivePlugin.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
 contract SelfCallAuthorizationTest is AccountTestBase {
     ComprehensivePlugin public comprehensivePlugin;

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -3,23 +3,27 @@ pragma solidity ^0.8.19;
 
 import {console} from "forge-std/Test.sol";
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
-import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {PluginManifest} from "../../src/interfaces/IPlugin.sol";
+
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
+import {PluginManifest} from "../../src/interfaces/IPlugin.sol";
 import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
+
 import {TokenReceiverPlugin} from "../../src/plugins/TokenReceiverPlugin.sol";
+import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
 
 import {Counter} from "../mocks/Counter.sol";
-import {ComprehensivePlugin} from "../mocks/plugins/ComprehensivePlugin.sol";
+
 import {MockPlugin} from "../mocks/MockPlugin.sol";
+import {ComprehensivePlugin} from "../mocks/plugins/ComprehensivePlugin.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";
 

--- a/test/comparison/CompareSimpleAccount.t.sol
+++ b/test/comparison/CompareSimpleAccount.t.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.19;
 
 import {Test} from "forge-std/Test.sol";
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import {SimpleAccount} from "@eth-infinitism/account-abstraction/samples/SimpleAccount.sol";
 import {SimpleAccountFactory} from "@eth-infinitism/account-abstraction/samples/SimpleAccountFactory.sol";
@@ -34,8 +34,8 @@ contract CompareSimpleAccountTest is Test {
 
     Counter public counter;
 
-    uint256 public constant CALL_GAS_LIMIT = 500000;
-    uint256 public constant VERIFICATION_GAS_LIMIT = 500000;
+    uint256 public constant CALL_GAS_LIMIT = 500_000;
+    uint256 public constant VERIFICATION_GAS_LIMIT = 500_000;
 
     // helper function to compress 2 gas values into a single bytes32
     function _encodeGas(uint256 g1, uint256 g2) internal pure returns (bytes32) {

--- a/test/libraries/AccountStorage.t.sol
+++ b/test/libraries/AccountStorage.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {Test} from "forge-std/Test.sol";
 import {_ACCOUNT_STORAGE_SLOT} from "../../src/account/AccountStorage.sol";
 import {AccountStorageInitializable} from "../../src/account/AccountStorageInitializable.sol";
 import {MockDiamondStorageContract} from "../mocks/MockDiamondStorageContract.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Test} from "forge-std/Test.sol";
 
 // Test implementation of AccountStorageInitializable which is contained in UpgradeableModularAccount
 contract AccountStorageTest is Test {

--- a/test/libraries/KnowSelectors.t.sol
+++ b/test/libraries/KnowSelectors.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {Test} from "forge-std/Test.sol";
 import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.sol";
 import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {KnownSelectors} from "../../src/helpers/KnownSelectors.sol";
 import {IPlugin} from "../../src/interfaces/IPlugin.sol";

--- a/test/mocks/Counter.t.sol
+++ b/test/mocks/Counter.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {Test} from "forge-std/Test.sol";
 import {Counter} from "./Counter.sol";
+import {Test} from "forge-std/Test.sol";
 
 contract CounterTest is Test {
     Counter public counter;

--- a/test/mocks/MockPlugin.sol
+++ b/test/mocks/MockPlugin.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.19;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {PluginManifest, IPlugin, PluginMetadata} from "../../src/interfaces/IPlugin.sol";
-import {IValidation} from "../../src/interfaces/IValidation.sol";
 import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
+import {IPlugin, PluginManifest, PluginMetadata} from "../../src/interfaces/IPlugin.sol";
+import {IValidation} from "../../src/interfaces/IValidation.sol";
 
 contract MockPlugin is ERC165 {
     // It's super inefficient to hold the entire abi-encoded manifest in storage, but this is fine since it's
@@ -17,9 +17,9 @@ contract MockPlugin is ERC165 {
     // struct ManifestAssociatedFunction memory[] memory to storage not yet supported.
     bytes internal _manifest;
 
-    string public constant NAME = "Mock Plugin Modifiable";
-    string public constant VERSION = "1.0.0";
-    string public constant AUTHOR = "ERC-6900 Authors";
+    string internal constant _NAME = "Mock Plugin Modifiable";
+    string internal constant _VERSION = "1.0.0";
+    string internal constant _AUTHOR = "ERC-6900 Authors";
 
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
@@ -52,9 +52,9 @@ contract MockPlugin is ERC165 {
 
     function pluginMetadata() external pure returns (PluginMetadata memory) {
         PluginMetadata memory metadata;
-        metadata.name = NAME;
-        metadata.version = VERSION;
-        metadata.author = AUTHOR;
+        metadata.name = _NAME;
+        metadata.version = _VERSION;
+        metadata.author = _AUTHOR;
         return metadata;
     }
 

--- a/test/mocks/SingleSignerFactoryFixture.sol
+++ b/test/mocks/SingleSignerFactoryFixture.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
-import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
 
 import {OptimizedTest} from "../utils/OptimizedTest.sol";

--- a/test/mocks/plugins/ComprehensivePlugin.sol
+++ b/test/mocks/plugins/ComprehensivePlugin.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
+import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
 import {
-    ManifestExecutionHook,
     ManifestExecutionFunction,
+    ManifestExecutionHook,
     ManifestValidation,
     PluginManifest,
     PluginMetadata
@@ -13,7 +14,6 @@ import {
 import {PluginManifest} from "../../../src/interfaces/IPlugin.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
-import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
 
 import {BasePlugin} from "../../../src/plugins/BasePlugin.sol";
 
@@ -28,9 +28,9 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
         SIG_VALIDATION
     }
 
-    string public constant NAME = "Comprehensive Plugin";
-    string public constant VERSION = "1.0.0";
-    string public constant AUTHOR = "ERC-6900 Authors";
+    string internal constant _NAME = "Comprehensive Plugin";
+    string internal constant _VERSION = "1.0.0";
+    string internal constant _AUTHOR = "ERC-6900 Authors";
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃    Execution functions    ┃
@@ -176,9 +176,9 @@ contract ComprehensivePlugin is IValidation, IValidationHook, IExecutionHook, Ba
 
     function pluginMetadata() external pure virtual override returns (PluginMetadata memory) {
         PluginMetadata memory metadata;
-        metadata.name = NAME;
-        metadata.version = VERSION;
-        metadata.author = AUTHOR;
+        metadata.name = _NAME;
+        metadata.version = _VERSION;
+        metadata.author = _AUTHOR;
         return metadata;
     }
 }

--- a/test/mocks/plugins/DirectCallPlugin.sol
+++ b/test/mocks/plugins/DirectCallPlugin.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
+import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
 import {PluginManifest, PluginMetadata} from "../../../src/interfaces/IPlugin.sol";
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
-import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
 
 import {BasePlugin} from "../../../src/plugins/BasePlugin.sol";
 

--- a/test/mocks/plugins/MockAccessControlHookPlugin.sol
+++ b/test/mocks/plugins/MockAccessControlHookPlugin.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.25;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {PluginMetadata, PluginManifest} from "../../../src/interfaces/IPlugin.sol";
-import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
+import {PluginManifest, PluginMetadata} from "../../../src/interfaces/IPlugin.sol";
+
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
+import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
 import {BasePlugin} from "../../../src/plugins/BasePlugin.sol";
 
 // A pre validaiton hook plugin that uses per-hook data.

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -9,8 +9,9 @@ import {
     PluginManifest,
     PluginMetadata
 } from "../../../src/interfaces/IPlugin.sol";
-import {IValidation} from "../../../src/interfaces/IValidation.sol";
+
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
+import {IValidation} from "../../../src/interfaces/IValidation.sol";
 
 import {BasePlugin} from "../../../src/plugins/BasePlugin.sol";
 

--- a/test/mocks/plugins/ValidationPluginMocks.sol
+++ b/test/mocks/plugins/ValidationPluginMocks.sol
@@ -6,8 +6,8 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 import {
     ManifestExecutionFunction,
     ManifestValidation,
-    PluginMetadata,
-    PluginManifest
+    PluginManifest,
+    PluginMetadata
 } from "../../../src/interfaces/IPlugin.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";

--- a/test/plugin/ERC20TokenLimitPlugin.t.sol
+++ b/test/plugin/ERC20TokenLimitPlugin.t.sol
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {PluginEntity} from "../../src/helpers/PluginEntityLib.sol";
+
+import {PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
+
+import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
+import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
+import {PluginManifest} from "../../src/interfaces/IPlugin.sol";
+import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {ERC20TokenLimitPlugin} from "../../src/plugins/ERC20TokenLimitPlugin.sol";
 import {MockPlugin} from "../mocks/MockPlugin.sol";
-import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
-import {PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
-import {IStandardExecutor, Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {PluginManifest} from "../../src/interfaces/IPlugin.sol";
-import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
@@ -71,8 +73,8 @@ contract ERC20TokenLimitPluginTest is AccountTestBase {
             nonce: 0,
             initCode: "",
             callData: abi.encodePacked(UpgradeableModularAccount.executeUserOp.selector, callData),
-            accountGasLimits: bytes32(bytes16(uint128(200000))) | bytes32(uint256(200000)),
-            preVerificationGas: 200000,
+            accountGasLimits: bytes32(bytes16(uint128(200_000))) | bytes32(uint256(200_000)),
+            preVerificationGas: 200_000,
             gasFees: bytes32(uint256(uint128(0))),
             paymasterAndData: "",
             signature: _encodeSignature(PluginEntityLib.pack(address(validationPlugin), 0), 1, "")
@@ -102,13 +104,13 @@ contract ERC20TokenLimitPluginTest is AccountTestBase {
         calls[2] = Call({
             target: address(erc20),
             value: 0,
-            data: abi.encodeCall(IERC20.transfer, (recipient, 5 ether + 100000))
+            data: abi.encodeCall(IERC20.transfer, (recipient, 5 ether + 100_000))
         });
 
         vm.startPrank(address(entryPoint));
         assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether);
         acct.executeUserOp(_getPackedUO(abi.encodeCall(IStandardExecutor.executeBatch, (calls))), bytes32(0));
-        assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether - 6 ether - 100001);
+        assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether - 6 ether - 100_001);
     }
 
     function test_userOp_executeBatch_approveAndTransferLimit() public {
@@ -120,13 +122,13 @@ contract ERC20TokenLimitPluginTest is AccountTestBase {
         calls[2] = Call({
             target: address(erc20),
             value: 0,
-            data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100000))
+            data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100_000))
         });
 
         vm.startPrank(address(entryPoint));
         assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether);
         acct.executeUserOp(_getPackedUO(abi.encodeCall(IStandardExecutor.executeBatch, (calls))), bytes32(0));
-        assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether - 6 ether - 100001);
+        assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether - 6 ether - 100_001);
     }
 
     function test_userOp_executeBatch_approveAndTransferLimit_fail() public {
@@ -138,7 +140,7 @@ contract ERC20TokenLimitPluginTest is AccountTestBase {
         calls[2] = Call({
             target: address(erc20),
             value: 0,
-            data: abi.encodeCall(IERC20.approve, (recipient, 9 ether + 100000))
+            data: abi.encodeCall(IERC20.approve, (recipient, 9 ether + 100_000))
         });
 
         vm.startPrank(address(entryPoint));
@@ -168,7 +170,7 @@ contract ERC20TokenLimitPluginTest is AccountTestBase {
         calls[2] = Call({
             target: address(erc20),
             value: 0,
-            data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100000))
+            data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100_000))
         });
 
         assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether);
@@ -176,6 +178,6 @@ contract ERC20TokenLimitPluginTest is AccountTestBase {
             abi.encodeCall(IStandardExecutor.executeBatch, (calls)),
             _encodeSignature(PluginEntityLib.pack(address(validationPlugin), 0), 1, "")
         );
-        assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether - 6 ether - 100001);
+        assertEq(plugin.limits(0, address(erc20), address(acct)), 10 ether - 6 ether - 100_001);
     }
 }

--- a/test/plugin/TokenReceiverPlugin.t.sol
+++ b/test/plugin/TokenReceiverPlugin.t.sol
@@ -2,15 +2,17 @@
 pragma solidity ^0.8.19;
 
 import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {TokenReceiverPlugin} from "../../src/plugins/TokenReceiverPlugin.sol";
 
-import {SingleSignerFactoryFixture} from "../mocks/SingleSignerFactoryFixture.sol";
-import {MockERC721} from "../mocks/MockERC721.sol";
 import {MockERC1155} from "../mocks/MockERC1155.sol";
+import {MockERC721} from "../mocks/MockERC721.sol";
+import {SingleSignerFactoryFixture} from "../mocks/SingleSignerFactoryFixture.sol";
+
 import {OptimizedTest} from "../utils/OptimizedTest.sol";
 
 contract TokenReceiverPluginTest is OptimizedTest, IERC1155Receiver {

--- a/test/samples/AllowlistPlugin.t.sol
+++ b/test/samples/AllowlistPlugin.t.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.25;
 
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
-import {Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
+import {Call} from "../../src/interfaces/IStandardExecutor.sol";
+
 import {AllowlistPlugin} from "../../src/samples/permissionhooks/AllowlistPlugin.sol";
 
-import {CustomValidationTestBase} from "../utils/CustomValidationTestBase.sol";
 import {Counter} from "../mocks/Counter.sol";
+import {CustomValidationTestBase} from "../utils/CustomValidationTestBase.sol";
 
 contract AllowlistPluginTest is CustomValidationTestBase {
     AllowlistPlugin public allowlistPlugin;

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -5,10 +5,10 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
-import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
-import {IStandardExecutor, Call} from "../../src/interfaces/IStandardExecutor.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {PluginEntity, PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
+import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
+import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
 
 import {OptimizedTest} from "./OptimizedTest.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID as EXT_CONST_TEST_DEFAULT_VALIDATION_ENTITY_ID} from
@@ -40,8 +40,8 @@ abstract contract AccountTestBase is OptimizedTest {
     // Re-declare the constant to prevent derived test contracts from having to import it
     uint32 public constant TEST_DEFAULT_VALIDATION_ENTITY_ID = EXT_CONST_TEST_DEFAULT_VALIDATION_ENTITY_ID;
 
-    uint256 public constant CALL_GAS_LIMIT = 100000;
-    uint256 public constant VERIFICATION_GAS_LIMIT = 1200000;
+    uint256 public constant CALL_GAS_LIMIT = 100_000;
+    uint256 public constant VERIFICATION_GAS_LIMIT = 1_200_000;
 
     struct PreValidationHookData {
         uint8 index;

--- a/test/utils/CustomValidationTestBase.sol
+++ b/test/utils/CustomValidationTestBase.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.25;
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
+import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {PluginEntity} from "../../src/helpers/PluginEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {AccountTestBase} from "./AccountTestBase.sol";
 

--- a/test/utils/OptimizedTest.sol
+++ b/test/utils/OptimizedTest.sol
@@ -6,8 +6,9 @@ import {Test} from "forge-std/Test.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
+
 import {TokenReceiverPlugin} from "../../src/plugins/TokenReceiverPlugin.sol";
+import {SingleSignerValidation} from "../../src/plugins/validation/SingleSignerValidation.sol";
 
 /// @dev This contract provides functions to deploy optimized (via IR) precompiled contracts. By compiling just
 /// the source contracts (excluding the test suite) via IR, and using the resulting bytecode within the tests

--- a/test/validation/SingleSignerValidation.t.sol
+++ b/test/validation/SingleSignerValidation.t.sol
@@ -8,9 +8,9 @@ import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAcc
 import {PluginEntityLib} from "../../src/helpers/PluginEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 
+import {ContractOwner} from "../mocks/ContractOwner.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";
-import {ContractOwner} from "../mocks/ContractOwner.sol";
 
 contract SingleSignerValidationTest is AccountTestBase {
     using MessageHashUtils for bytes32;


### PR DESCRIPTION
## Motivation

We have some inconsistent code style throughout the codebase, and linter warnings slip through the CI because they don't return 1 on warnings.

## Solution

Update the linter to fail-on-warn
- Fix function ordering issue in SingleSignerValidation

Add additional config to forge formatter:
- Sort imports
- Add underscores to big numbers
- Enforce long-form value types (`uint256` over `uint`)

Also adjusts the plugin metadata fields to not be exported twice, by having both a public field and a view function to get them.