### PR TITLE
feat: [v0.8-develop] User controlled install 1/N

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -88,9 +88,4 @@ abstract contract AccountLoupe is IAccountLoupe {
     {
         preValidationHooks = getAccountStorage().validationData[validationFunction].preValidationHooks;
     }
-
-    /// @inheritdoc IAccountLoupe
-    function getInstalledModules() external view override returns (address[] memory moduleAddresses) {
-        moduleAddresses = getAccountStorage().moduleManifestHashes.keys();
-    }
 }

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
@@ -43,7 +42,6 @@ struct AccountStorage {
     // AccountStorageInitializable variables
     uint8 initialized;
     bool initializing;
-    EnumerableMap.AddressToUintMap moduleManifestHashes;
     // Execution functions and their associated functions
     mapping(bytes4 => SelectorData) selectorData;
     mapping(ModuleEntity validationFunction => ValidationData) validationData;

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -35,8 +35,7 @@ library KnownSelectors {
         // check against IAccountLoupe methods
         || selector == IAccountLoupe.getExecutionFunctionHandler.selector
             || selector == IAccountLoupe.getSelectors.selector || selector == IAccountLoupe.getExecutionHooks.selector
-            || selector == IAccountLoupe.getPreValidationHooks.selector
-            || selector == IAccountLoupe.getInstalledModules.selector;
+            || selector == IAccountLoupe.getPreValidationHooks.selector;
     }
 
     function isErc4337Function(bytes4 selector) internal pure returns (bool) {

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -40,8 +40,4 @@ interface IAccountLoupe {
         external
         view
         returns (ModuleEntity[] memory preValidationHooks);
-
-    /// @notice Get an array of all installed modules.
-    /// @return The addresses of all installed modules.
-    function getInstalledModules() external view returns (address[] memory);
 }

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -1,21 +1,24 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.25;
 
+import {ModuleManifest} from "./IModule.sol";
+
 type ModuleEntity is bytes24;
 
 type ValidationConfig is bytes26;
 
 interface IModuleManager {
-    event ModuleInstalled(address indexed module, bytes32 manifestHash);
+    event ModuleInstalled(address indexed module);
 
     event ModuleUninstalled(address indexed module, bool indexed onUninstallSucceeded);
 
     /// @notice Install a module to the modular account.
     /// @param module The module to install.
-    /// @param manifestHash The hash of the module manifest.
+    /// @param manifest the manifest describing functions to install
     /// @param moduleInstallData Optional data to be decoded and used by the module to setup initial module data
     /// for the modular account.
-    function installModule(address module, bytes32 manifestHash, bytes calldata moduleInstallData) external;
+    function installModule(address module, ModuleManifest calldata manifest, bytes calldata moduleInstallData)
+        external;
 
     /// @notice Temporary install function - pending a different user-supplied install config & manifest validation
     /// path.
@@ -53,9 +56,9 @@ interface IModuleManager {
 
     /// @notice Uninstall a module from the modular account.
     /// @param module The module to uninstall.
-    /// @param config An optional, implementation-specific field that accounts may use to ensure consistency
-    /// guarantees.
+    /// @param manifest the manifest describing functions to uninstall.
     /// @param moduleUninstallData Optional data to be decoded and used by the module to clear module data for the
     /// modular account.
-    function uninstallModule(address module, bytes calldata config, bytes calldata moduleUninstallData) external;
+    function uninstallModule(address module, ModuleManifest calldata manifest, bytes calldata moduleUninstallData)
+        external;
 }

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -21,17 +21,9 @@ contract AccountLoupeTest is CustomValidationTestBase {
 
         _customValidationSetup();
 
-        bytes32 manifestHash = keccak256(abi.encode(comprehensiveModule.moduleManifest()));
-        vm.prank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), manifestHash, "");
-    }
-
-    function test_moduleLoupe_getInstalledModules_initial() public {
-        address[] memory modules = account1.getInstalledModules();
-
-        assertEq(modules.length, 1);
-
-        assertEq(modules[0], address(comprehensiveModule));
+        vm.startPrank(address(entryPoint));
+        account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
+        vm.stopPrank();
     }
 
     function test_moduleLoupe_getExecutionFunctionHandler_native() public {

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -26,21 +26,19 @@ contract AccountReturnDataTest is AccountTestBase {
         resultConsumerModule = new ResultConsumerModule(resultCreatorModule, regularResultContract);
 
         // Add the result creator module to the account
-        bytes32 resultCreatorManifestHash = keccak256(abi.encode(resultCreatorModule.moduleManifest()));
-        vm.prank(address(entryPoint));
+        vm.startPrank(address(entryPoint));
         account1.installModule({
             module: address(resultCreatorModule),
-            manifestHash: resultCreatorManifestHash,
+            manifest: resultCreatorModule.moduleManifest(),
             moduleInstallData: ""
         });
         // Add the result consumer module to the account
-        bytes32 resultConsumerManifestHash = keccak256(abi.encode(resultConsumerModule.moduleManifest()));
-        vm.prank(address(entryPoint));
         account1.installModule({
             module: address(resultConsumerModule),
-            manifestHash: resultConsumerManifestHash,
+            manifest: resultConsumerModule.moduleManifest(),
             moduleInstallData: ""
         });
+        vm.stopPrank();
     }
 
     // Tests the ability to read the result of module execution functions via the account's fallback

--- a/test/account/PermittedCallPermissions.t.sol
+++ b/test/account/PermittedCallPermissions.t.sol
@@ -21,21 +21,19 @@ contract PermittedCallPermissionsTest is AccountTestBase {
         permittedCallerModule = new PermittedCallerModule();
 
         // Add the result creator module to the account
-        bytes32 resultCreatorManifestHash = keccak256(abi.encode(resultCreatorModule.moduleManifest()));
-        vm.prank(address(entryPoint));
+        vm.startPrank(address(entryPoint));
         account1.installModule({
             module: address(resultCreatorModule),
-            manifestHash: resultCreatorManifestHash,
+            manifest: resultCreatorModule.moduleManifest(),
             moduleInstallData: ""
         });
         // Add the permitted caller module to the account
-        bytes32 permittedCallerManifestHash = keccak256(abi.encode(permittedCallerModule.moduleManifest()));
-        vm.prank(address(entryPoint));
         account1.installModule({
             module: address(permittedCallerModule),
-            manifestHash: permittedCallerManifestHash,
+            manifest: permittedCallerModule.moduleManifest(),
             moduleInstallData: ""
         });
+        vm.stopPrank();
     }
 
     function test_permittedCall_Allowed() public {

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -24,9 +24,9 @@ contract SelfCallAuthorizationTest is AccountTestBase {
 
         comprehensiveModule = new ComprehensiveModule();
 
-        bytes32 manifestHash = keccak256(abi.encode(comprehensiveModule.moduleManifest()));
-        vm.prank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), manifestHash, "");
+        vm.startPrank(address(entryPoint));
+        account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
+        vm.stopPrank();
 
         comprehensiveModuleValidation =
             ModuleEntityLib.pack(address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.VALIDATION));

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -49,12 +49,12 @@ contract ValidationIntersectionTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         account1.installModule({
             module: address(noHookModule),
-            manifestHash: keccak256(abi.encode(noHookModule.moduleManifest())),
+            manifest: noHookModule.moduleManifest(),
             moduleInstallData: ""
         });
         account1.installModule({
             module: address(oneHookModule),
-            manifestHash: keccak256(abi.encode(oneHookModule.moduleManifest())),
+            manifest: oneHookModule.moduleManifest(),
             moduleInstallData: ""
         });
         // TODO: change with new install flow
@@ -74,7 +74,7 @@ contract ValidationIntersectionTest is AccountTestBase {
         );
         account1.installModule({
             module: address(twoHookModule),
-            manifestHash: keccak256(abi.encode(twoHookModule.moduleManifest())),
+            manifest: twoHookModule.moduleManifest(),
             moduleInstallData: ""
         });
         // temporary fix to add the pre-validation hook

--- a/test/module/TokenReceiverModule.t.sol
+++ b/test/module/TokenReceiverModule.t.sol
@@ -55,10 +55,9 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
     }
 
     function _initModule() internal {
-        bytes32 manifestHash = keccak256(abi.encode(module.moduleManifest()));
-
-        vm.prank(address(entryPoint));
-        acct.installModule(address(module), manifestHash, "");
+        vm.startPrank(address(entryPoint));
+        acct.installModule(address(module), module.moduleManifest(), "");
+        vm.stopPrank();
     }
 
     function test_failERC721Transfer() public {


### PR DESCRIPTION
## Motivation

A point of contention in the ERC-6900 v0.7 design was the fixed nature of the manifest making plugin design inflexible. This caused issues in two areas:
- It was difficult to reuse plugins in different settings, because there was only 1 possible way to install them.
- Plugin-limiting permissions were difficult to configure: the account would always grant permissions requested in the manifest, and there wasn’t a clean way to attach restricting or blocking hooks to these permission requests because the hook plugins were inflexible.

These concerns were captured in a 6900 standards improvement issue here: https://github.com/erc6900/resources/issues/9

As shown in our goals of composable and reusable validation functions, it is in our interest to allow plugins to be more flexibly installed than what we currently support. In the process of implementing v0.8 features, we introduced `installValidation`, a function to allow customizable installation that only follows user-supplied instructions for installation, rather than decoding and following what a manifest says. This allows us to install validation plugins multiple times with different IDs and hooks attached to them, and for the user to control what functions on the account a validation may use. This solves the issues of static, manifest-based installs, but only for validation functions.

Now, we have to answer the question of what to do with the existing workflow in `installPlugin` / `uninstallPlugin`, where the plugin manifest is read, and individual plugin functions are added according to the manifest.

## Solution

This PR makes the manifest a fully user-controlled install sequence. There is still the view function `pluginManifest()` that allows a caller to retrieve the manifest, which describes what execution functions, execution hooks, validation functions, and ERC-165 interface IDs should be added to the account. However, the `installPlugin` and `uninstallPlugin` functions no longer read the manifest in their implementation and work off of that, instead having the manifest passed in as a parameter by the user.

This allows the caller to inspect and modify the manifest before installing the functions within it. It also removes the necessity for the account to:
- retrieve the manifest during install
- compare the retrieved manifest with a user-provided hash
- store the manifest hash for the future
- provide an escape hatch for the manifest to be passed in during uninstall, if the plugin changes the return value of the manifest in the future

It does, however, mean that the caller (user, or the wallet software around it) will need to be aware of what functions were installed, in order to have a clean uninstall. Doing so efficiently may require us to change the types emitted in events, but that is deferred here.

## Future work

This PR does not address the issue of applying limitations to validations installed via the manifest format. I.e. if there is some validation function defined in the `PluginManifest` provided to install plugin, it is not yet possible to apply pre-validation hooks or permission hooks to it.