### PR TITLE
fix: single signer validation duplicate view func, missing 1271 UO validation

### DIFF
--- a/src/modules/validation/ISingleSignerValidation.sol
+++ b/src/modules/validation/ISingleSignerValidation.sol
@@ -19,10 +19,4 @@ interface ISingleSignerValidation is IValidation {
     /// @param entityId The entityId for the account and the signer.
     /// @param newSigner The address of the new signer.
     function transferSigner(uint32 entityId, address newSigner) external;
-
-    /// @notice Get the signer of the `account`'s validation.
-    /// @param entityId The entityId for the account and the signer.
-    /// @param account The account to get the signer of.
-    /// @return The address of the signer.
-    function signerOf(uint32 entityId, address account) external view returns (address);
 }

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -354,7 +354,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     }
 
     function test_transferOwnership() public {
-        assertEq(singleSignerValidation.signerOf(TEST_DEFAULT_VALIDATION_ENTITY_ID, address(account1)), owner1);
+        assertEq(singleSignerValidation.signers(TEST_DEFAULT_VALIDATION_ENTITY_ID, address(account1)), owner1);
 
         vm.prank(address(entryPoint));
         account1.execute(
@@ -363,7 +363,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             abi.encodeCall(SingleSignerValidation.transferSigner, (TEST_DEFAULT_VALIDATION_ENTITY_ID, owner2))
         );
 
-        assertEq(singleSignerValidation.signerOf(TEST_DEFAULT_VALIDATION_ENTITY_ID, address(account1)), owner2);
+        assertEq(singleSignerValidation.signers(TEST_DEFAULT_VALIDATION_ENTITY_ID, address(account1)), owner2);
     }
 
     function test_isValidSignature() public {

--- a/test/module/SingleSignerValidation.t.sol
+++ b/test/module/SingleSignerValidation.t.sol
@@ -121,7 +121,7 @@ contract SingleSignerValidationTest is AccountTestBase {
 
         // transfer ownership to signer
         singleSignerValidation.transferSigner(TEST_DEFAULT_VALIDATION_ENTITY_ID, signer);
-        assertEq(signer, singleSignerValidation.signerOf(TEST_DEFAULT_VALIDATION_ENTITY_ID, accountAddr));
+        assertEq(signer, singleSignerValidation.signers(TEST_DEFAULT_VALIDATION_ENTITY_ID, accountAddr));
 
         // sig check should pass
         assertEq(


### PR DESCRIPTION
## Motivation

- SingleSignerValidation had two view functions that did the same thing - `signer` and `signerOf`.
- Missing 1271 owner validation check in `validateUserOp`

## Solution

- Remove `signerOf` and rename the public storage field `signer` -> `signers`
   - Seems like generally the style we've been doing so far, but open to switching back
- Use the same `SignatureChecker` lib used for `validateSignature` in `validateUserOp`