### PR TITLE
Refactor:  split IExecution out from IModule and rename vars to reflect new structure

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -22,8 +22,8 @@ abstract contract AccountLoupe is IAccountLoupe {
         if (
             selector == IStandardExecutor.execute.selector || selector == IStandardExecutor.executeBatch.selector
                 || selector == UUPSUpgradeable.upgradeToAndCall.selector
-                || selector == IModuleManager.installModule.selector
-                || selector == IModuleManager.uninstallModule.selector
+                || selector == IModuleManager.installExecution.selector
+                || selector == IModuleManager.uninstallExecution.selector
         ) {
             return address(this);
         }

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -10,7 +10,7 @@ import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {KnownSelectors} from "../helpers/KnownSelectors.sol";
 import {ModuleEntityLib} from "../helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
-import {ManifestExecutionHook, ModuleManifest} from "../interfaces/IExecution.sol";
+import {ExecutionManifest, ManifestExecutionHook} from "../interfaces/IExecution.sol";
 import {IModule} from "../interfaces/IModule.sol";
 import {HookConfig, IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
 import {
@@ -125,7 +125,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
         hooks.remove(toSetValue(hookConfig));
     }
 
-    function _installModule(address module, ModuleManifest calldata manifest, bytes memory moduleInstallData)
+    function _installModule(address module, ExecutionManifest calldata manifest, bytes memory moduleInstallData)
         internal
     {
         AccountStorage storage _storage = getAccountStorage();
@@ -177,7 +177,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
         emit ModuleInstalled(module);
     }
 
-    function _uninstallModule(address module, ModuleManifest calldata manifest, bytes memory uninstallData)
+    function _uninstallModule(address module, ExecutionManifest calldata manifest, bytes memory uninstallData)
         internal
     {
         AccountStorage storage _storage = getAccountStorage();

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -125,7 +125,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
         hooks.remove(toSetValue(hookConfig));
     }
 
-    function _installModule(address module, ExecutionManifest calldata manifest, bytes memory moduleInstallData)
+    function _installExecution(address module, ExecutionManifest calldata manifest, bytes memory moduleInstallData)
         internal
     {
         AccountStorage storage _storage = getAccountStorage();
@@ -177,7 +177,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
         emit ModuleInstalled(module);
     }
 
-    function _uninstallModule(address module, ExecutionManifest calldata manifest, bytes memory uninstallData)
+    function _uninstallExecution(address module, ExecutionManifest calldata manifest, bytes memory uninstallData)
         internal
     {
         AccountStorage storage _storage = getAccountStorage();

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -10,7 +10,8 @@ import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {KnownSelectors} from "../helpers/KnownSelectors.sol";
 import {ModuleEntityLib} from "../helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
-import {IModule, ManifestExecutionHook, ModuleManifest} from "../interfaces/IModule.sol";
+import {ManifestExecutionHook, ModuleManifest} from "../interfaces/IExecution.sol";
+import {IModule} from "../interfaces/IModule.sol";
 import {HookConfig, IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
 import {
     AccountStorage,

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -20,8 +20,9 @@ import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationResHelpers.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITYID, RESERVED_VALIDATION_DATA_INDEX} from "../helpers/Constants.sol";
+
+import {ModuleManifest} from "../interfaces/IExecution.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
-import {ModuleManifest} from "../interfaces/IModule.sol";
 import {IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
 import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 import {IValidation} from "../interfaces/IValidation.sol";

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -21,7 +21,7 @@ import {_coalescePreValidation, _coalesceValidation} from "../helpers/Validation
 
 import {DIRECT_CALL_VALIDATION_ENTITYID, RESERVED_VALIDATION_DATA_INDEX} from "../helpers/Constants.sol";
 
-import {ModuleManifest} from "../interfaces/IExecution.sol";
+import {ExecutionManifest} from "../interfaces/IExecution.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
 import {IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
 import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
@@ -225,7 +225,7 @@ contract UpgradeableModularAccount is
 
     /// @inheritdoc IModuleManager
     /// @notice May be validated by a global validation.
-    function installModule(address module, ModuleManifest calldata manifest, bytes calldata moduleInstallData)
+    function installModule(address module, ExecutionManifest calldata manifest, bytes calldata moduleInstallData)
         external
         override
         wrapNativeFunction
@@ -235,11 +235,11 @@ contract UpgradeableModularAccount is
 
     /// @inheritdoc IModuleManager
     /// @notice May be validated by a global validation.
-    function uninstallModule(address module, ModuleManifest calldata manifest, bytes calldata moduleUninstallData)
-        external
-        override
-        wrapNativeFunction
-    {
+    function uninstallModule(
+        address module,
+        ExecutionManifest calldata manifest,
+        bytes calldata moduleUninstallData
+    ) external override wrapNativeFunction {
         _uninstallModule(module, manifest, moduleUninstallData);
     }
 

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -90,7 +90,7 @@ contract UpgradeableModularAccount is
     error SignatureSegmentOutOfOrder();
 
     // Wraps execution of a native function with runtime validation and hooks
-    // Used for upgradeTo, upgradeToAndCall, execute, executeBatch, installModule, uninstallModule
+    // Used for upgradeTo, upgradeToAndCall, execute, executeBatch, installExecution, uninstallExecution
     modifier wrapNativeFunction() {
         (PostExecToRun[] memory postPermissionHooks, PostExecToRun[] memory postExecHooks) =
             _checkPermittedCallerAndAssociatedHooks();
@@ -225,22 +225,22 @@ contract UpgradeableModularAccount is
 
     /// @inheritdoc IModuleManager
     /// @notice May be validated by a global validation.
-    function installModule(address module, ExecutionManifest calldata manifest, bytes calldata moduleInstallData)
-        external
-        override
-        wrapNativeFunction
-    {
-        _installModule(module, manifest, moduleInstallData);
+    function installExecution(
+        address module,
+        ExecutionManifest calldata manifest,
+        bytes calldata moduleInstallData
+    ) external override wrapNativeFunction {
+        _installExecution(module, manifest, moduleInstallData);
     }
 
     /// @inheritdoc IModuleManager
     /// @notice May be validated by a global validation.
-    function uninstallModule(
+    function uninstallExecution(
         address module,
         ExecutionManifest calldata manifest,
         bytes calldata moduleUninstallData
     ) external override wrapNativeFunction {
-        _uninstallModule(module, manifest, moduleUninstallData);
+        _uninstallExecution(module, manifest, moduleUninstallData);
     }
 
     /// @notice Initializes the account with a validation function added to the global pool.
@@ -690,7 +690,7 @@ contract UpgradeableModularAccount is
     function _globalValidationAllowed(bytes4 selector) internal view returns (bool) {
         if (
             selector == this.execute.selector || selector == this.executeBatch.selector
-                || selector == this.installModule.selector || selector == this.uninstallModule.selector
+                || selector == this.installExecution.selector || selector == this.uninstallExecution.selector
                 || selector == this.installValidation.selector || selector == this.uninstallValidation.selector
                 || selector == this.upgradeToAndCall.selector
         ) {

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -8,6 +8,8 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
+
+import {IExecution} from "../interfaces/IExecution.sol";
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
 import {IModule} from "../interfaces/IModule.sol";
 import {IModuleManager} from "../interfaces/IModuleManager.sol";
@@ -47,7 +49,7 @@ library KnownSelectors {
 
     function isIModuleFunction(bytes4 selector) internal pure returns (bool) {
         return selector == IModule.onInstall.selector || selector == IModule.onUninstall.selector
-            || selector == IModule.moduleManifest.selector || selector == IModule.moduleMetadata.selector
+            || selector == IExecution.moduleManifest.selector || selector == IModule.moduleMetadata.selector
             || selector == IExecutionHook.preExecutionHook.selector
             || selector == IExecutionHook.postExecutionHook.selector || selector == IValidation.validateUserOp.selector
             || selector == IValidation.validateRuntime.selector || selector == IValidation.validateSignature.selector

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -25,7 +25,8 @@ library KnownSelectors {
         // check against IAccount methods
         selector == IAccount.validateUserOp.selector
         // check against IModuleManager methods
-        || selector == IModuleManager.installModule.selector || selector == IModuleManager.uninstallModule.selector
+        || selector == IModuleManager.installExecution.selector
+            || selector == IModuleManager.uninstallExecution.selector
         // check against IERC165 methods
         || selector == IERC165.supportsInterface.selector
         // check against UUPSUpgradeable methods

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -49,7 +49,7 @@ library KnownSelectors {
 
     function isIModuleFunction(bytes4 selector) internal pure returns (bool) {
         return selector == IModule.onInstall.selector || selector == IModule.onUninstall.selector
-            || selector == IExecution.moduleManifest.selector || selector == IModule.moduleMetadata.selector
+            || selector == IExecution.executionManifest.selector || selector == IModule.moduleMetadata.selector
             || selector == IExecutionHook.preExecutionHook.selector
             || selector == IExecutionHook.postExecutionHook.selector || selector == IValidation.validateUserOp.selector
             || selector == IValidation.validateRuntime.selector || selector == IValidation.validateSignature.selector

--- a/src/interfaces/IExecution.sol
+++ b/src/interfaces/IExecution.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.25;
+
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+
+import {IModule} from "./IModule.sol";
+
+struct ManifestExecutionFunction {
+    // TODO(erc6900 spec): These fields can be packed into a single word
+    // The selector to install
+    bytes4 executionSelector;
+    // If true, the function won't need runtime validation, and can be called by anyone.
+    bool isPublic;
+    // If true, the function can be validated by a global validation function.
+    bool allowGlobalValidation;
+}
+
+struct ManifestExecutionHook {
+    // TODO(erc6900 spec): These fields can be packed into a single word
+    bytes4 executionSelector;
+    uint32 entityId;
+    bool isPreHook;
+    bool isPostHook;
+}
+
+/// @dev A struct describing how the module should be installed on a modular account.
+struct ModuleManifest {
+    // Execution functions defined in this module to be installed on the MSCA.
+    ManifestExecutionFunction[] executionFunctions;
+    ManifestExecutionHook[] executionHooks;
+    // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
+    // IModule's interface ID.
+    bytes4[] interfaceIds;
+}
+
+interface IExecution is IModule {
+    /// @notice Describe the contents and intended configuration of the module.
+    /// @dev This manifest MUST stay constant over time.
+    /// @return A manifest describing the contents and intended configuration of the module.
+    function moduleManifest() external pure returns (ModuleManifest memory);
+}

--- a/src/interfaces/IExecution.sol
+++ b/src/interfaces/IExecution.sol
@@ -24,7 +24,7 @@ struct ManifestExecutionHook {
 }
 
 /// @dev A struct describing how the module should be installed on a modular account.
-struct ModuleManifest {
+struct ExecutionManifest {
     // Execution functions defined in this module to be installed on the MSCA.
     ManifestExecutionFunction[] executionFunctions;
     ManifestExecutionHook[] executionHooks;
@@ -37,5 +37,5 @@ interface IExecution is IModule {
     /// @notice Describe the contents and intended configuration of the module.
     /// @dev This manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the module.
-    function moduleManifest() external pure returns (ModuleManifest memory);
+    function executionManifest() external pure returns (ExecutionManifest memory);
 }

--- a/src/interfaces/IExecution.sol
+++ b/src/interfaces/IExecution.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.25;
 
-import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
-
 import {IModule} from "./IModule.sol";
 
 struct ManifestExecutionFunction {

--- a/src/interfaces/IModule.sol
+++ b/src/interfaces/IModule.sol
@@ -26,13 +26,13 @@ struct ModuleMetadata {
 
 interface IModule is IERC165 {
     /// @notice Initialize module data for the modular account.
-    /// @dev Called by the modular account during `installModule`.
+    /// @dev Called by the modular account during `installExecution`.
     /// @param data Optional bytes array to be decoded and used by the module to setup initial module data for the
     /// modular account.
     function onInstall(bytes calldata data) external;
 
     /// @notice Clear module data for the modular account.
-    /// @dev Called by the modular account during `uninstallModule`.
+    /// @dev Called by the modular account during `uninstallExecution`.
     /// @param data Optional bytes array to be decoded and used by the module to clear module data for the modular
     /// account.
     function onUninstall(bytes calldata data) external;

--- a/src/interfaces/IModule.sol
+++ b/src/interfaces/IModule.sol
@@ -3,24 +3,6 @@ pragma solidity ^0.8.25;
 
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
-struct ManifestExecutionFunction {
-    // TODO(erc6900 spec): These fields can be packed into a single word
-    // The selector to install
-    bytes4 executionSelector;
-    // If true, the function won't need runtime validation, and can be called by anyone.
-    bool isPublic;
-    // If true, the function can be validated by a global validation function.
-    bool allowGlobalValidation;
-}
-
-struct ManifestExecutionHook {
-    // TODO(erc6900 spec): These fields can be packed into a single word
-    bytes4 executionSelector;
-    uint32 entityId;
-    bool isPreHook;
-    bool isPostHook;
-}
-
 struct SelectorPermission {
     bytes4 functionSelector;
     string permissionDescription;
@@ -42,16 +24,6 @@ struct ModuleMetadata {
     string[] permissionRequest;
 }
 
-/// @dev A struct describing how the module should be installed on a modular account.
-struct ModuleManifest {
-    // Execution functions defined in this module to be installed on the MSCA.
-    ManifestExecutionFunction[] executionFunctions;
-    ManifestExecutionHook[] executionHooks;
-    // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
-    // IModule's interface ID.
-    bytes4[] interfaceIds;
-}
-
 interface IModule is IERC165 {
     /// @notice Initialize module data for the modular account.
     /// @dev Called by the modular account during `installModule`.
@@ -64,11 +36,6 @@ interface IModule is IERC165 {
     /// @param data Optional bytes array to be decoded and used by the module to clear module data for the modular
     /// account.
     function onUninstall(bytes calldata data) external;
-
-    /// @notice Describe the contents and intended configuration of the module.
-    /// @dev This manifest MUST stay constant over time.
-    /// @return A manifest describing the contents and intended configuration of the module.
-    function moduleManifest() external pure returns (ModuleManifest memory);
 
     /// @notice Describe the metadata of the module.
     /// @dev This metadata MUST stay constant over time.

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.25;
 
-import {ModuleManifest} from "./IExecution.sol";
+import {ExecutionManifest} from "./IExecution.sol";
 
 type ModuleEntity is bytes24;
 
@@ -19,7 +19,7 @@ interface IModuleManager {
     /// @param manifest the manifest describing functions to install
     /// @param moduleInstallData Optional data to be decoded and used by the module to setup initial module data
     /// for the modular account.
-    function installModule(address module, ModuleManifest calldata manifest, bytes calldata moduleInstallData)
+    function installModule(address module, ExecutionManifest calldata manifest, bytes calldata moduleInstallData)
         external;
 
     /// @notice Temporary install function - pending a different user-supplied install config & manifest validation
@@ -60,6 +60,9 @@ interface IModuleManager {
     /// @param manifest the manifest describing functions to uninstall.
     /// @param moduleUninstallData Optional data to be decoded and used by the module to clear module data for the
     /// modular account.
-    function uninstallModule(address module, ModuleManifest calldata manifest, bytes calldata moduleUninstallData)
-        external;
+    function uninstallModule(
+        address module,
+        ExecutionManifest calldata manifest,
+        bytes calldata moduleUninstallData
+    ) external;
 }

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -19,8 +19,11 @@ interface IModuleManager {
     /// @param manifest the manifest describing functions to install
     /// @param moduleInstallData Optional data to be decoded and used by the module to setup initial module data
     /// for the modular account.
-    function installModule(address module, ExecutionManifest calldata manifest, bytes calldata moduleInstallData)
-        external;
+    function installExecution(
+        address module,
+        ExecutionManifest calldata manifest,
+        bytes calldata moduleInstallData
+    ) external;
 
     /// @notice Temporary install function - pending a different user-supplied install config & manifest validation
     /// path.
@@ -60,7 +63,7 @@ interface IModuleManager {
     /// @param manifest the manifest describing functions to uninstall.
     /// @param moduleUninstallData Optional data to be decoded and used by the module to clear module data for the
     /// modular account.
-    function uninstallModule(
+    function uninstallExecution(
         address module,
         ExecutionManifest calldata manifest,
         bytes calldata moduleUninstallData

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.25;
 
-import {ModuleManifest} from "./IModule.sol";
+import {ModuleManifest} from "./IExecution.sol";
 
 type ModuleEntity is bytes24;
 

--- a/src/modules/ERC20TokenLimitModule.sol
+++ b/src/modules/ERC20TokenLimitModule.sol
@@ -13,8 +13,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
-import {ModuleManifest, ModuleMetadata} from "../interfaces/IModule.sol";
-import {IModule} from "../interfaces/IModule.sol";
+import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 
 import {BaseModule, IERC165} from "./BaseModule.sol";
@@ -113,10 +112,6 @@ contract ERC20TokenLimitModule is BaseModule, IExecutionHook {
     function postExecutionHook(uint32, bytes calldata) external pure override {
         revert NotImplemented();
     }
-
-    /// @inheritdoc IModule
-    // solhint-disable-next-line no-empty-blocks
-    function moduleManifest() external pure override returns (ModuleManifest memory) {}
 
     /// @inheritdoc IModule
     function moduleMetadata() external pure virtual override returns (ModuleMetadata memory) {

--- a/src/modules/NativeTokenLimitModule.sol
+++ b/src/modules/NativeTokenLimitModule.sol
@@ -6,8 +6,7 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
-import {ModuleManifest, ModuleMetadata} from "../interfaces/IModule.sol";
-import {IModule} from "../interfaces/IModule.sol";
+import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 
 import {IValidationHook} from "../interfaces/IValidationHook.sol";
@@ -116,10 +115,6 @@ contract NativeTokenLimitModule is BaseModule, IExecutionHook, IValidationHook {
         pure
         override
     {} // solhint-disable-line no-empty-blocks
-
-    /// @inheritdoc IModule
-    // solhint-disable-next-line no-empty-blocks
-    function moduleManifest() external pure override returns (ModuleManifest memory) {}
 
     /// @inheritdoc IModule
     function moduleMetadata() external pure virtual override returns (ModuleMetadata memory) {

--- a/src/modules/TokenReceiverModule.sol
+++ b/src/modules/TokenReceiverModule.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.25;
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {IModule, ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../interfaces/IModule.sol";
+import {ManifestExecutionFunction, ModuleManifest} from "../interfaces/IExecution.sol";
+import {IExecution, ModuleManifest} from "../interfaces/IExecution.sol";
+import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {BaseModule} from "./BaseModule.sol";
 
 /// @title Token Receiver Module
 /// @author ERC-6900 Authors
 /// @notice This module allows modular accounts to receive various types of tokens by implementing
 /// required token receiver interfaces.
-contract TokenReceiverModule is BaseModule, IERC721Receiver, IERC1155Receiver {
+contract TokenReceiverModule is BaseModule, IExecution, IERC721Receiver, IERC1155Receiver {
     string internal constant _NAME = "Token Receiver Module";
     string internal constant _VERSION = "1.0.0";
     string internal constant _AUTHOR = "ERC-6900 Authors";
@@ -54,7 +56,7 @@ contract TokenReceiverModule is BaseModule, IERC721Receiver, IERC1155Receiver {
     // solhint-disable-next-line no-empty-blocks
     function onUninstall(bytes calldata) external pure override {}
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IExecution
     function moduleManifest() external pure override returns (ModuleManifest memory) {
         ModuleManifest memory manifest;
 

--- a/src/modules/TokenReceiverModule.sol
+++ b/src/modules/TokenReceiverModule.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.25;
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {ManifestExecutionFunction, ModuleManifest} from "../interfaces/IExecution.sol";
-import {IExecution, ModuleManifest} from "../interfaces/IExecution.sol";
+import {ExecutionManifest, ManifestExecutionFunction} from "../interfaces/IExecution.sol";
+import {ExecutionManifest, IExecution} from "../interfaces/IExecution.sol";
 import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {BaseModule} from "./BaseModule.sol";
 
@@ -57,8 +57,8 @@ contract TokenReceiverModule is BaseModule, IExecution, IERC721Receiver, IERC115
     function onUninstall(bytes calldata) external pure override {}
 
     /// @inheritdoc IExecution
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](3);
         manifest.executionFunctions[0] = ManifestExecutionFunction({

--- a/src/modules/permissionhooks/AllowlistModule.sol
+++ b/src/modules/permissionhooks/AllowlistModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {ModuleManifest, ModuleMetadata} from "../../interfaces/IModule.sol";
+import {ModuleMetadata} from "../../interfaces/IModule.sol";
 
 import {Call, IStandardExecutor} from "../../interfaces/IStandardExecutor.sol";
 import {IValidationHook} from "../../interfaces/IValidationHook.sol";
@@ -103,9 +103,6 @@ contract AllowlistModule is IValidationHook, BaseModule {
 
         return metadata;
     }
-
-    // solhint-disable-next-line no-empty-blocks
-    function moduleManifest() external pure override returns (ModuleManifest memory) {}
 
     function _checkAllowlistCalldata(bytes calldata callData) internal view {
         if (bytes4(callData[:4]) == IStandardExecutor.execute.selector) {

--- a/src/modules/validation/SingleSignerValidation.sol
+++ b/src/modules/validation/SingleSignerValidation.sol
@@ -6,7 +6,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
-import {IModule, ModuleManifest, ModuleMetadata} from "../../interfaces/IModule.sol";
+import {IModule, ModuleMetadata} from "../../interfaces/IModule.sol";
 import {IValidation} from "../../interfaces/IValidation.sol";
 import {BaseModule} from "../BaseModule.sol";
 import {ISingleSignerValidation} from "./ISingleSignerValidation.sol";
@@ -117,12 +117,6 @@ contract SingleSignerValidation is ISingleSignerValidation, BaseModule {
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-    /// @inheritdoc IModule
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
-        return manifest;
-    }
 
     /// @inheritdoc IModule
     function moduleMetadata() external pure virtual override returns (ModuleMetadata memory) {

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
 import {
     IModule,
     ManifestExecutionFunction,
     ManifestExecutionHook,
     ModuleManifest
-} from "../../src/interfaces/IModule.sol";
+} from "../../src/interfaces/IExecution.sol";
+import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
 
 import {MockModule} from "../mocks/MockModule.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.19;
 
 import {
+    ExecutionManifest,
     IModule,
     ManifestExecutionFunction,
-    ManifestExecutionHook,
-    ModuleManifest
+    ManifestExecutionHook
 } from "../../src/interfaces/IExecution.sol";
 import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
 
@@ -20,7 +20,7 @@ contract AccountExecHooksTest is AccountTestBase {
     uint32 internal constant _POST_HOOK_FUNCTION_ID_2 = 2;
     uint32 internal constant _BOTH_HOOKS_FUNCTION_ID_3 = 3;
 
-    ModuleManifest internal _m1;
+    ExecutionManifest internal _m1;
 
     event ModuleInstalled(address indexed module);
     event ModuleUninstalled(address indexed module, bool indexed callbacksSucceeded);
@@ -169,7 +169,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         account1.installModule({
             module: address(mockModule1),
-            manifest: mockModule1.moduleManifest(),
+            manifest: mockModule1.executionManifest(),
             moduleInstallData: bytes("")
         });
         vm.stopPrank();
@@ -182,7 +182,7 @@ contract AccountExecHooksTest is AccountTestBase {
         emit ModuleUninstalled(address(module), true);
 
         vm.startPrank(address(entryPoint));
-        account1.uninstallModule(address(module), module.moduleManifest(), bytes(""));
+        account1.uninstallModule(address(module), module.executionManifest(), bytes(""));
         vm.stopPrank();
     }
 }

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -40,7 +40,7 @@ contract AccountExecHooksTest is AccountTestBase {
     }
 
     function test_preExecHook_install() public {
-        _installModule1WithHooks(
+        _installExecution1WithHooks(
             ManifestExecutionHook({
                 executionSelector: _EXEC_SELECTOR,
                 entityId: _PRE_HOOK_FUNCTION_ID_1,
@@ -74,11 +74,11 @@ contract AccountExecHooksTest is AccountTestBase {
     function test_preExecHook_uninstall() public {
         test_preExecHook_install();
 
-        _uninstallModule(mockModule1);
+        _uninstallExecution(mockModule1);
     }
 
     function test_execHookPair_install() public {
-        _installModule1WithHooks(
+        _installExecution1WithHooks(
             ManifestExecutionHook({
                 executionSelector: _EXEC_SELECTOR,
                 entityId: _BOTH_HOOKS_FUNCTION_ID_3,
@@ -122,11 +122,11 @@ contract AccountExecHooksTest is AccountTestBase {
     function test_execHookPair_uninstall() public {
         test_execHookPair_install();
 
-        _uninstallModule(mockModule1);
+        _uninstallExecution(mockModule1);
     }
 
     function test_postOnlyExecHook_install() public {
-        _installModule1WithHooks(
+        _installExecution1WithHooks(
             ManifestExecutionHook({
                 executionSelector: _EXEC_SELECTOR,
                 entityId: _POST_HOOK_FUNCTION_ID_2,
@@ -154,10 +154,10 @@ contract AccountExecHooksTest is AccountTestBase {
     function test_postOnlyExecHook_uninstall() public {
         test_postOnlyExecHook_install();
 
-        _uninstallModule(mockModule1);
+        _uninstallExecution(mockModule1);
     }
 
-    function _installModule1WithHooks(ManifestExecutionHook memory execHooks) internal {
+    function _installExecution1WithHooks(ManifestExecutionHook memory execHooks) internal {
         _m1.executionHooks.push(execHooks);
         mockModule1 = new MockModule(_m1);
 
@@ -167,7 +167,7 @@ contract AccountExecHooksTest is AccountTestBase {
         emit ModuleInstalled(address(mockModule1));
 
         vm.startPrank(address(entryPoint));
-        account1.installModule({
+        account1.installExecution({
             module: address(mockModule1),
             manifest: mockModule1.executionManifest(),
             moduleInstallData: bytes("")
@@ -175,14 +175,14 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.stopPrank();
     }
 
-    function _uninstallModule(MockModule module) internal {
+    function _uninstallExecution(MockModule module) internal {
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(abi.encodeCall(IModule.onUninstall, (bytes(""))), 0);
         vm.expectEmit(true, true, true, true);
         emit ModuleUninstalled(address(module), true);
 
         vm.startPrank(address(entryPoint));
-        account1.uninstallModule(address(module), module.executionManifest(), bytes(""));
+        account1.uninstallExecution(address(module), module.executionManifest(), bytes(""));
         vm.stopPrank();
     }
 }

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -27,7 +27,7 @@ contract AccountLoupeTest is CustomValidationTestBase {
         _customValidationSetup();
 
         vm.startPrank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), comprehensiveModule.executionManifest(), "");
+        account1.installExecution(address(comprehensiveModule), comprehensiveModule.executionManifest(), "");
         vm.stopPrank();
     }
 
@@ -40,9 +40,9 @@ contract AccountLoupeTest is CustomValidationTestBase {
 
         selectorsToCheck[2] = UUPSUpgradeable.upgradeToAndCall.selector;
 
-        selectorsToCheck[3] = IModuleManager.installModule.selector;
+        selectorsToCheck[3] = IModuleManager.installExecution.selector;
 
-        selectorsToCheck[4] = IModuleManager.uninstallModule.selector;
+        selectorsToCheck[4] = IModuleManager.uninstallExecution.selector;
 
         for (uint256 i = 0; i < selectorsToCheck.length; i++) {
             address module = account1.getExecutionFunctionHandler(selectorsToCheck[i]);

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -27,7 +27,7 @@ contract AccountLoupeTest is CustomValidationTestBase {
         _customValidationSetup();
 
         vm.startPrank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
+        account1.installModule(address(comprehensiveModule), comprehensiveModule.executionManifest(), "");
         vm.stopPrank();
     }
 

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -30,13 +30,13 @@ contract AccountReturnDataTest is AccountTestBase {
 
         // Add the result creator module to the account
         vm.startPrank(address(entryPoint));
-        account1.installModule({
+        account1.installExecution({
             module: address(resultCreatorModule),
             manifest: resultCreatorModule.executionManifest(),
             moduleInstallData: ""
         });
         // Add the result consumer module to the account
-        account1.installModule({
+        account1.installExecution({
             module: address(resultConsumerModule),
             manifest: resultConsumerModule.executionManifest(),
             moduleInstallData: ""

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -32,13 +32,13 @@ contract AccountReturnDataTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         account1.installModule({
             module: address(resultCreatorModule),
-            manifest: resultCreatorModule.moduleManifest(),
+            manifest: resultCreatorModule.executionManifest(),
             moduleInstallData: ""
         });
         // Add the result consumer module to the account
         account1.installModule({
             module: address(resultConsumerModule),
-            manifest: resultConsumerModule.moduleManifest(),
+            manifest: resultConsumerModule.executionManifest(),
             moduleInstallData: ""
         });
         // Allow the result consumer module to perform direct calls to the account

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -34,9 +34,9 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     }
 
     function test_Fail_DirectCallModuleUninstalled() external {
-        _installModule();
+        _installExecution();
 
-        _uninstallModule();
+        _uninstallExecution();
 
         vm.prank(address(_module));
         vm.expectRevert(_buildDirectCallDisallowedError(IStandardExecutor.execute.selector));
@@ -44,7 +44,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     }
 
     function test_Fail_DirectCallModuleCallOtherSelector() external {
-        _installModule();
+        _installExecution();
 
         Call[] memory calls = new Call[](0);
 
@@ -58,7 +58,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     /* -------------------------------------------------------------------------- */
 
     function test_Pass_DirectCallFromModulePrank() external {
-        _installModule();
+        _installExecution();
 
         vm.prank(address(_module));
         account1.execute(address(0), 0, "");
@@ -68,7 +68,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     }
 
     function test_Pass_DirectCallFromModuleCallback() external {
-        _installModule();
+        _installExecution();
 
         bytes memory encodedCall = abi.encodeCall(DirectCallModule.directCall, ());
 
@@ -86,7 +86,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     function test_Flow_DirectCallFromModuleSequence() external {
         // Install => Succeesfully call => uninstall => fail to call
 
-        _installModule();
+        _installExecution();
 
         vm.prank(address(_module));
         account1.execute(address(0), 0, "");
@@ -94,7 +94,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         assertTrue(_module.preHookRan());
         assertTrue(_module.postHookRan());
 
-        _uninstallModule();
+        _uninstallExecution();
 
         vm.prank(address(_module));
         vm.expectRevert(_buildDirectCallDisallowedError(IStandardExecutor.execute.selector));
@@ -105,7 +105,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     /*                                  Internals                                 */
     /* -------------------------------------------------------------------------- */
 
-    function _installModule() internal {
+    function _installExecution() internal {
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = IStandardExecutor.execute.selector;
 
@@ -122,7 +122,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         account1.installValidation(validationConfig, selectors, "", hooks);
     }
 
-    function _uninstallModule() internal {
+    function _uninstallExecution() internal {
         vm.prank(address(entryPoint));
         account1.uninstallValidation(_moduleEntity, "", new bytes[](1));
     }

--- a/test/account/PermittedCallPermissions.t.sol
+++ b/test/account/PermittedCallPermissions.t.sol
@@ -22,13 +22,13 @@ contract PermittedCallPermissionsTest is AccountTestBase {
 
         // Add the result creator module to the account
         vm.startPrank(address(entryPoint));
-        account1.installModule({
+        account1.installExecution({
             module: address(resultCreatorModule),
             manifest: resultCreatorModule.executionManifest(),
             moduleInstallData: ""
         });
         // Add the permitted caller module to the account
-        account1.installModule({
+        account1.installExecution({
             module: address(permittedCallerModule),
             manifest: permittedCallerModule.executionManifest(),
             moduleInstallData: ""

--- a/test/account/PermittedCallPermissions.t.sol
+++ b/test/account/PermittedCallPermissions.t.sol
@@ -24,13 +24,13 @@ contract PermittedCallPermissionsTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         account1.installModule({
             module: address(resultCreatorModule),
-            manifest: resultCreatorModule.moduleManifest(),
+            manifest: resultCreatorModule.executionManifest(),
             moduleInstallData: ""
         });
         // Add the permitted caller module to the account
         account1.installModule({
             module: address(permittedCallerModule),
-            manifest: permittedCallerModule.moduleManifest(),
+            manifest: permittedCallerModule.executionManifest(),
             moduleInstallData: ""
         });
         vm.stopPrank();

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -31,7 +31,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         validationSelectors[0] = ComprehensiveModule.foo.selector;
 
         vm.startPrank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), comprehensiveModule.executionManifest(), "");
+        account1.installExecution(address(comprehensiveModule), comprehensiveModule.executionManifest(), "");
         account1.installValidation(
             ValidationConfigLib.pack(comprehensiveModuleValidation, false, false),
             validationSelectors,

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -31,7 +31,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         validationSelectors[0] = ComprehensiveModule.foo.selector;
 
         vm.startPrank(address(entryPoint));
-        account1.installModule(address(comprehensiveModule), comprehensiveModule.moduleManifest(), "");
+        account1.installModule(address(comprehensiveModule), comprehensiveModule.executionManifest(), "");
         account1.installValidation(
             ValidationConfigLib.pack(comprehensiveModuleValidation, false, false),
             validationSelectors,

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -236,12 +236,12 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         assertEq(ethRecipient.balance, 2 wei);
     }
 
-    function test_installModule() public {
+    function test_installExecution() public {
         vm.startPrank(address(entryPoint));
 
         vm.expectEmit(true, true, true, true);
         emit ModuleInstalled(address(tokenReceiverModule));
-        IModuleManager(account1).installModule({
+        IModuleManager(account1).installExecution({
             module: address(tokenReceiverModule),
             manifest: tokenReceiverModule.executionManifest(),
             moduleInstallData: abi.encode(uint48(1 days))
@@ -252,21 +252,21 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         assertEq(handler, address(tokenReceiverModule));
     }
 
-    function test_installModule_PermittedCallSelectorNotInstalled() public {
+    function test_installExecution_PermittedCallSelectorNotInstalled() public {
         vm.startPrank(address(entryPoint));
 
         ExecutionManifest memory m;
 
         MockModule mockModuleWithBadPermittedExec = new MockModule(m);
 
-        IModuleManager(account1).installModule({
+        IModuleManager(account1).installExecution({
             module: address(mockModuleWithBadPermittedExec),
             manifest: mockModuleWithBadPermittedExec.executionManifest(),
             moduleInstallData: ""
         });
     }
 
-    function test_installModule_interfaceNotSupported() public {
+    function test_installExecution_interfaceNotSupported() public {
         vm.startPrank(address(entryPoint));
 
         address badModule = address(1);
@@ -276,14 +276,14 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
         ExecutionManifest memory m;
 
-        IModuleManager(account1).installModule({module: address(badModule), manifest: m, moduleInstallData: ""});
+        IModuleManager(account1).installExecution({module: address(badModule), manifest: m, moduleInstallData: ""});
     }
 
-    function test_installModule_alreadyInstalled() public {
+    function test_installExecution_alreadyInstalled() public {
         ExecutionManifest memory m = tokenReceiverModule.executionManifest();
 
         vm.prank(address(entryPoint));
-        IModuleManager(account1).installModule({
+        IModuleManager(account1).installExecution({
             module: address(tokenReceiverModule),
             manifest: m,
             moduleInstallData: abi.encode(uint48(1 days))
@@ -296,18 +296,18 @@ contract UpgradeableModularAccountTest is AccountTestBase {
                 TokenReceiverModule.onERC721Received.selector
             )
         );
-        IModuleManager(account1).installModule({
+        IModuleManager(account1).installExecution({
             module: address(tokenReceiverModule),
             manifest: m,
             moduleInstallData: abi.encode(uint48(1 days))
         });
     }
 
-    function test_uninstallModule_default() public {
+    function test_uninstallExecution_default() public {
         vm.startPrank(address(entryPoint));
 
         ComprehensiveModule module = new ComprehensiveModule();
-        IModuleManager(account1).installModule({
+        IModuleManager(account1).installExecution({
             module: address(module),
             manifest: module.executionManifest(),
             moduleInstallData: ""
@@ -315,7 +315,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
         vm.expectEmit(true, true, true, true);
         emit ModuleUninstalled(address(module), true);
-        IModuleManager(account1).uninstallModule({
+        IModuleManager(account1).uninstallExecution({
             module: address(module),
             manifest: module.executionManifest(),
             moduleUninstallData: ""
@@ -325,12 +325,12 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         assertEq(handler, address(0));
     }
 
-    function _installModuleWithExecHooks() internal returns (MockModule module) {
+    function _installExecutionWithExecHooks() internal returns (MockModule module) {
         vm.startPrank(address(entryPoint));
 
         module = new MockModule(_manifest);
 
-        IModuleManager(account1).installModule({
+        IModuleManager(account1).installExecution({
             module: address(module),
             manifest: module.executionManifest(),
             moduleInstallData: ""

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -13,7 +13,7 @@ import {ModuleManagerInternals} from "../../src/account/ModuleManagerInternals.s
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
-import {ModuleManifest} from "../../src/interfaces/IModule.sol";
+import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
 import {IModuleManager} from "../../src/interfaces/IModuleManager.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
 

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -13,7 +13,7 @@ import {ModuleManagerInternals} from "../../src/account/ModuleManagerInternals.s
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
-import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
 import {IModuleManager} from "../../src/interfaces/IModuleManager.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
 
@@ -40,7 +40,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
     address public ethRecipient;
     Counter public counter;
-    ModuleManifest internal _manifest;
+    ExecutionManifest internal _manifest;
 
     event ModuleInstalled(address indexed module);
     event ModuleUninstalled(address indexed module, bool indexed callbacksSucceeded);
@@ -243,7 +243,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         emit ModuleInstalled(address(tokenReceiverModule));
         IModuleManager(account1).installModule({
             module: address(tokenReceiverModule),
-            manifest: tokenReceiverModule.moduleManifest(),
+            manifest: tokenReceiverModule.executionManifest(),
             moduleInstallData: abi.encode(uint48(1 days))
         });
 
@@ -255,13 +255,13 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     function test_installModule_PermittedCallSelectorNotInstalled() public {
         vm.startPrank(address(entryPoint));
 
-        ModuleManifest memory m;
+        ExecutionManifest memory m;
 
         MockModule mockModuleWithBadPermittedExec = new MockModule(m);
 
         IModuleManager(account1).installModule({
             module: address(mockModuleWithBadPermittedExec),
-            manifest: mockModuleWithBadPermittedExec.moduleManifest(),
+            manifest: mockModuleWithBadPermittedExec.executionManifest(),
             moduleInstallData: ""
         });
     }
@@ -274,13 +274,13 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             abi.encodeWithSelector(ModuleManagerInternals.ModuleInterfaceNotSupported.selector, address(badModule))
         );
 
-        ModuleManifest memory m;
+        ExecutionManifest memory m;
 
         IModuleManager(account1).installModule({module: address(badModule), manifest: m, moduleInstallData: ""});
     }
 
     function test_installModule_alreadyInstalled() public {
-        ModuleManifest memory m = tokenReceiverModule.moduleManifest();
+        ExecutionManifest memory m = tokenReceiverModule.executionManifest();
 
         vm.prank(address(entryPoint));
         IModuleManager(account1).installModule({
@@ -309,7 +309,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         ComprehensiveModule module = new ComprehensiveModule();
         IModuleManager(account1).installModule({
             module: address(module),
-            manifest: module.moduleManifest(),
+            manifest: module.executionManifest(),
             moduleInstallData: ""
         });
 
@@ -317,7 +317,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         emit ModuleUninstalled(address(module), true);
         IModuleManager(account1).uninstallModule({
             module: address(module),
-            manifest: module.moduleManifest(),
+            manifest: module.executionManifest(),
             moduleUninstallData: ""
         });
 
@@ -332,7 +332,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
         IModuleManager(account1).installModule({
             module: address(module),
-            manifest: module.moduleManifest(),
+            manifest: module.executionManifest(),
             moduleInstallData: ""
         });
 

--- a/test/mocks/MockModule.sol
+++ b/test/mocks/MockModule.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.19;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
+import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
 import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
-import {IModule, ModuleManifest, ModuleMetadata} from "../../src/interfaces/IModule.sol";
+import {IModule, ModuleMetadata} from "../../src/interfaces/IModule.sol";
 import {IValidation} from "../../src/interfaces/IValidation.sol";
 
 contract MockModule is ERC165 {

--- a/test/mocks/MockModule.sol
+++ b/test/mocks/MockModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
 import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
 import {IModule, ModuleMetadata} from "../../src/interfaces/IModule.sol";
 import {IValidation} from "../../src/interfaces/IValidation.sol";
@@ -28,26 +28,26 @@ contract MockModule is ERC165 {
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    constructor(ModuleManifest memory _moduleManifest) {
-        _manifest = abi.encode(_moduleManifest);
+    constructor(ExecutionManifest memory _executionManifest) {
+        _manifest = abi.encode(_executionManifest);
     }
 
-    function _getManifest() internal view returns (ModuleManifest memory) {
-        ModuleManifest memory m = abi.decode(_manifest, (ModuleManifest));
+    function _getManifest() internal view returns (ExecutionManifest memory) {
+        ExecutionManifest memory m = abi.decode(_manifest, (ExecutionManifest));
         return m;
     }
 
-    function _castToPure(function() internal view returns (ModuleManifest memory) fnIn)
+    function _castToPure(function() internal view returns (ExecutionManifest memory) fnIn)
         internal
         pure
-        returns (function() internal pure returns (ModuleManifest memory) fnOut)
+        returns (function() internal pure returns (ExecutionManifest memory) fnOut)
     {
         assembly ("memory-safe") {
             fnOut := fnIn
         }
     }
 
-    function moduleManifest() external pure returns (ModuleManifest memory) {
+    function executionManifest() external pure returns (ExecutionManifest memory) {
         return _castToPure(_getManifest)();
     }
 

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -3,20 +3,22 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
 import {
+    IExecution,
     ManifestExecutionFunction,
     ManifestExecutionHook,
-    ModuleManifest,
-    ModuleMetadata
-} from "../../../src/interfaces/IModule.sol";
-import {ModuleManifest} from "../../../src/interfaces/IModule.sol";
+    ModuleManifest
+} from "../../../src/interfaces/IExecution.sol";
+
+import {IExecution} from "../../../src/interfaces/IExecution.sol";
+import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
+import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
-contract ComprehensiveModule is IValidation, IValidationHook, IExecutionHook, BaseModule {
+contract ComprehensiveModule is IExecution, IValidation, IValidationHook, IExecutionHook, BaseModule {
     enum EntityId {
         PRE_VALIDATION_HOOK_1,
         PRE_VALIDATION_HOOK_2,

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.19;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
 import {
+    ExecutionManifest,
     IExecution,
     ManifestExecutionFunction,
-    ManifestExecutionHook,
-    ModuleManifest
+    ManifestExecutionHook
 } from "../../../src/interfaces/IExecution.sol";
 
 import {IExecution} from "../../../src/interfaces/IExecution.sol";
@@ -131,8 +131,8 @@ contract ComprehensiveModule is IExecution, IValidation, IValidationHook, IExecu
         revert NotImplemented();
     }
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({

--- a/test/mocks/modules/DirectCallModule.sol
+++ b/test/mocks/modules/DirectCallModule.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
-import {ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
+import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
@@ -14,8 +14,6 @@ contract DirectCallModule is BaseModule, IExecutionHook {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}
-
-    function moduleManifest() external pure override returns (ModuleManifest memory) {}
 
     function directCall() external returns (bytes memory) {
         return IStandardExecutor(msg.sender).execute(address(this), 0, abi.encodeCall(this.getData, ()));

--- a/test/mocks/modules/MockAccessControlHookModule.sol
+++ b/test/mocks/modules/MockAccessControlHookModule.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.25;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
-
+import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
@@ -74,6 +73,4 @@ contract MockAccessControlHookModule is IValidationHook, BaseModule {
     }
 
     function moduleMetadata() external pure override returns (ModuleMetadata memory) {}
-
-    function moduleManifest() external pure override returns (ModuleManifest memory) {}
 }

--- a/test/mocks/modules/PermittedCallMocks.sol
+++ b/test/mocks/modules/PermittedCallMocks.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
+import {IExecution, ManifestExecutionFunction, ModuleManifest} from "../../../src/interfaces/IExecution.sol";
+import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 import {ResultCreatorModule} from "./ReturnDataModuleMocks.sol";
 
-contract PermittedCallerModule is BaseModule {
+contract PermittedCallerModule is IExecution, BaseModule {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}

--- a/test/mocks/modules/PermittedCallMocks.sol
+++ b/test/mocks/modules/PermittedCallMocks.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {IExecution, ManifestExecutionFunction, ModuleManifest} from "../../../src/interfaces/IExecution.sol";
+import {ExecutionManifest, IExecution, ManifestExecutionFunction} from "../../../src/interfaces/IExecution.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
@@ -12,8 +12,8 @@ contract PermittedCallerModule is IExecution, BaseModule {
 
     function onUninstall(bytes calldata) external override {}
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
         manifest.executionFunctions[0].executionSelector = this.usePermittedCallAllowed.selector;

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
+import {IExecution, ManifestExecutionFunction, ModuleManifest} from "../../../src/interfaces/IExecution.sol";
+import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../../src/helpers/Constants.sol";
 
@@ -22,7 +23,7 @@ contract RegularResultContract {
     }
 }
 
-contract ResultCreatorModule is BaseModule {
+contract ResultCreatorModule is IExecution, BaseModule {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}
@@ -56,7 +57,7 @@ contract ResultCreatorModule is BaseModule {
     function moduleMetadata() external pure override returns (ModuleMetadata memory) {}
 }
 
-contract ResultConsumerModule is BaseModule, IValidation {
+contract ResultConsumerModule is IExecution, BaseModule, IValidation {
     ResultCreatorModule public immutable RESULT_CREATOR;
     RegularResultContract public immutable REGULAR_RESULT_CONTRACT;
 

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {IExecution, ManifestExecutionFunction, ModuleManifest} from "../../../src/interfaces/IExecution.sol";
+import {ExecutionManifest, IExecution, ManifestExecutionFunction} from "../../../src/interfaces/IExecution.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../../src/helpers/Constants.sol";
@@ -36,8 +36,8 @@ contract ResultCreatorModule is IExecution, BaseModule {
         return keccak256("foo");
     }
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
@@ -115,8 +115,8 @@ contract ResultConsumerModule is IExecution, BaseModule, IValidation {
 
     function onUninstall(bytes calldata) external override {}
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
         manifest.executionFunctions[0] = ManifestExecutionFunction({

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {ManifestExecutionFunction, ModuleManifest, ModuleMetadata} from "../../../src/interfaces/IModule.sol";
+import {IExecution, ManifestExecutionFunction, ModuleManifest} from "../../../src/interfaces/IExecution.sol";
+import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
-abstract contract MockBaseUserOpValidationModule is IValidation, IValidationHook, BaseModule {
+abstract contract MockBaseUserOpValidationModule is IExecution, IValidation, IValidationHook, BaseModule {
     enum EntityId {
         USER_OP_VALIDATION,
         PRE_VALIDATION_HOOK_1,

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {IExecution, ManifestExecutionFunction, ModuleManifest} from "../../../src/interfaces/IExecution.sol";
+import {ExecutionManifest, IExecution, ManifestExecutionFunction} from "../../../src/interfaces/IExecution.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IValidation} from "../../../src/interfaces/IValidation.sol";
 import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
@@ -98,8 +98,8 @@ contract MockUserOpValidationModule is MockBaseUserOpValidationModule {
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
@@ -130,8 +130,8 @@ contract MockUserOpValidation1HookModule is MockBaseUserOpValidationModule {
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
@@ -165,8 +165,8 @@ contract MockUserOpValidation2HookModule is MockBaseUserOpValidationModule {
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    function moduleManifest() external pure override returns (ModuleManifest memory) {
-        ModuleManifest memory manifest;
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -13,7 +13,7 @@ import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
-import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
 import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {ERC20TokenLimitModule} from "../../src/modules/ERC20TokenLimitModule.sol";
 import {MockModule} from "../mocks/MockModule.sol";
@@ -24,7 +24,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
     address public recipient = address(1);
     MockERC20 public erc20;
     address payable public bundler = payable(address(2));
-    ModuleManifest internal _m;
+    ExecutionManifest internal _m;
     MockModule public validationModule = new MockModule(_m);
     ModuleEntity public validationFunction;
 

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -13,7 +13,7 @@ import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {ExecutionHook} from "../../src/interfaces/IAccountLoupe.sol";
-import {ModuleManifest} from "../../src/interfaces/IModule.sol";
+import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
 import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {ERC20TokenLimitModule} from "../../src/modules/ERC20TokenLimitModule.sol";
 import {MockModule} from "../mocks/MockModule.sol";

--- a/test/module/NativeTokenLimitModule.t.sol
+++ b/test/module/NativeTokenLimitModule.t.sol
@@ -10,7 +10,7 @@ import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {ModuleManifest} from "../../src/interfaces/IModule.sol";
+import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
 import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {NativeTokenLimitModule} from "../../src/modules/NativeTokenLimitModule.sol";
 import {MockModule} from "../mocks/MockModule.sol";

--- a/test/module/NativeTokenLimitModule.t.sol
+++ b/test/module/NativeTokenLimitModule.t.sol
@@ -10,7 +10,7 @@ import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {ModuleManifest} from "../../src/interfaces/IExecution.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
 import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {NativeTokenLimitModule} from "../../src/modules/NativeTokenLimitModule.sol";
 import {MockModule} from "../mocks/MockModule.sol";
@@ -20,7 +20,7 @@ import {AccountTestBase} from "../utils/AccountTestBase.sol";
 contract NativeTokenLimitModuleTest is AccountTestBase {
     address public recipient = address(1);
     address payable public bundler = payable(address(2));
-    ModuleManifest internal _m;
+    ExecutionManifest internal _m;
     MockModule public validationModule = new MockModule(_m);
     ModuleEntity public validationFunction;
 

--- a/test/module/TokenReceiverModule.t.sol
+++ b/test/module/TokenReceiverModule.t.sol
@@ -56,7 +56,7 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
 
     function _initModule() internal {
         vm.startPrank(address(entryPoint));
-        acct.installModule(address(module), module.moduleManifest(), "");
+        acct.installModule(address(module), module.executionManifest(), "");
         vm.stopPrank();
     }
 

--- a/test/module/TokenReceiverModule.t.sol
+++ b/test/module/TokenReceiverModule.t.sol
@@ -56,7 +56,7 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
 
     function _initModule() internal {
         vm.startPrank(address(entryPoint));
-        acct.installModule(address(module), module.executionManifest(), "");
+        acct.installExecution(address(module), module.executionManifest(), "");
         vm.stopPrank();
     }
 


### PR DESCRIPTION
Refactor interfaces to enable simpler implementation by getting rid of unnecessary function requirement.
Also rename vars to match the refactor.