### PR TITLE
chore: drop optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -25,7 +25,7 @@ depth = 10
 [profile.optimized-build]
 via_ir = true
 test = 'src'
-optimizer_runs = 20000
+optimizer_runs = 15000
 out = 'out-optimized'
 
 [profile.optimized-test]


### PR DESCRIPTION
## Motivation

We want to deploy a new alpha build of the RI, but contract size is now too large by a small margin.

## Solution

Drop optimizer runs to 15k.