### PR TITLE
feat: [v0.8-develop] Remove validation installation from the manifest 3/N

### DIFF
--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -5,7 +5,7 @@ import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165C
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {RESERVED_VALIDATION_DATA_INDEX, SELF_PERMIT_VALIDATION_FUNCTIONID} from "../helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITYID, MAX_PRE_VALIDATION_HOOKS} from "../helpers/Constants.sol";
 import {KnownSelectors} from "../helpers/KnownSelectors.sol";
 import {ModuleEntityLib} from "../helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
@@ -244,7 +244,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
             }
 
             // Avoid collision between reserved index and actual indices
-            if (_validationData.preValidationHooks.length > RESERVED_VALIDATION_DATA_INDEX) {
+            if (_validationData.preValidationHooks.length > MAX_PRE_VALIDATION_HOOKS) {
                 revert PreValidationHookLimitExceeded();
             }
         }
@@ -274,7 +274,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
             }
         }
 
-        if (validationConfig.entityId() != SELF_PERMIT_VALIDATION_FUNCTIONID) {
+        if (validationConfig.entityId() != DIRECT_CALL_VALIDATION_ENTITYID) {
             // Only allow global validations and signature validations if they're not direct-call validations.
 
             _validationData.isGlobal = validationConfig.isGlobal();

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -105,28 +105,6 @@ contract UpgradeableModularAccount is
 
     // EXTERNAL FUNCTIONS
 
-    /// @notice Initializes the account with a set of modules
-    /// @param modules The modules to install
-    /// @param manifests The manifests of the modules to install
-    /// @param moduleInstallDatas The module install datas of the modules to install
-    function initialize(
-        address[] memory modules,
-        ModuleManifest[] calldata manifests,
-        bytes[] memory moduleInstallDatas
-    ) external initializer {
-        uint256 length = modules.length;
-
-        if (length != manifests.length || length != moduleInstallDatas.length) {
-            revert ArrayLengthMismatch();
-        }
-
-        for (uint256 i = 0; i < length; ++i) {
-            _installModule(modules[i], manifests[i], moduleInstallDatas[i]);
-        }
-
-        emit ModularAccountInitialized(_ENTRY_POINT);
-    }
-
     receive() external payable {}
 
     /// @notice Fallback function

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -18,7 +18,7 @@ import {SparseCalldataSegmentLib} from "../helpers/SparseCalldataSegmentLib.sol"
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationResHelpers.sol";
 
-import {RESERVED_VALIDATION_DATA_INDEX, SELF_PERMIT_VALIDATION_FUNCTIONID} from "../helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITYID, RESERVED_VALIDATION_DATA_INDEX} from "../helpers/Constants.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
 import {ModuleManifest} from "../interfaces/IModule.sol";
 import {IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
@@ -613,7 +613,7 @@ contract UpgradeableModularAccount is
             return (new PostExecToRun[](0), new PostExecToRun[](0));
         }
 
-        ModuleEntity directCallValidationKey = ModuleEntityLib.pack(msg.sender, SELF_PERMIT_VALIDATION_FUNCTIONID);
+        ModuleEntity directCallValidationKey = ModuleEntityLib.pack(msg.sender, DIRECT_CALL_VALIDATION_ENTITYID);
 
         _checkIfValidationAppliesCallData(msg.data, directCallValidationKey, false);
 

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -18,6 +18,7 @@ import {SparseCalldataSegmentLib} from "../helpers/SparseCalldataSegmentLib.sol"
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationResHelpers.sol";
 
+import {RESERVED_VALIDATION_DATA_INDEX, SELF_PERMIT_VALIDATION_FUNCTIONID} from "../helpers/Constants.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
 import {ModuleManifest} from "../interfaces/IModule.sol";
 import {IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
@@ -28,7 +29,6 @@ import {AccountExecutor} from "./AccountExecutor.sol";
 import {AccountLoupe} from "./AccountLoupe.sol";
 import {AccountStorage, getAccountStorage, toExecutionHook, toSetValue} from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
-
 import {ModuleManagerInternals} from "./ModuleManagerInternals.sol";
 
 contract UpgradeableModularAccount is
@@ -441,7 +441,7 @@ contract UpgradeableModularAccount is
 
         // Run the user op validationFunction
         {
-            if (signatureSegment.getIndex() != _RESERVED_VALIDATION_DATA_INDEX) {
+            if (signatureSegment.getIndex() != RESERVED_VALIDATION_DATA_INDEX) {
                 revert ValidationSignatureSegmentMissing();
             }
 
@@ -497,7 +497,7 @@ contract UpgradeableModularAccount is
             _doPreRuntimeValidationHook(preRuntimeValidationHooks[i], callData, currentAuthData);
         }
 
-        if (authSegment.getIndex() != _RESERVED_VALIDATION_DATA_INDEX) {
+        if (authSegment.getIndex() != RESERVED_VALIDATION_DATA_INDEX) {
             revert ValidationSignatureSegmentMissing();
         }
 
@@ -635,7 +635,7 @@ contract UpgradeableModularAccount is
             return (new PostExecToRun[](0), new PostExecToRun[](0));
         }
 
-        ModuleEntity directCallValidationKey = ModuleEntityLib.pack(msg.sender, _SELF_PERMIT_VALIDATION_FUNCTIONID);
+        ModuleEntity directCallValidationKey = ModuleEntityLib.pack(msg.sender, SELF_PERMIT_VALIDATION_FUNCTIONID);
 
         _checkIfValidationAppliesCallData(msg.data, directCallValidationKey, false);
 

--- a/src/helpers/Constants.sol
+++ b/src/helpers/Constants.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.25;
 
 // Index marking the start of the data for the validation function.
-uint8 constant RESERVED_VALIDATION_DATA_INDEX = 255;
+uint8 constant RESERVED_VALIDATION_DATA_INDEX = type(uint8).max;
+
+// Maximum number of pre-validation hooks that can be registered.
+uint8 constant MAX_PRE_VALIDATION_HOOKS = type(uint8).max;
 
 // Magic value for the Entity ID of direct call validation.
-uint32 constant SELF_PERMIT_VALIDATION_FUNCTIONID = type(uint32).max;
+uint32 constant DIRECT_CALL_VALIDATION_ENTITYID = type(uint32).max;

--- a/src/helpers/Constants.sol
+++ b/src/helpers/Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+// Index marking the start of the data for the validation function.
+uint8 constant RESERVED_VALIDATION_DATA_INDEX = 255;
+
+// Magic value for the Entity ID of direct call validation.
+uint32 constant SELF_PERMIT_VALIDATION_FUNCTIONID = type(uint32).max;

--- a/src/interfaces/IModule.sol
+++ b/src/interfaces/IModule.sol
@@ -13,14 +13,6 @@ struct ManifestExecutionFunction {
     bool allowGlobalValidation;
 }
 
-// todo: do we need these at all? Or do we fully switch to `installValidation`?
-struct ManifestValidation {
-    uint32 entityId;
-    bool isGlobal;
-    bool isSignatureValidation;
-    bytes4[] selectors;
-}
-
 struct ManifestExecutionHook {
     // TODO(erc6900 spec): These fields can be packed into a single word
     bytes4 executionSelector;
@@ -54,7 +46,6 @@ struct ModuleMetadata {
 struct ModuleManifest {
     // Execution functions defined in this module to be installed on the MSCA.
     ManifestExecutionFunction[] executionFunctions;
-    ManifestValidation[] validationFunctions;
     ManifestExecutionHook[] executionHooks;
     // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
     // IModule's interface ID.

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -16,8 +16,12 @@ contract AccountLoupeTest is CustomValidationTestBase {
 
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
+    ModuleEntity public comprehensiveModuleValidation;
+
     function setUp() public {
         comprehensiveModule = new ComprehensiveModule();
+        comprehensiveModuleValidation =
+            ModuleEntityLib.pack(address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.VALIDATION));
 
         _customValidationSetup();
 
@@ -61,9 +65,6 @@ contract AccountLoupeTest is CustomValidationTestBase {
     }
 
     function test_moduleLoupe_getSelectors() public {
-        ModuleEntity comprehensiveModuleValidation =
-            ModuleEntityLib.pack(address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.VALIDATION));
-
         bytes4[] memory selectors = account1.getSelectors(comprehensiveModuleValidation);
 
         assertEq(selectors.length, 1);
@@ -107,7 +108,7 @@ contract AccountLoupeTest is CustomValidationTestBase {
     }
 
     function test_moduleLoupe_getValidationHooks() public {
-        ModuleEntity[] memory hooks = account1.getPreValidationHooks(_signerValidation);
+        ModuleEntity[] memory hooks = account1.getPreValidationHooks(comprehensiveModuleValidation);
 
         assertEq(hooks.length, 2);
         assertEq(
@@ -144,12 +145,15 @@ contract AccountLoupeTest is CustomValidationTestBase {
             address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.PRE_VALIDATION_HOOK_2)
         );
 
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = comprehensiveModule.foo.selector;
+
         bytes[] memory installDatas = new bytes[](2);
         return (
-            _signerValidation,
+            comprehensiveModuleValidation,
             true,
             true,
-            new bytes4[](0),
+            selectors,
             bytes(""),
             abi.encode(preValidationHooks, installDatas),
             ""

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
+import {SELF_PERMIT_VALIDATION_FUNCTIONID} from "../../src/helpers/Constants.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
+import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
+import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 
 import {
     RegularResultContract,
@@ -38,6 +41,18 @@ contract AccountReturnDataTest is AccountTestBase {
             manifest: resultConsumerModule.moduleManifest(),
             moduleInstallData: ""
         });
+        // Allow the result consumer module to perform direct calls to the account
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = IStandardExecutor.execute.selector;
+        account1.installValidation(
+            ValidationConfigLib.pack(
+                address(resultConsumerModule), SELF_PERMIT_VALIDATION_FUNCTIONID, false, false
+            ),
+            selectors,
+            "",
+            "",
+            ""
+        );
         vm.stopPrank();
     }
 

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {SELF_PERMIT_VALIDATION_FUNCTIONID} from "../../src/helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../src/helpers/Constants.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
@@ -45,9 +45,7 @@ contract AccountReturnDataTest is AccountTestBase {
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = IStandardExecutor.execute.selector;
         account1.installValidation(
-            ValidationConfigLib.pack(
-                address(resultConsumerModule), SELF_PERMIT_VALIDATION_FUNCTIONID, false, false
-            ),
+            ValidationConfigLib.pack(address(resultConsumerModule), DIRECT_CALL_VALIDATION_ENTITYID, false, false),
             selectors,
             "",
             "",

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -24,12 +24,18 @@ contract SelfCallAuthorizationTest is AccountTestBase {
 
         comprehensiveModule = new ComprehensiveModule();
 
-        vm.startPrank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
-        vm.stopPrank();
-
         comprehensiveModuleValidation =
             ModuleEntityLib.pack(address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.VALIDATION));
+
+        bytes4[] memory validationSelectors = new bytes4[](1);
+        validationSelectors[0] = ComprehensiveModule.foo.selector;
+
+        vm.startPrank(address(entryPoint));
+        account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
+        account1.installValidation(
+            ValidationConfigLib.pack(comprehensiveModuleValidation, false, false), validationSelectors, "", "", ""
+        );
+        vm.stopPrank();
     }
 
     function test_selfCallFails_userOp() public {

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -7,7 +7,6 @@ import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
 import {
     ManifestExecutionFunction,
     ManifestExecutionHook,
-    ManifestValidation,
     ModuleManifest,
     ModuleMetadata
 } from "../../../src/interfaces/IModule.sol";
@@ -138,17 +137,6 @@ contract ComprehensiveModule is IValidation, IValidationHook, IExecutionHook, Ba
             executionSelector: this.foo.selector,
             isPublic: false,
             allowGlobalValidation: false
-        });
-
-        bytes4[] memory validationSelectors = new bytes4[](1);
-        validationSelectors[0] = this.foo.selector;
-
-        manifest.validationFunctions = new ManifestValidation[](1);
-        manifest.validationFunctions[0] = ManifestValidation({
-            entityId: uint32(EntityId.VALIDATION),
-            isGlobal: true,
-            isSignatureValidation: false,
-            selectors: validationSelectors
         });
 
         manifest.executionHooks = new ManifestExecutionHook[](3);

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -5,7 +5,7 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
-import {SELF_PERMIT_VALIDATION_FUNCTIONID} from "../../../src/helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../../src/helpers/Constants.sol";
 
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
@@ -100,7 +100,7 @@ contract ResultConsumerModule is BaseModule, IValidation {
         // This result should be allowed based on the manifest permission request
         bytes memory returnData = IStandardExecutor(msg.sender).executeWithAuthorization(
             abi.encodeCall(IStandardExecutor.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
-            abi.encodePacked(this, SELF_PERMIT_VALIDATION_FUNCTIONID, uint8(0), uint32(1), uint8(255)) // Validation
+            abi.encodePacked(this, DIRECT_CALL_VALIDATION_ENTITYID, uint8(0), uint32(1), uint8(255)) // Validation
                 // function of self,
                 // selector-associated, with no auth data
         );

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -3,12 +3,9 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {
-    ManifestExecutionFunction,
-    ManifestValidation,
-    ModuleManifest,
-    ModuleMetadata
-} from "../../../src/interfaces/IModule.sol";
+import {ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
+
+import {SELF_PERMIT_VALIDATION_FUNCTIONID} from "../../../src/helpers/Constants.sol";
 
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
@@ -103,7 +100,8 @@ contract ResultConsumerModule is BaseModule, IValidation {
         // This result should be allowed based on the manifest permission request
         bytes memory returnData = IStandardExecutor(msg.sender).executeWithAuthorization(
             abi.encodeCall(IStandardExecutor.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
-            abi.encodePacked(this, uint32(0), uint8(0), uint32(1), uint8(255)) // Validation function of self,
+            abi.encodePacked(this, SELF_PERMIT_VALIDATION_FUNCTIONID, uint8(0), uint32(1), uint8(255)) // Validation
+                // function of self,
                 // selector-associated, with no auth data
         );
 
@@ -118,18 +116,6 @@ contract ResultConsumerModule is BaseModule, IValidation {
 
     function moduleManifest() external pure override returns (ModuleManifest memory) {
         ModuleManifest memory manifest;
-
-        // todo: this is the exact workflow that would benefit from a "permiteed call" setup in the manifest.
-        bytes4[] memory validationSelectors = new bytes4[](1);
-        validationSelectors[0] = IStandardExecutor.execute.selector;
-
-        manifest.validationFunctions = new ManifestValidation[](1);
-        manifest.validationFunctions[0] = ManifestValidation({
-            entityId: 0,
-            isGlobal: true,
-            isSignatureValidation: false,
-            selectors: validationSelectors
-        });
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
         manifest.executionFunctions[0] = ManifestExecutionFunction({

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -3,12 +3,7 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {
-    ManifestExecutionFunction,
-    ManifestValidation,
-    ModuleManifest,
-    ModuleMetadata
-} from "../../../src/interfaces/IModule.sol";
+import {ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
@@ -112,17 +107,6 @@ contract MockUserOpValidationModule is MockBaseUserOpValidationModule {
             allowGlobalValidation: false
         });
 
-        bytes4[] memory validationSelectors = new bytes4[](1);
-        validationSelectors[0] = this.foo.selector;
-
-        manifest.validationFunctions = new ManifestValidation[](1);
-        manifest.validationFunctions[0] = ManifestValidation({
-            entityId: uint32(EntityId.USER_OP_VALIDATION),
-            isGlobal: false,
-            isSignatureValidation: false,
-            selectors: validationSelectors
-        });
-
         return manifest;
     }
 }
@@ -153,17 +137,6 @@ contract MockUserOpValidation1HookModule is MockBaseUserOpValidationModule {
             executionSelector: this.bar.selector,
             isPublic: false,
             allowGlobalValidation: false
-        });
-
-        bytes4[] memory validationSelectors = new bytes4[](1);
-        validationSelectors[0] = this.bar.selector;
-
-        manifest.validationFunctions = new ManifestValidation[](2);
-        manifest.validationFunctions[0] = ManifestValidation({
-            entityId: uint32(EntityId.USER_OP_VALIDATION),
-            isGlobal: false,
-            isSignatureValidation: false,
-            selectors: validationSelectors
         });
 
         return manifest;
@@ -199,17 +172,6 @@ contract MockUserOpValidation2HookModule is MockBaseUserOpValidationModule {
             executionSelector: this.baz.selector,
             isPublic: false,
             allowGlobalValidation: false
-        });
-
-        bytes4[] memory validationSelectors = new bytes4[](1);
-        validationSelectors[0] = this.baz.selector;
-
-        manifest.validationFunctions = new ManifestValidation[](1);
-        manifest.validationFunctions[0] = ManifestValidation({
-            entityId: uint32(EntityId.USER_OP_VALIDATION),
-            isGlobal: false,
-            isSignatureValidation: false,
-            selectors: validationSelectors
         });
 
         return manifest;


### PR DESCRIPTION
## Motivation

As noted in #103, since the introduction of `installValidation`, there have been two pathways of installing validation functions: by specifying them in `installValidation`, or by having a plugin specifying them in the manifest and calling `installPlugin`.

Given the context that most uses of validation-in-manifest installs was for direct call authorization, and the context that adding pre-validation hooks + permission hooks to the manifest based install is not very direct, this PR explores an option of removing validation installation from the manifest completely.

## Solution

Remove validation functions from the manifest.

Update any usages of direct call validation specified in the manifest to an initialization of the direct call permission via `installValidation`.

## Future Work

If we decide to go this route, we should define a place in the plugin metadata to indicate a request for direct call permissions.

