### PR TITLE
fix: renamed loupe function

### DIFF
--- a/test/account/ReplaceModule.t.sol
+++ b/test/account/ReplaceModule.t.sol
@@ -94,7 +94,7 @@ contract UpgradeModuleTest is AccountTestBase {
         );
 
         // test installed, test if old module still installed
-        assertEq(account1.getExecutionFunctionHandler(TestModule.testFunction.selector), address(moduleV2));
+        assertEq(account1.getExecutionData((TestModule.testFunction.selector)).module, address(moduleV2));
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(
             abi.encodeCall(IExecutionHook.preExecutionHook, (entityId, address(owner1), 0, callData)), 0


### PR DESCRIPTION
## Motivation

We merged #120 without rebasing onto `develop`, and #122, which was merged earlier, changed the interface for loupe events. This made it not able to compile.

## Solution

Update the view function used in the test.