### PR TITLE
feat: [v0.8-develop] HookConfig install parameter & internal structure 4/N

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -38,7 +38,7 @@ runs = 5000
 depth = 32
 
 [profile.deep.fuzz]
-runs = 10000
+runs = 100000
 
 [profile.deep.invariant]
 runs = 5000

--- a/src/account/AccountFactory.sol
+++ b/src/account/AccountFactory.sol
@@ -51,8 +51,7 @@ contract AccountFactory is Ownable {
                 ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION, entityId, true, true),
                 new bytes4[](0),
                 pluginInstallData,
-                "",
-                ""
+                new bytes[](0)
             );
         }
 

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -6,14 +6,16 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
+import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {ExecutionHook, IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
-import {IModuleManager, ModuleEntity} from "../interfaces/IModuleManager.sol";
+import {HookConfig, IModuleManager, ModuleEntity} from "../interfaces/IModuleManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 import {getAccountStorage, toExecutionHook, toSelector} from "./AccountStorage.sol";
 
 abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using EnumerableMap for EnumerableMap.AddressToUintMap;
+    using HookConfigLib for HookConfig;
 
     /// @inheritdoc IAccountLoupe
     function getExecutionFunctionHandler(bytes4 selector) external view override returns (address module) {
@@ -56,8 +58,12 @@ abstract contract AccountLoupe is IAccountLoupe {
 
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = hooks.at(i);
-            ExecutionHook memory execHook = execHooks[i];
-            (execHook.hookFunction, execHook.isPreHook, execHook.isPostHook) = toExecutionHook(key);
+            HookConfig hook = toExecutionHook(key);
+            execHooks[i] = ExecutionHook({
+                hookFunction: hook.moduleEntity(),
+                isPreHook: hook.hasPreHook(),
+                isPostHook: hook.hasPostHook()
+            });
         }
     }
 
@@ -74,8 +80,12 @@ abstract contract AccountLoupe is IAccountLoupe {
         permissionHooks = new ExecutionHook[](executionHooksLength);
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = hooks.at(i);
-            ExecutionHook memory execHook = permissionHooks[i];
-            (execHook.hookFunction, execHook.isPreHook, execHook.isPostHook) = toExecutionHook(key);
+            HookConfig hook = toExecutionHook(key);
+            permissionHooks[i] = ExecutionHook({
+                hookFunction: hook.moduleEntity(),
+                isPreHook: hook.hasPreHook(),
+                isPostHook: hook.hasPostHook()
+            });
         }
     }
 

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -10,7 +10,7 @@ import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {ExecutionHook, IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
 import {HookConfig, IModuleManager, ModuleEntity} from "../interfaces/IModuleManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
-import {getAccountStorage, toExecutionHook, toSelector} from "./AccountStorage.sol";
+import {getAccountStorage, toHookConfig, toSelector} from "./AccountStorage.sol";
 
 abstract contract AccountLoupe is IAccountLoupe {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -58,7 +58,7 @@ abstract contract AccountLoupe is IAccountLoupe {
 
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = hooks.at(i);
-            HookConfig hookConfig = toExecutionHook(key);
+            HookConfig hookConfig = toHookConfig(key);
             execHooks[i] = ExecutionHook({
                 hookFunction: hookConfig.moduleEntity(),
                 isPreHook: hookConfig.hasPreHook(),
@@ -80,7 +80,7 @@ abstract contract AccountLoupe is IAccountLoupe {
         permissionHooks = new ExecutionHook[](executionHooksLength);
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = hooks.at(i);
-            HookConfig hookConfig = toExecutionHook(key);
+            HookConfig hookConfig = toHookConfig(key);
             permissionHooks[i] = ExecutionHook({
                 hookFunction: hookConfig.moduleEntity(),
                 isPreHook: hookConfig.hasPreHook(),

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -58,11 +58,11 @@ abstract contract AccountLoupe is IAccountLoupe {
 
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = hooks.at(i);
-            HookConfig hook = toExecutionHook(key);
+            HookConfig hookConfig = toExecutionHook(key);
             execHooks[i] = ExecutionHook({
-                hookFunction: hook.moduleEntity(),
-                isPreHook: hook.hasPreHook(),
-                isPostHook: hook.hasPostHook()
+                hookFunction: hookConfig.moduleEntity(),
+                isPreHook: hookConfig.hasPreHook(),
+                isPostHook: hookConfig.hasPostHook()
             });
         }
     }
@@ -80,11 +80,11 @@ abstract contract AccountLoupe is IAccountLoupe {
         permissionHooks = new ExecutionHook[](executionHooksLength);
         for (uint256 i = 0; i < executionHooksLength; ++i) {
             bytes32 key = hooks.at(i);
-            HookConfig hook = toExecutionHook(key);
+            HookConfig hookConfig = toExecutionHook(key);
             permissionHooks[i] = ExecutionHook({
-                hookFunction: hook.moduleEntity(),
-                isPreHook: hook.hasPreHook(),
-                isPostHook: hook.hasPostHook()
+                hookFunction: hookConfig.moduleEntity(),
+                isPreHook: hookConfig.hasPreHook(),
+                isPostHook: hookConfig.hasPostHook()
             });
         }
     }

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -73,7 +73,7 @@ function toSetValue(HookConfig hookConfig) pure returns (bytes32) {
     return bytes32(HookConfig.unwrap(hookConfig));
 }
 
-function toExecutionHook(bytes32 setValue) pure returns (HookConfig) {
+function toHookConfig(bytes32 setValue) pure returns (HookConfig) {
     return HookConfig.wrap(bytes26(setValue));
 }
 

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.25;
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {ExecutionHook} from "../interfaces/IAccountLoupe.sol";
-import {ModuleEntity} from "../interfaces/IModuleManager.sol";
+import {HookConfig, ModuleEntity} from "../interfaces/IModuleManager.sol";
 
 // bytes = keccak256("ERC6900.UpgradeableModularAccount.Storage")
 bytes32 constant _ACCOUNT_STORAGE_SLOT = 0x9f09680beaa4e5c9f38841db2460c401499164f368baef687948c315d9073e40;
@@ -70,19 +69,12 @@ function toModuleEntity(bytes32 setValue) pure returns (ModuleEntity) {
 // 0x________________________________________________AA____________________ is pre hook
 // 0x__________________________________________________BB__________________ is post hook
 
-function toSetValue(ExecutionHook memory executionHook) pure returns (bytes32) {
-    return bytes32(ModuleEntity.unwrap(executionHook.hookFunction))
-        | bytes32(executionHook.isPreHook ? uint256(1) << 56 : 0)
-        | bytes32(executionHook.isPostHook ? uint256(1) << 48 : 0);
+function toSetValue(HookConfig hookConfig) pure returns (bytes32) {
+    return bytes32(HookConfig.unwrap(hookConfig));
 }
 
-function toExecutionHook(bytes32 setValue)
-    pure
-    returns (ModuleEntity hookFunction, bool isPreHook, bool isPostHook)
-{
-    hookFunction = ModuleEntity.wrap(bytes24(setValue));
-    isPreHook = (uint256(setValue) >> 56) & 0xFF == 1;
-    isPostHook = (uint256(setValue) >> 48) & 0xFF == 1;
+function toExecutionHook(bytes32 setValue) pure returns (HookConfig) {
+    return HookConfig.wrap(bytes26(setValue));
 }
 
 function toSetValue(bytes4 selector) pure returns (bytes32) {

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -240,26 +240,22 @@ abstract contract ModuleManagerInternals is IModuleManager {
             getAccountStorage().validationData[validationConfig.moduleEntity()];
 
         for (uint256 i = 0; i < hooks.length; ++i) {
-            HookConfig hook = HookConfig.wrap(bytes26(hooks[i][:26]));
+            HookConfig hookConfig = HookConfig.wrap(bytes26(hooks[i][:26]));
             bytes calldata hookData = hooks[i][26:];
 
-            if (hook.isValidationHook()) {
-                _validationData.preValidationHooks.push(hook.moduleEntity());
+            if (hookConfig.isValidationHook()) {
+                _validationData.preValidationHooks.push(hookConfig.moduleEntity());
 
                 // Avoid collision between reserved index and actual indices
                 if (_validationData.preValidationHooks.length > MAX_PRE_VALIDATION_HOOKS) {
                     revert PreValidationHookLimitExceeded();
                 }
-
-                _onInstall(hook.module(), hookData);
-            } else {
-                // Hook is an execution hook
-                if (!_validationData.permissionHooks.add(toSetValue(hook))) {
-                    revert PermissionAlreadySet(validationConfig.moduleEntity(), hook);
-                }
-
-                _onInstall(hook.module(), hookData);
+            } // Hook is an execution hook
+            else if (!_validationData.permissionHooks.add(toSetValue(hookConfig))) {
+                revert PermissionAlreadySet(validationConfig.moduleEntity(), hookConfig);
             }
+
+            _onInstall(hookConfig.module(), hookData);
         }
 
         for (uint256 i = 0; i < selectors.length; ++i) {

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -33,7 +33,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
     error IModuleFunctionNotAllowed(bytes4 selector);
     error NativeFunctionNotAllowed(bytes4 selector);
     error NullModule();
-    error PermissionAlreadySet(ModuleEntity validationFunction, HookConfig hookFunction);
+    error PermissionAlreadySet(ModuleEntity validationFunction, HookConfig hookConfig);
     error ModuleInstallCallbackFailed(address module, bytes revertReason);
     error ModuleInterfaceNotSupported(address module);
     error ModuleNotInstalled(address module);
@@ -116,12 +116,12 @@ abstract contract ModuleManagerInternals is IModuleManager {
         }
     }
 
-    function _addExecHooks(EnumerableSet.Bytes32Set storage hooks, HookConfig hookFunction) internal {
-        hooks.add(toSetValue(hookFunction));
+    function _addExecHooks(EnumerableSet.Bytes32Set storage hooks, HookConfig hookConfig) internal {
+        hooks.add(toSetValue(hookConfig));
     }
 
-    function _removeExecHooks(EnumerableSet.Bytes32Set storage hooks, HookConfig hookFunction) internal {
-        hooks.remove(toSetValue(hookFunction));
+    function _removeExecHooks(EnumerableSet.Bytes32Set storage hooks, HookConfig hookConfig) internal {
+        hooks.remove(toSetValue(hookConfig));
     }
 
     function _installModule(address module, ModuleManifest calldata manifest, bytes memory moduleInstallData)
@@ -152,13 +152,13 @@ abstract contract ModuleManagerInternals is IModuleManager {
         for (uint256 i = 0; i < length; ++i) {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             EnumerableSet.Bytes32Set storage execHooks = _storage.selectorData[mh.executionSelector].executionHooks;
-            HookConfig hookFunction = HookConfigLib.packExecHook({
+            HookConfig hookConfig = HookConfigLib.packExecHook({
                 _module: module,
                 _entityId: mh.entityId,
                 _hasPre: mh.isPreHook,
                 _hasPost: mh.isPostHook
             });
-            _addExecHooks(execHooks, hookFunction);
+            _addExecHooks(execHooks, hookConfig);
         }
 
         length = manifest.interfaceIds.length;
@@ -187,13 +187,13 @@ abstract contract ModuleManagerInternals is IModuleManager {
         for (uint256 i = 0; i < length; ++i) {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             EnumerableSet.Bytes32Set storage execHooks = _storage.selectorData[mh.executionSelector].executionHooks;
-            HookConfig hookFunction = HookConfigLib.packExecHook({
+            HookConfig hookConfig = HookConfigLib.packExecHook({
                 _module: module,
                 _entityId: mh.entityId,
                 _hasPre: mh.isPreHook,
                 _hasPost: mh.isPostHook
             });
-            _removeExecHooks(execHooks, hookFunction);
+            _removeExecHooks(execHooks, hookConfig);
         }
 
         length = manifest.executionFunctions.length;

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -500,24 +500,24 @@ contract UpgradeableModularAccount is
         // Copy all post hooks to the array. This happens before any pre hooks are run, so we can
         // be sure that the set of hooks to run will not be affected by state changes mid-execution.
         for (uint256 i = 0; i < hooksLength; ++i) {
-            HookConfig hookFunction = toExecutionHook(executionHooks.at(i));
-            if (hookFunction.hasPostHook()) {
-                postHooksToRun[i].postExecHook = hookFunction.moduleEntity();
+            HookConfig hookConfig = toExecutionHook(executionHooks.at(i));
+            if (hookConfig.hasPostHook()) {
+                postHooksToRun[i].postExecHook = hookConfig.moduleEntity();
             }
         }
 
         // Run the pre hooks and copy their return data to the post hooks array, if an associated post-exec hook
         // exists.
         for (uint256 i = 0; i < hooksLength; ++i) {
-            HookConfig hookFunction = toExecutionHook(executionHooks.at(i));
+            HookConfig hookConfig = toExecutionHook(executionHooks.at(i));
 
-            if (hookFunction.hasPreHook()) {
+            if (hookConfig.hasPreHook()) {
                 bytes memory preExecHookReturnData;
 
-                preExecHookReturnData = _runPreExecHook(hookFunction.moduleEntity(), data);
+                preExecHookReturnData = _runPreExecHook(hookConfig.moduleEntity(), data);
 
                 // If there is an associated post-exec hook, save the return data.
-                if (hookFunction.hasPostHook()) {
+                if (hookConfig.hasPostHook()) {
                     postHooksToRun[i].preExecHookReturnData = preExecHookReturnData;
                 }
             }

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -28,7 +28,7 @@ import {IValidation} from "../interfaces/IValidation.sol";
 import {IValidationHook} from "../interfaces/IValidationHook.sol";
 import {AccountExecutor} from "./AccountExecutor.sol";
 import {AccountLoupe} from "./AccountLoupe.sol";
-import {AccountStorage, getAccountStorage, toExecutionHook, toSetValue} from "./AccountStorage.sol";
+import {AccountStorage, getAccountStorage, toHookConfig, toSetValue} from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
 import {ModuleManagerInternals} from "./ModuleManagerInternals.sol";
 
@@ -500,7 +500,7 @@ contract UpgradeableModularAccount is
         // Copy all post hooks to the array. This happens before any pre hooks are run, so we can
         // be sure that the set of hooks to run will not be affected by state changes mid-execution.
         for (uint256 i = 0; i < hooksLength; ++i) {
-            HookConfig hookConfig = toExecutionHook(executionHooks.at(i));
+            HookConfig hookConfig = toHookConfig(executionHooks.at(i));
             if (hookConfig.hasPostHook()) {
                 postHooksToRun[i].postExecHook = hookConfig.moduleEntity();
             }
@@ -509,7 +509,7 @@ contract UpgradeableModularAccount is
         // Run the pre hooks and copy their return data to the post hooks array, if an associated post-exec hook
         // exists.
         for (uint256 i = 0; i < hooksLength; ++i) {
-            HookConfig hookConfig = toExecutionHook(executionHooks.at(i));
+            HookConfig hookConfig = toHookConfig(executionHooks.at(i));
 
             if (hookConfig.hasPreHook()) {
                 bytes memory preExecHookReturnData;

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -251,10 +251,9 @@ contract UpgradeableModularAccount is
         ValidationConfig validationConfig,
         bytes4[] memory selectors,
         bytes calldata installData,
-        bytes calldata preValidationHooks,
-        bytes calldata permissionHooks
+        bytes[] calldata hooks
     ) external initializer {
-        _installValidation(validationConfig, selectors, installData, preValidationHooks, permissionHooks);
+        _installValidation(validationConfig, selectors, installData, hooks);
         emit ModularAccountInitialized(_ENTRY_POINT);
     }
 
@@ -264,10 +263,9 @@ contract UpgradeableModularAccount is
         ValidationConfig validationConfig,
         bytes4[] memory selectors,
         bytes calldata installData,
-        bytes calldata preValidationHooks,
-        bytes calldata permissionHooks
+        bytes[] calldata hooks
     ) external wrapNativeFunction {
-        _installValidation(validationConfig, selectors, installData, preValidationHooks, permissionHooks);
+        _installValidation(validationConfig, selectors, installData, hooks);
     }
 
     /// @inheritdoc IModuleManager
@@ -275,12 +273,9 @@ contract UpgradeableModularAccount is
     function uninstallValidation(
         ModuleEntity validationFunction,
         bytes calldata uninstallData,
-        bytes calldata preValidationHookUninstallData,
-        bytes calldata permissionHookUninstallData
+        bytes[] calldata hookUninstallData
     ) external wrapNativeFunction {
-        _uninstallValidation(
-            validationFunction, uninstallData, preValidationHookUninstallData, permissionHookUninstallData
-        );
+        _uninstallValidation(validationFunction, uninstallData, hookUninstallData);
     }
 
     /// @notice ERC165 introspection

--- a/src/helpers/HookConfigLib.sol
+++ b/src/helpers/HookConfigLib.sol
@@ -22,7 +22,7 @@ import {HookConfig, ModuleEntity} from "../interfaces/IModuleManager.sol";
 //
 
 // Hook types:
-// 0x00 // Exec
+// 0x00 // Exec (selector and validation associated)
 // 0x01 // Validation
 
 // Exec hook flags layout:

--- a/src/helpers/HookConfigLib.sol
+++ b/src/helpers/HookConfigLib.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import {HookConfig, ModuleEntity} from "../interfaces/IModuleManager.sol";
+
+// Hook types:
+// Exec hook: bools for hasPre, hasPost
+// Validation hook: no bools
+
+// Hook fields:
+// module address
+// entity ID
+// hook type
+// if exec hook: hasPre, hasPost
+
+// Hook config is a packed representation of a hook function and flags for its configuration.
+// Layout:
+// 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA________________________ // Address
+// 0x________________________________________BBBBBBBB________________ // Entity ID
+// 0x________________________________________________CC______________ // Type
+// 0x__________________________________________________DD____________ // exec hook flags
+//
+
+// Hook types:
+// 0x00 // Exec
+// 0x01 // Validation
+
+// Exec hook flags layout:
+// 0b000000__ // unused
+// 0b______A_ // hasPre
+// 0b_______B // hasPost
+
+library HookConfigLib {
+    // Hook type constants
+    // Exec has no bits set
+    bytes32 internal constant _HOOK_TYPE_EXEC = bytes32(uint256(0));
+    // Validation has 1 in the 25th byte
+    bytes32 internal constant _HOOK_TYPE_VALIDATION = bytes32(uint256(1) << 56);
+
+    // Exec hook flags constants
+    // Pre hook has 1 in 2's bit in the 26th byte
+    bytes32 internal constant _EXEC_HOOK_HAS_PRE = bytes32(uint256(1) << 49);
+    // Post hook has 1 in 1's bit in the 26th byte
+    bytes32 internal constant _EXEC_HOOK_HAS_POST = bytes32(uint256(1) << 48);
+
+    function packValidationHook(ModuleEntity _hookFunction) internal pure returns (HookConfig) {
+        return
+            HookConfig.wrap(bytes26(bytes26(ModuleEntity.unwrap(_hookFunction)) | bytes26(_HOOK_TYPE_VALIDATION)));
+    }
+
+    function packValidationHook(address _module, uint32 _entityId) internal pure returns (HookConfig) {
+        return HookConfig.wrap(
+            bytes25(
+                // module address stored in the first 20 bytes
+                bytes25(bytes20(_module))
+                // entityId stored in the 21st - 24th byte
+                | bytes25(bytes24(uint192(_entityId))) | bytes25(_HOOK_TYPE_VALIDATION)
+            )
+        );
+    }
+
+    function packExecHook(ModuleEntity _hookFunction, bool _hasPre, bool _hasPost)
+        internal
+        pure
+        returns (HookConfig)
+    {
+        return HookConfig.wrap(
+            bytes26(
+                bytes26(ModuleEntity.unwrap(_hookFunction))
+                // | bytes26(_HOOK_TYPE_EXEC) // Can omit because exec type is 0
+                | bytes26(_hasPre ? _EXEC_HOOK_HAS_PRE : bytes32(0))
+                    | bytes26(_hasPost ? _EXEC_HOOK_HAS_POST : bytes32(0))
+            )
+        );
+    }
+
+    function packExecHook(address _module, uint32 _entityId, bool _hasPre, bool _hasPost)
+        internal
+        pure
+        returns (HookConfig)
+    {
+        return HookConfig.wrap(
+            bytes26(
+                // module address stored in the first 20 bytes
+                bytes26(bytes20(_module))
+                // entityId stored in the 21st - 24th byte
+                | bytes26(bytes24(uint192(_entityId)))
+                // | bytes26(_HOOK_TYPE_EXEC) // Can omit because exec type is 0
+                | bytes26(_hasPre ? _EXEC_HOOK_HAS_PRE : bytes32(0))
+                    | bytes26(_hasPost ? _EXEC_HOOK_HAS_POST : bytes32(0))
+            )
+        );
+    }
+
+    function unpackValidationHook(HookConfig _config) internal pure returns (ModuleEntity _hookFunction) {
+        bytes26 configBytes = HookConfig.unwrap(_config);
+        _hookFunction = ModuleEntity.wrap(bytes24(configBytes));
+    }
+
+    function unpackExecHook(HookConfig _config)
+        internal
+        pure
+        returns (ModuleEntity _hookFunction, bool _hasPre, bool _hasPost)
+    {
+        bytes26 configBytes = HookConfig.unwrap(_config);
+        _hookFunction = ModuleEntity.wrap(bytes24(configBytes));
+        _hasPre = configBytes & _EXEC_HOOK_HAS_PRE != 0;
+        _hasPost = configBytes & _EXEC_HOOK_HAS_POST != 0;
+    }
+
+    function module(HookConfig _config) internal pure returns (address) {
+        return address(bytes20(HookConfig.unwrap(_config)));
+    }
+
+    function entityId(HookConfig _config) internal pure returns (uint32) {
+        return uint32(bytes4(HookConfig.unwrap(_config) << 160));
+    }
+
+    function moduleEntity(HookConfig _config) internal pure returns (ModuleEntity) {
+        return ModuleEntity.wrap(bytes24(HookConfig.unwrap(_config)));
+    }
+
+    // Check if the hook is a validation hook
+    // If false, it is an exec hook
+    function isValidationHook(HookConfig _config) internal pure returns (bool) {
+        return HookConfig.unwrap(_config) & _HOOK_TYPE_VALIDATION != 0;
+    }
+
+    // Check if the exec hook has a pre hook
+    // Undefined behavior if the hook is not an exec hook
+    function hasPreHook(HookConfig _config) internal pure returns (bool) {
+        return HookConfig.unwrap(_config) & _EXEC_HOOK_HAS_PRE != 0;
+    }
+
+    // Check if the exec hook has a post hook
+    // Undefined behavior if the hook is not an exec hook
+    function hasPostHook(HookConfig _config) internal pure returns (bool) {
+        return HookConfig.unwrap(_config) & _EXEC_HOOK_HAS_POST != 0;
+    }
+}

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -7,6 +7,8 @@ type ModuleEntity is bytes24;
 
 type ValidationConfig is bytes26;
 
+type HookConfig is bytes26;
+
 interface IModuleManager {
     event ModuleInstalled(address indexed module);
 
@@ -29,14 +31,14 @@ interface IModuleManager {
     /// @param validationConfig The validation function to install, along with configuration flags.
     /// @param selectors The selectors to install the validation function for.
     /// @param installData Optional data to be decoded and used by the module to setup initial module state.
-    /// @param preValidationHooks Optional pre-validation hooks to install for the validation function.
-    /// @param permissionHooks Optional permission hooks to install for the validation function.
+    /// @param hooks Optional hooks to install, associated with the validation function. These may be
+    /// pre-validation hooks or execution hooks. The expected format is a bytes26 HookConfig, followed by the
+    /// install data, if any.
     function installValidation(
         ValidationConfig validationConfig,
         bytes4[] memory selectors,
         bytes calldata installData,
-        bytes calldata preValidationHooks,
-        bytes calldata permissionHooks
+        bytes[] calldata hooks
     ) external;
 
     /// @notice Uninstall a validation function from a set of execution selectors.
@@ -44,14 +46,13 @@ interface IModuleManager {
     /// @param validationFunction The validation function to uninstall.
     /// @param uninstallData Optional data to be decoded and used by the module to clear module data for the
     /// account.
-    /// @param preValidationHookUninstallData Optional data to be decoded and used by the module to clear account
-    /// data
-    /// @param permissionHookUninstallData Optional data to be decoded and used by the module to clear account data
+    /// @param hookUninstallData Optional data to be used by hooks for cleanup. If any are provided, the array must
+    /// be of a length equal to existing pre-validation hooks plus permission hooks. Hooks are indexed by
+    /// pre-validation hook order first, then permission hooks.
     function uninstallValidation(
         ModuleEntity validationFunction,
         bytes calldata uninstallData,
-        bytes calldata preValidationHookUninstallData,
-        bytes calldata permissionHookUninstallData
+        bytes[] calldata hookUninstallData
     ) external;
 
     /// @notice Uninstall a module from the modular account.

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -36,7 +36,7 @@ interface IModuleManager {
     /// install data, if any.
     function installValidation(
         ValidationConfig validationConfig,
-        bytes4[] memory selectors,
+        bytes4[] calldata selectors,
         bytes calldata installData,
         bytes[] calldata hooks
     ) external;

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
+import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
 import {IModuleManager} from "../../src/interfaces/IModuleManager.sol";
@@ -135,28 +136,23 @@ contract AccountLoupeTest is CustomValidationTestBase {
         internal
         virtual
         override
-        returns (ModuleEntity, bool, bool, bytes4[] memory, bytes memory, bytes memory, bytes memory)
+        returns (ModuleEntity, bool, bool, bytes4[] memory, bytes memory, bytes[] memory)
     {
-        ModuleEntity[] memory preValidationHooks = new ModuleEntity[](2);
-        preValidationHooks[0] = ModuleEntityLib.pack(
-            address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.PRE_VALIDATION_HOOK_1)
+        bytes[] memory hooks = new bytes[](2);
+        hooks[0] = abi.encodePacked(
+            HookConfigLib.packValidationHook(
+                address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.PRE_VALIDATION_HOOK_1)
+            )
         );
-        preValidationHooks[1] = ModuleEntityLib.pack(
-            address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.PRE_VALIDATION_HOOK_2)
+        hooks[1] = abi.encodePacked(
+            HookConfigLib.packValidationHook(
+                address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.PRE_VALIDATION_HOOK_2)
+            )
         );
 
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = comprehensiveModule.foo.selector;
 
-        bytes[] memory installDatas = new bytes[](2);
-        return (
-            comprehensiveModuleValidation,
-            true,
-            true,
-            selectors,
-            bytes(""),
-            abi.encode(preValidationHooks, installDatas),
-            ""
-        );
+        return (comprehensiveModuleValidation, true, true, selectors, bytes(""), hooks);
     }
 }

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -48,8 +48,7 @@ contract AccountReturnDataTest is AccountTestBase {
             ValidationConfigLib.pack(address(resultConsumerModule), DIRECT_CALL_VALIDATION_ENTITYID, false, false),
             selectors,
             "",
-            "",
-            ""
+            new bytes[](0)
         );
         vm.stopPrank();
     }

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -39,8 +39,7 @@ contract MultiValidationTest is AccountTestBase {
             ValidationConfigLib.pack(address(validator2), TEST_DEFAULT_VALIDATION_ENTITY_ID, true, true),
             new bytes4[](0),
             abi.encode(TEST_DEFAULT_VALIDATION_ENTITY_ID, owner2),
-            "",
-            ""
+            new bytes[](0)
         );
 
         ModuleEntity[] memory validations = new ModuleEntity[](2);

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -33,7 +33,10 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
         account1.installValidation(
-            ValidationConfigLib.pack(comprehensiveModuleValidation, false, false), validationSelectors, "", "", ""
+            ValidationConfigLib.pack(comprehensiveModuleValidation, false, false),
+            validationSelectors,
+            "",
+            new bytes[](0)
         );
         vm.stopPrank();
     }
@@ -302,7 +305,12 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         account1.executeWithAuthorization(
             abi.encodeCall(
                 UpgradeableModularAccount.installValidation,
-                (ValidationConfigLib.pack(comprehensiveModuleValidation, false, false), selectors, "", "", "")
+                (
+                    ValidationConfigLib.pack(comprehensiveModuleValidation, false, false),
+                    selectors,
+                    "",
+                    new bytes[](0)
+                )
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );

--- a/test/libraries/HookConfigLib.t.sol
+++ b/test/libraries/HookConfigLib.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
+import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
+import {HookConfig, ModuleEntity} from "../../src/interfaces/IModuleManager.sol";
+
+contract HookConfigLibTest is Test {
+    using ModuleEntityLib for ModuleEntity;
+    using HookConfigLib for HookConfig;
+
+    // Tests the packing and unpacking of a hook config with a randomized state
+
+    function testFuzz_hookConfig_packingUnderlying(
+        address addr,
+        uint32 entityId,
+        bool isValidation,
+        bool hasPre,
+        bool hasPost
+    ) public {
+        HookConfig hookConfig;
+
+        if (isValidation) {
+            hookConfig = HookConfigLib.packValidationHook(addr, entityId);
+        } else {
+            hookConfig = HookConfigLib.packExecHook(addr, entityId, hasPre, hasPost);
+        }
+
+        assertEq(hookConfig.module(), addr, "module mismatch");
+        assertEq(hookConfig.entityId(), entityId, "entityId mismatch");
+        assertEq(hookConfig.isValidationHook(), isValidation, "isValidation mismatch");
+
+        if (!isValidation) {
+            assertEq(hookConfig.hasPreHook(), hasPre, "hasPre mismatch");
+            assertEq(hookConfig.hasPostHook(), hasPost, "hasPost mismatch");
+        }
+    }
+
+    function testFuzz_hookConfig_packingModuleEntity(
+        ModuleEntity hookFunction,
+        bool isValidation,
+        bool hasPre,
+        bool hasPost
+    ) public {
+        HookConfig hookConfig;
+
+        if (isValidation) {
+            hookConfig = HookConfigLib.packValidationHook(hookFunction);
+        } else {
+            hookConfig = HookConfigLib.packExecHook(hookFunction, hasPre, hasPost);
+        }
+
+        assertEq(
+            ModuleEntity.unwrap(hookConfig.moduleEntity()),
+            ModuleEntity.unwrap(hookFunction),
+            "moduleEntity mismatch"
+        );
+        assertEq(hookConfig.isValidationHook(), isValidation, "isValidation mismatch");
+
+        if (!isValidation) {
+            assertEq(hookConfig.hasPreHook(), hasPre, "hasPre mismatch");
+            assertEq(hookConfig.hasPostHook(), hasPost, "hasPost mismatch");
+        }
+    }
+}

--- a/test/mocks/SingleSignerFactoryFixture.sol
+++ b/test/mocks/SingleSignerFactoryFixture.sol
@@ -56,8 +56,7 @@ contract SingleSignerFactoryFixture is OptimizedTest {
                 ),
                 new bytes4[](0),
                 moduleInstallData,
-                "",
-                ""
+                new bytes[](0)
             );
         }
 

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -56,7 +56,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         bytes[] memory hooks = new bytes[](1);
         hooks[0] = abi.encodePacked(
             HookConfigLib.packExecHook({_module: address(module), _entityId: 0, _hasPre: true, _hasPost: false}),
-            abi.encode(uint8(0), limit) // TODO: should this still be uint8?
+            abi.encode(uint32(0), limit)
         );
 
         vm.prank(address(acct));

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -8,6 +8,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {ModuleEntity} from "../../src/helpers/ModuleEntityLib.sol";
 
+import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
@@ -52,16 +53,15 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         ERC20TokenLimitModule.ERC20SpendLimit[] memory limit = new ERC20TokenLimitModule.ERC20SpendLimit[](1);
         limit[0] = ERC20TokenLimitModule.ERC20SpendLimit({token: address(erc20), limits: limits});
 
-        bytes[] memory permissionInitDatas = new bytes[](1);
-        permissionInitDatas[0] = abi.encode(uint8(0), limit);
+        bytes[] memory hooks = new bytes[](1);
+        hooks[0] = abi.encodePacked(
+            HookConfigLib.packExecHook({_module: address(module), _entityId: 0, _hasPre: true, _hasPost: false}),
+            abi.encode(uint8(0), limit) // TODO: should this still be uint8?
+        );
 
         vm.prank(address(acct));
         acct.installValidation(
-            ValidationConfigLib.pack(address(validationModule), 0, true, true),
-            new bytes4[](0),
-            new bytes(0),
-            new bytes(0),
-            abi.encode(permissionHooks, permissionInitDatas)
+            ValidationConfigLib.pack(address(validationModule), 0, true, true), new bytes4[](0), "", hooks
         );
 
         validationFunction = ModuleEntityLib.pack(address(validationModule), 0);

--- a/test/module/NativeTokenLimitModule.t.sol
+++ b/test/module/NativeTokenLimitModule.t.sol
@@ -115,7 +115,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
                 UpgradeableModularAccount.PreExecHookReverted.selector,
                 abi.encode(
                     address(module),
-                    uint8(0),
+                    uint32(0),
                     abi.encodePacked(NativeTokenLimitModule.ExceededNativeTokenLimit.selector)
                 )
             )

--- a/test/module/SingleSignerValidation.t.sol
+++ b/test/module/SingleSignerValidation.t.sol
@@ -83,8 +83,7 @@ contract SingleSignerValidationTest is AccountTestBase {
             ValidationConfigLib.pack(address(singleSignerValidation), newEntityId, true, false),
             new bytes4[](0),
             abi.encode(newEntityId, owner2),
-            "",
-            ""
+            new bytes[](0)
         );
 
         vm.prank(owner2);

--- a/test/utils/CustomValidationTestBase.sol
+++ b/test/utils/CustomValidationTestBase.sol
@@ -21,8 +21,7 @@ abstract contract CustomValidationTestBase is AccountTestBase {
             bool isSignatureValidation,
             bytes4[] memory selectors,
             bytes memory installData,
-            bytes memory preValidationHooks,
-            bytes memory permissionHooks
+            bytes[] memory hooks
         ) = _initialValidationConfig();
 
         address accountImplementation = address(factory.accountImplementation());
@@ -33,8 +32,7 @@ abstract contract CustomValidationTestBase is AccountTestBase {
             ValidationConfigLib.pack(validationFunction, isGlobal, isSignatureValidation),
             selectors,
             installData,
-            preValidationHooks,
-            permissionHooks
+            hooks
         );
 
         vm.deal(address(account1), 100 ether);
@@ -49,7 +47,6 @@ abstract contract CustomValidationTestBase is AccountTestBase {
             bool isSignatureValidation,
             bytes4[] memory selectors,
             bytes memory installData,
-            bytes memory preValidationHooks,
-            bytes memory permissionHooks
+            bytes[] memory hooks
         );
 }


### PR DESCRIPTION
## Motivation

The parameter format of specifying pre-validation hooks and permission hooks separately for install is redundant, and uses inefficient patterns of ABI encoding for its inner fields.

## Solution

Much like `ValidationConfig`, introduce a `HookConfig` UDVT for holding:
- Module address
- Entity ID
- Hook type
- Pre/Post hook status

Use this type for installing validation associated hooks (pre-validation + permission hooks).

Use this type for internal encoding / decoding over the memory type `ExecutionHook`, which was only intended for external view functions.

Also bumps up the fuzzing runs for local testing - this setting is not used by CI, which uses `optimized-test-deep`.