### PR TITLE
feat: update allowlist module to use entity id [1/2]

### DIFF
--- a/src/modules/permissionhooks/AllowlistModule.sol
+++ b/src/modules/permissionhooks/AllowlistModule.sol
@@ -10,10 +10,6 @@ import {IValidationHook} from "../../interfaces/IValidationHook.sol";
 import {BaseModule} from "../../modules/BaseModule.sol";
 
 contract AllowlistModule is IValidationHook, BaseModule {
-    enum EntityId {
-        PRE_VALIDATION_HOOK
-    }
-
     struct AllowlistInit {
         address target;
         bool hasSelectorAllowlist;
@@ -25,48 +21,53 @@ contract AllowlistModule is IValidationHook, BaseModule {
         bool hasSelectorAllowlist;
     }
 
-    mapping(address target => mapping(address account => AllowlistEntry)) public targetAllowlist;
-    mapping(address target => mapping(bytes4 selector => mapping(address account => bool))) public
-        selectorAllowlist;
+    mapping(uint32 entityId => mapping(address target => mapping(address account => AllowlistEntry))) public
+        targetAllowlist;
+    mapping(
+        uint32 entityId => mapping(address target => mapping(bytes4 selector => mapping(address account => bool)))
+    ) public selectorAllowlist;
 
     error TargetNotAllowed();
     error SelectorNotAllowed();
     error NoSelectorSpecified();
 
     function onInstall(bytes calldata data) external override {
-        AllowlistInit[] memory init = abi.decode(data, (AllowlistInit[]));
+        (uint32 entityId, AllowlistInit[] memory init) = abi.decode(data, (uint32, AllowlistInit[]));
 
         for (uint256 i = 0; i < init.length; i++) {
-            targetAllowlist[init[i].target][msg.sender] = AllowlistEntry(true, init[i].hasSelectorAllowlist);
+            targetAllowlist[entityId][init[i].target][msg.sender] =
+                AllowlistEntry(true, init[i].hasSelectorAllowlist);
 
             if (init[i].hasSelectorAllowlist) {
                 for (uint256 j = 0; j < init[i].selectors.length; j++) {
-                    selectorAllowlist[init[i].target][init[i].selectors[j]][msg.sender] = true;
+                    selectorAllowlist[entityId][init[i].target][init[i].selectors[j]][msg.sender] = true;
                 }
             }
         }
     }
 
     function onUninstall(bytes calldata data) external override {
-        AllowlistInit[] memory init = abi.decode(data, (AllowlistInit[]));
+        (uint32 entityId, AllowlistInit[] memory init) = abi.decode(data, (uint32, AllowlistInit[]));
 
         for (uint256 i = 0; i < init.length; i++) {
-            delete targetAllowlist[init[i].target][msg.sender];
+            delete targetAllowlist[entityId][init[i].target][msg.sender];
 
             if (init[i].hasSelectorAllowlist) {
                 for (uint256 j = 0; j < init[i].selectors.length; j++) {
-                    delete selectorAllowlist[init[i].target][init[i].selectors[j]][msg.sender];
+                    delete selectorAllowlist[entityId][init[i].target][init[i].selectors[j]][msg.sender];
                 }
             }
         }
     }
 
-    function setAllowlistTarget(address target, bool allowed, bool hasSelectorAllowlist) external {
-        targetAllowlist[target][msg.sender] = AllowlistEntry(allowed, hasSelectorAllowlist);
+    function setAllowlistTarget(uint32 entityId, address target, bool allowed, bool hasSelectorAllowlist)
+        external
+    {
+        targetAllowlist[entityId][target][msg.sender] = AllowlistEntry(allowed, hasSelectorAllowlist);
     }
 
-    function setAllowlistSelector(address target, bytes4 selector, bool allowed) external {
-        selectorAllowlist[target][selector][msg.sender] = allowed;
+    function setAllowlistSelector(uint32 entityId, address target, bytes4 selector, bool allowed) external {
+        selectorAllowlist[entityId][target][selector][msg.sender] = allowed;
     }
 
     function preUserOpValidationHook(uint32 entityId, PackedUserOperation calldata userOp, bytes32)
@@ -75,11 +76,8 @@ contract AllowlistModule is IValidationHook, BaseModule {
         override
         returns (uint256)
     {
-        if (entityId == uint32(EntityId.PRE_VALIDATION_HOOK)) {
-            _checkAllowlistCalldata(userOp.callData);
-            return 0;
-        }
-        revert NotImplemented();
+        checkAllowlistCalldata(entityId, userOp.callData);
+        return 0;
     }
 
     function preRuntimeValidationHook(uint32 entityId, address, uint256, bytes calldata data, bytes calldata)
@@ -87,12 +85,8 @@ contract AllowlistModule is IValidationHook, BaseModule {
         view
         override
     {
-        if (entityId == uint32(EntityId.PRE_VALIDATION_HOOK)) {
-            _checkAllowlistCalldata(data);
-            return;
-        }
-
-        revert NotImplemented();
+        checkAllowlistCalldata(entityId, data);
+        return;
     }
 
     function moduleMetadata() external pure override returns (ModuleMetadata memory) {
@@ -104,21 +98,24 @@ contract AllowlistModule is IValidationHook, BaseModule {
         return metadata;
     }
 
-    function _checkAllowlistCalldata(bytes calldata callData) internal view {
+    function checkAllowlistCalldata(uint32 entityId, bytes calldata callData) public view {
         if (bytes4(callData[:4]) == IStandardExecutor.execute.selector) {
             (address target,, bytes memory data) = abi.decode(callData[4:], (address, uint256, bytes));
-            _checkCallPermission(msg.sender, target, data);
+            _checkCallPermission(entityId, msg.sender, target, data);
         } else if (bytes4(callData[:4]) == IStandardExecutor.executeBatch.selector) {
             Call[] memory calls = abi.decode(callData[4:], (Call[]));
 
             for (uint256 i = 0; i < calls.length; i++) {
-                _checkCallPermission(msg.sender, calls[i].target, calls[i].data);
+                _checkCallPermission(entityId, msg.sender, calls[i].target, calls[i].data);
             }
         }
     }
 
-    function _checkCallPermission(address account, address target, bytes memory data) internal view {
-        AllowlistEntry storage entry = targetAllowlist[target][account];
+    function _checkCallPermission(uint32 entityId, address account, address target, bytes memory data)
+        internal
+        view
+    {
+        AllowlistEntry storage entry = targetAllowlist[entityId][target][account];
         (bool allowed, bool hasSelectorAllowlist) = (entry.allowed, entry.hasSelectorAllowlist);
 
         if (!allowed) {
@@ -132,7 +129,7 @@ contract AllowlistModule is IValidationHook, BaseModule {
 
             bytes4 selector = bytes4(data);
 
-            if (!selectorAllowlist[target][selector][account]) {
+            if (!selectorAllowlist[entityId][target][selector][account]) {
                 revert SelectorNotAllowed();
             }
         }

--- a/src/modules/permissionhooks/AllowlistModule.sol
+++ b/src/modules/permissionhooks/AllowlistModule.sol
@@ -27,6 +27,13 @@ contract AllowlistModule is IValidationHook, BaseModule {
         uint32 entityId => mapping(address target => mapping(bytes4 selector => mapping(address account => bool)))
     ) public selectorAllowlist;
 
+    event AllowlistTargetUpdated(
+        uint32 indexed entityId, address indexed account, address indexed target, AllowlistEntry entry
+    );
+    event AllowlistSelectorUpdated(
+        uint32 indexed entityId, address indexed account, bytes24 indexed targetAndSelector, bool allowed
+    );
+
     error TargetNotAllowed();
     error SelectorNotAllowed();
     error NoSelectorSpecified();
@@ -35,12 +42,11 @@ contract AllowlistModule is IValidationHook, BaseModule {
         (uint32 entityId, AllowlistInit[] memory init) = abi.decode(data, (uint32, AllowlistInit[]));
 
         for (uint256 i = 0; i < init.length; i++) {
-            targetAllowlist[entityId][init[i].target][msg.sender] =
-                AllowlistEntry(true, init[i].hasSelectorAllowlist);
+            setAllowlistTarget(entityId, init[i].target, true, init[i].hasSelectorAllowlist);
 
             if (init[i].hasSelectorAllowlist) {
                 for (uint256 j = 0; j < init[i].selectors.length; j++) {
-                    selectorAllowlist[entityId][init[i].target][init[i].selectors[j]][msg.sender] = true;
+                    setAllowlistSelector(entityId, init[i].target, init[i].selectors[j], true);
                 }
             }
         }
@@ -50,24 +56,14 @@ contract AllowlistModule is IValidationHook, BaseModule {
         (uint32 entityId, AllowlistInit[] memory init) = abi.decode(data, (uint32, AllowlistInit[]));
 
         for (uint256 i = 0; i < init.length; i++) {
-            delete targetAllowlist[entityId][init[i].target][msg.sender];
+            setAllowlistTarget(entityId, init[i].target, false, false);
 
             if (init[i].hasSelectorAllowlist) {
                 for (uint256 j = 0; j < init[i].selectors.length; j++) {
-                    delete selectorAllowlist[entityId][init[i].target][init[i].selectors[j]][msg.sender];
+                    setAllowlistSelector(entityId, init[i].target, init[i].selectors[j], false);
                 }
             }
         }
-    }
-
-    function setAllowlistTarget(uint32 entityId, address target, bool allowed, bool hasSelectorAllowlist)
-        external
-    {
-        targetAllowlist[entityId][target][msg.sender] = AllowlistEntry(allowed, hasSelectorAllowlist);
-    }
-
-    function setAllowlistSelector(uint32 entityId, address target, bytes4 selector, bool allowed) external {
-        selectorAllowlist[entityId][target][selector][msg.sender] = allowed;
     }
 
     function preUserOpValidationHook(uint32 entityId, PackedUserOperation calldata userOp, bytes32)
@@ -96,6 +92,18 @@ contract AllowlistModule is IValidationHook, BaseModule {
         metadata.author = "ERC-6900 Working Group";
 
         return metadata;
+    }
+
+    function setAllowlistTarget(uint32 entityId, address target, bool allowed, bool hasSelectorAllowlist) public {
+        AllowlistEntry memory entry = AllowlistEntry(allowed, hasSelectorAllowlist);
+        targetAllowlist[entityId][target][msg.sender] = entry;
+        emit AllowlistTargetUpdated(entityId, msg.sender, target, entry);
+    }
+
+    function setAllowlistSelector(uint32 entityId, address target, bytes4 selector, bool allowed) public {
+        selectorAllowlist[entityId][target][selector][msg.sender] = allowed;
+        bytes24 targetAndSelector = bytes24(bytes24(bytes20(target)) | (bytes24(selector) >> 160));
+        emit AllowlistSelectorUpdated(entityId, msg.sender, targetAndSelector, allowed);
     }
 
     function checkAllowlistCalldata(uint32 entityId, bytes calldata callData) public view {

--- a/test/module/AllowlistModule.t.sol
+++ b/test/module/AllowlistModule.t.sol
@@ -21,6 +21,8 @@ contract AllowlistModuleTest is CustomValidationTestBase {
 
     Counter[] public counters;
 
+    uint32 public constant HOOK_ENTITY_ID = 0;
+
     function setUp() public {
         allowlistModule = new AllowlistModule();
 
@@ -147,11 +149,13 @@ contract AllowlistModuleTest is CustomValidationTestBase {
             Call memory call = calls[i];
 
             (bool allowed, bool hasSelectorAllowlist) =
-                allowlistModule.targetAllowlist(call.target, address(account1));
+                allowlistModule.targetAllowlist(HOOK_ENTITY_ID, call.target, address(account1));
             if (allowed) {
                 if (
                     hasSelectorAllowlist
-                        && !allowlistModule.selectorAllowlist(call.target, bytes4(call.data), address(account1))
+                        && !allowlistModule.selectorAllowlist(
+                            HOOK_ENTITY_ID, call.target, bytes4(call.data), address(account1)
+                        )
                 ) {
                     return abi.encodeWithSelector(
                         IEntryPoint.FailedOpWithRevert.selector,
@@ -178,16 +182,18 @@ contract AllowlistModuleTest is CustomValidationTestBase {
             Call memory call = calls[i];
 
             (bool allowed, bool hasSelectorAllowlist) =
-                allowlistModule.targetAllowlist(call.target, address(account1));
+                allowlistModule.targetAllowlist(HOOK_ENTITY_ID, call.target, address(account1));
             if (allowed) {
                 if (
                     hasSelectorAllowlist
-                        && !allowlistModule.selectorAllowlist(call.target, bytes4(call.data), address(account1))
+                        && !allowlistModule.selectorAllowlist(
+                            HOOK_ENTITY_ID, call.target, bytes4(call.data), address(account1)
+                        )
                 ) {
                     return abi.encodeWithSelector(
                         UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
                         address(allowlistModule),
-                        uint32(AllowlistModule.EntityId.PRE_VALIDATION_HOOK),
+                        HOOK_ENTITY_ID,
                         abi.encodeWithSelector(AllowlistModule.SelectorNotAllowed.selector)
                     );
                 }
@@ -195,7 +201,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
                 return abi.encodeWithSelector(
                     UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
                     address(allowlistModule),
-                    uint32(AllowlistModule.EntityId.PRE_VALIDATION_HOOK),
+                    HOOK_ENTITY_ID,
                     abi.encodeWithSelector(AllowlistModule.TargetNotAllowed.selector)
                 );
             }
@@ -297,10 +303,8 @@ contract AllowlistModuleTest is CustomValidationTestBase {
     {
         bytes[] memory hooks = new bytes[](1);
         hooks[0] = abi.encodePacked(
-            HookConfigLib.packValidationHook(
-                address(allowlistModule), uint32(AllowlistModule.EntityId.PRE_VALIDATION_HOOK)
-            ),
-            abi.encode(allowlistInit)
+            HookConfigLib.packValidationHook(address(allowlistModule), HOOK_ENTITY_ID),
+            abi.encode(HOOK_ENTITY_ID, allowlistInit)
         );
 
         return (

--- a/test/utils/CustomValidationTestBase.sol
+++ b/test/utils/CustomValidationTestBase.sol
@@ -28,6 +28,8 @@ abstract contract CustomValidationTestBase is AccountTestBase {
 
         account1 = UpgradeableModularAccount(payable(new ERC1967Proxy{salt: 0}(accountImplementation, "")));
 
+        _beforeInstallStep(address(account1));
+
         account1.initializeWithValidation(
             ValidationConfigLib.pack(validationFunction, isGlobal, isSignatureValidation),
             selectors,
@@ -49,4 +51,12 @@ abstract contract CustomValidationTestBase is AccountTestBase {
             bytes memory installData,
             bytes[] memory hooks
         );
+
+    // If the test needs to perform any setup or checks after the account is created, but before the call to
+    // `initializeWithValidation`,
+    // it should override this function.
+    function _beforeInstallStep(address accountImpl) internal virtual {
+        // Does nothing by default
+        (accountImpl);
+    }
 }


### PR DESCRIPTION
## Motivation

AllowlistModule still used the old "function id" interpretation of entity ids.

## Solution

Migrate AllowlistModule to use the new expected format for entity IDs, where each ID represents a unique storage config.

Update the corresponding test.