### PR TITLE
refactor: Use Solady instead of Openzeppelin for Factory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/modular-account-libs"]
 	path = lib/modular-account-libs
 	url = https://github.com/erc6900/modular-account-libs
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/vectorized/solady

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,3 +3,4 @@ forge-std/=lib/forge-std/src/
 @eth-infinitism/account-abstraction/=lib/account-abstraction/contracts/
 @openzeppelin/=lib/openzeppelin-contracts/
 @modular-account-libs/=lib/modular-account-libs/src/
+solady=lib/solady/src/

--- a/src/account/AccountFactory.sol
+++ b/src/account/AccountFactory.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.19;
 
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
-import {LibClone} from "solady/utils/LibClone.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
+import {LibClone} from "solady/utils/LibClone.sol";
 
 import {UpgradeableModularAccount} from "../account/UpgradeableModularAccount.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Openzeppelin's ERC1967 proxy contract includes some redundancies due to Solidity's compilation, it's generally more efficient to use Solady's implementations.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Replace the ERC1967 creation with `LibClone` calls, and OZ's Ownable with Solady's equivalent.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->