### PR TITLE
feat: update install execution events

### DIFF
--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -175,7 +175,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
             revert ModuleInstallCallbackFailed(module, revertReason);
         }
 
-        emit ModuleInstalled(module);
+        emit ExecutionInstalled(module, manifest);
     }
 
     function _uninstallExecution(address module, ExecutionManifest calldata manifest, bytes memory uninstallData)
@@ -218,7 +218,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
             onUninstallSuccess = false;
         }
 
-        emit ModuleUninstalled(module, onUninstallSuccess);
+        emit ExecutionUninstalled(module, onUninstallSuccess, manifest);
     }
 
     function _onInstall(address module, bytes calldata data) internal {

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -10,8 +10,8 @@ type ValidationConfig is bytes26;
 type HookConfig is bytes26;
 
 interface IModuleManager {
-    event ModuleInstalled(address indexed module);
-    event ModuleUninstalled(address indexed module, bool indexed onUninstallSucceeded);
+    event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
+    event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
     event ValidationInstalled(ModuleEntity indexed moduleEntity);
     event ValidationUninstalled(ModuleEntity indexed moduleEntity, bool indexed onUninstallSucceeded);
 

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -22,8 +22,8 @@ contract AccountExecHooksTest is AccountTestBase {
 
     ExecutionManifest internal _m1;
 
-    event ModuleInstalled(address indexed module);
-    event ModuleUninstalled(address indexed module, bool indexed callbacksSucceeded);
+    event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
+    event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
     // emitted by MockModule
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
@@ -164,7 +164,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(abi.encodeCall(IModule.onInstall, (bytes(""))), 0);
         vm.expectEmit(true, true, true, true);
-        emit ModuleInstalled(address(mockModule1));
+        emit ExecutionInstalled(address(mockModule1), _m1);
 
         vm.startPrank(address(entryPoint));
         account1.installExecution({
@@ -179,7 +179,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(abi.encodeCall(IModule.onUninstall, (bytes(""))), 0);
         vm.expectEmit(true, true, true, true);
-        emit ModuleUninstalled(address(module), true);
+        emit ExecutionUninstalled(address(module), true, module.executionManifest());
 
         vm.startPrank(address(entryPoint));
         account1.uninstallExecution(address(module), module.executionManifest(), bytes(""));

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -42,8 +42,8 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     Counter public counter;
     ExecutionManifest internal _manifest;
 
-    event ModuleInstalled(address indexed module);
-    event ModuleUninstalled(address indexed module, bool indexed callbacksSucceeded);
+    event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
+    event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     function setUp() public {
@@ -240,7 +240,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
 
         vm.expectEmit(true, true, true, true);
-        emit ModuleInstalled(address(tokenReceiverModule));
+        emit ExecutionInstalled(address(tokenReceiverModule), tokenReceiverModule.executionManifest());
         IModuleManager(account1).installExecution({
             module: address(tokenReceiverModule),
             manifest: tokenReceiverModule.executionManifest(),
@@ -314,7 +314,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         });
 
         vm.expectEmit(true, true, true, true);
-        emit ModuleUninstalled(address(module), true);
+        emit ExecutionUninstalled(address(module), true, module.executionManifest());
         IModuleManager(account1).uninstallExecution({
             module: address(module),
             manifest: module.executionManifest(),


### PR DESCRIPTION
## Motivation

With the user-controlled manifests introduced in #101, the existing `ModuleInstalled` events no longer sufficiently describe what happens during an install or uninstall.

Additionally, it is likely unnecessary to index the callback success field in the events.

## Solution

- Rename `ModuleInstalled`, `ModuleUninstalled` to `ExecutionInstalled`, `ExecutionUninstalled` (to match #117)
- Add the execution manifest to the install and uninstall events
- Make the callback success field not `indexed`