### PR TITLE
feat: split indexed fields in validation install events

### DIFF
--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -279,7 +279,7 @@ abstract contract ModuleManagerInternals is IModuleManager {
         _validationData.isSignatureValidation = validationConfig.isSignatureValidation();
 
         _onInstall(validationConfig.module(), installData);
-        emit ValidationInstalled(moduleEntity);
+        emit ValidationInstalled(validationConfig.module(), validationConfig.entityId());
     }
 
     function _uninstallValidation(
@@ -337,9 +337,9 @@ abstract contract ModuleManagerInternals is IModuleManager {
             _validationData.selectors.remove(selectorSetValue);
         }
 
-        (address module,) = ModuleEntityLib.unpack(validationFunction);
+        (address module, uint32 entityId) = ModuleEntityLib.unpack(validationFunction);
         onUninstallSuccess = onUninstallSuccess && _onUninstall(module, uninstallData);
 
-        emit ValidationUninstalled(validationFunction, onUninstallSuccess);
+        emit ValidationUninstalled(module, entityId, onUninstallSuccess);
     }
 }

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -12,8 +12,8 @@ type HookConfig is bytes26;
 interface IModuleManager {
     event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
     event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
-    event ValidationInstalled(ModuleEntity indexed moduleEntity);
-    event ValidationUninstalled(ModuleEntity indexed moduleEntity, bool indexed onUninstallSucceeded);
+    event ValidationInstalled(address indexed module, uint32 indexed entityId);
+    event ValidationUninstalled(address indexed module, uint32 indexed entityId, bool onUninstallSucceeded);
 
     /// @notice Install a module to the modular account.
     /// @param module The module to install.

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -16,7 +16,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     DirectCallModule internal _module;
     ModuleEntity internal _moduleEntity;
 
-    event ValidationUninstalled(ModuleEntity indexed moduleEntity, bool indexed onUninstallSucceeded);
+    event ValidationUninstalled(address indexed module, uint32 indexed entityId, bool onUninstallSucceeded);
 
     function setUp() public {
         _module = new DirectCallModule();
@@ -125,9 +125,10 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     }
 
     function _uninstallExecution() internal {
+        (address module, uint32 entityId) = ModuleEntityLib.unpack(_moduleEntity);
         vm.prank(address(entryPoint));
         vm.expectEmit(true, true, true, true);
-        emit ValidationUninstalled(_moduleEntity, true);
+        emit ValidationUninstalled(module, entityId, true);
         account1.uninstallValidation(_moduleEntity, "", new bytes[](1));
     }
 

--- a/test/module/SingleSignerValidation.t.sol
+++ b/test/module/SingleSignerValidation.t.sol
@@ -7,7 +7,6 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {ModuleEntity} from "../../src/interfaces/IModuleManager.sol";
 
 import {ContractOwner} from "../mocks/ContractOwner.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
@@ -25,7 +24,7 @@ contract SingleSignerValidationTest is AccountTestBase {
 
     ContractOwner public contractOwner;
 
-    event ValidationInstalled(ModuleEntity indexed moduleEntity);
+    event ValidationInstalled(address indexed module, uint32 indexed entityId);
 
     function setUp() public {
         ethRecipient = makeAddr("ethRecipient");
@@ -84,7 +83,7 @@ contract SingleSignerValidationTest is AccountTestBase {
         vm.prank(address(entryPoint));
 
         vm.expectEmit(true, true, true, true);
-        emit ValidationInstalled(ModuleEntityLib.pack(address(singleSignerValidation), newEntityId));
+        emit ValidationInstalled(address(singleSignerValidation), newEntityId);
         account.installValidation(
             ValidationConfigLib.pack(address(singleSignerValidation), newEntityId, true, false),
             new bytes4[](0),


### PR DESCRIPTION
## Motivation

Wallets and SDKs may want to search for instances of installed validations by module address, without knowing which entity ID is used.

Additionally, we don't need to index by the callback success, because this is the output of the action, rather than a filtering criteria.

## Solution

Update `ValidationInstalled` and `ValidationUninstalled` to have separate indexed fields for the module address and the entity id. It is still possible to filter by both.

Change `onUninstallSucceeded` in `ValidationUninstalled` to not be indexed.

