### PR TITLE
refactor: module suffix to execution and validation interfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ ENTRYPOINT=
 # Create2 expected addresses of the contracts.
 # When running for the first time, the error message will contain the expected addresses.
 ACCOUNT_IMPL=
-SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS=
+SINGLE_SIGNER_VALIDATION_MODULE=
 FACTORY=
 
 # Optional, defaults to bytes32(0)

--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,13 @@ ENTRYPOINT=
 # Create2 expected addresses of the contracts.
 # When running for the first time, the error message will contain the expected addresses.
 ACCOUNT_IMPL=
-SINGLE_SIGNER_VALIDATION=
+SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS=
 FACTORY=
 
 # Optional, defaults to bytes32(0)
 ACCOUNT_IMPL_SALT=
 FACTORY_SALT=
-SINGLE_SIGNER_VALIDATION_SALT=
+SINGLE_SIGNER_VALIDATION_MODULE_SALT=
 
 # Optional, defaults to 0.1 ether and 1 day, respectively
 STAKE_AMOUNT=

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reference implementation for [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900). It is an early draft implementation.
 
-The implementation includes an upgradable modular account with three modules (`SingleSignerValidation`, `TokenReceiverModule`, and `AllowlistModule`). It is compliant with ERC-6900 with the latest updates.
+The implementation includes an upgradable modular account with three modules (`SingleSignerValidationModule`, `TokenReceiverModule`, and `AllowlistModule`). It is compliant with ERC-6900 with the latest updates.
 
 ## Important Callouts
 
@@ -31,9 +31,10 @@ FOUNDRY_PROFILE=optimized-test forge test -vvv
 
 ## Integration testing
 
-The reference implementation provides a sample factory and deploy script for the factory, account implementation, and the demo validation module `SingleSignerValidation`. This is not auditted, nor intended for production use. Limitations set by the GPL-V3 license apply.
+The reference implementation provides a sample factory and deploy script for the factory, account implementation, and the demo validation module `SingleSignerValidationModule`. This is not auditted, nor intended for production use. Limitations set by the GPL-V3 license apply.
 
 To run this script, provide appropriate values in a `.env` file based on the `.env.example` template, then run:
+
 ```bash
 forge script script/Deploy.s.sol <wallet options> -r <rpc_url> --broadcast
 ```

--- a/deployments/arb-sepolia.md
+++ b/deployments/arb-sepolia.md
@@ -16,13 +16,12 @@ Chain ID: 421614
 | v0.8.0-alpha.1 | `0xC64Cb5192a1440Fea12CE03D000EAeB247B2369B` | [explorer](https://sepolia.arbiscan.io/address/0xC64Cb5192a1440Fea12CE03D000EAeB247B2369B) | `0`  |
 | v0.8.0-alpha.0 | `0x0809BF385117a43A322A4E31d459c0EcaA3B1A08` | [explorer](https://sepolia.arbiscan.io/address/0x0809BF385117a43A322A4E31d459c0EcaA3B1A08) | `0`  |
 
-## SingleSignerValidation
+## SingleSignerValidationModule
 
 | Version        | Address                                      | Explorer                                                                                   | Salt |
 | -------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ | ---- |
 | v0.8.0-alpha.1 | `0xEa3a0b544d517f6Ed3Dc2186C74D869c702C376e` | [explorer](https://sepolia.arbiscan.io/address/0xEa3a0b544d517f6Ed3Dc2186C74D869c702C376e) | `0`  |
 | v0.8.0-alpha.0 | `0x9DA8c098A483E257dd96022831DF308cB24fCBE6` | [explorer](https://sepolia.arbiscan.io/address/0x9DA8c098A483E257dd96022831DF308cB24fCBE6) | `0`  |
-
 
 ## AllowlistModule
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -17,8 +17,7 @@ contract DeployScript is Script {
 
     address public accountImpl = vm.envOr("ACCOUNT_IMPL", address(0));
     address public factory = vm.envOr("FACTORY", address(0));
-    address public singleSignerValidationModuleAddress =
-        vm.envOr("SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS", address(0));
+    address public singleSignerValidationModule = vm.envOr("SINGLE_SIGNER_VALIDATION_MODULE", address(0));
 
     bytes32 public accountImplSalt = bytes32(vm.envOr("ACCOUNT_IMPL_SALT", uint256(0)));
     bytes32 public factorySalt = bytes32(vm.envOr("FACTORY_SALT", uint256(0)));
@@ -36,7 +35,7 @@ contract DeployScript is Script {
 
         vm.startBroadcast();
         _deployAccountImpl(accountImplSalt, accountImpl);
-        _deploySingleSignerValidationModule(singleSignerValidationModuleSalt, singleSignerValidationModuleAddress);
+        _deploySingleSignerValidationModule(singleSignerValidationModuleSalt, singleSignerValidationModule);
         _deployAccountFactory(factorySalt, factory);
         _addStakeForFactory(uint32(requiredUnstakeDelay), requiredStakeAmount);
         vm.stopBroadcast();
@@ -112,7 +111,7 @@ contract DeployScript is Script {
             keccak256(
                 abi.encodePacked(
                     type(AccountFactory).creationCode,
-                    abi.encode(entryPoint, accountImpl, singleSignerValidationModuleAddress, owner)
+                    abi.encode(entryPoint, accountImpl, singleSignerValidationModule, owner)
                 )
             ),
             CREATE2_FACTORY
@@ -127,10 +126,7 @@ contract DeployScript is Script {
         if (addr.code.length == 0) {
             console.log("No code found at expected address, deploying...");
             AccountFactory deployed = new AccountFactory{salt: salt}(
-                entryPoint,
-                UpgradeableModularAccount(payable(accountImpl)),
-                singleSignerValidationModuleAddress,
-                owner
+                entryPoint, UpgradeableModularAccount(payable(accountImpl)), singleSignerValidationModule, owner
             );
 
             if (address(deployed) != expected) {

--- a/src/account/AccountFactory.sol
+++ b/src/account/AccountFactory.sol
@@ -14,19 +14,19 @@ contract AccountFactory is Ownable {
     UpgradeableModularAccount public immutable ACCOUNT_IMPL;
     bytes32 private immutable _PROXY_BYTECODE_HASH;
     IEntryPoint public immutable ENTRY_POINT;
-    address public immutable SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS;
+    address public immutable SINGLE_SIGNER_VALIDATION_MODULE;
 
     constructor(
         IEntryPoint _entryPoint,
         UpgradeableModularAccount _accountImpl,
-        address _singleSignerValidationModuleAddress,
+        address _singleSignerValidationModule,
         address owner
     ) Ownable(owner) {
         ENTRY_POINT = _entryPoint;
         _PROXY_BYTECODE_HASH =
             keccak256(abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(address(_accountImpl), "")));
         ACCOUNT_IMPL = _accountImpl;
-        SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS = _singleSignerValidationModuleAddress;
+        SINGLE_SIGNER_VALIDATION_MODULE = _singleSignerValidationModule;
     }
 
     /**
@@ -50,7 +50,7 @@ contract AccountFactory is Ownable {
             new ERC1967Proxy{salt: combinedSalt}(address(ACCOUNT_IMPL), "");
             // point proxy to actual implementation and init plugins
             UpgradeableModularAccount(payable(addr)).initializeWithValidation(
-                ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS, entityId, true, true),
+                ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION_MODULE, entityId, true, true),
                 new bytes4[](0),
                 pluginInstallData,
                 new bytes[](0)

--- a/src/account/AccountFactory.sol
+++ b/src/account/AccountFactory.sol
@@ -14,19 +14,19 @@ contract AccountFactory is Ownable {
     UpgradeableModularAccount public immutable ACCOUNT_IMPL;
     bytes32 private immutable _PROXY_BYTECODE_HASH;
     IEntryPoint public immutable ENTRY_POINT;
-    address public immutable SINGLE_SIGNER_VALIDATION;
+    address public immutable SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS;
 
     constructor(
         IEntryPoint _entryPoint,
         UpgradeableModularAccount _accountImpl,
-        address _singleSignerValidation,
+        address _singleSignerValidationModuleAddress,
         address owner
     ) Ownable(owner) {
         ENTRY_POINT = _entryPoint;
         _PROXY_BYTECODE_HASH =
             keccak256(abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(address(_accountImpl), "")));
         ACCOUNT_IMPL = _accountImpl;
-        SINGLE_SIGNER_VALIDATION = _singleSignerValidation;
+        SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS = _singleSignerValidationModuleAddress;
     }
 
     /**
@@ -50,7 +50,7 @@ contract AccountFactory is Ownable {
             new ERC1967Proxy{salt: combinedSalt}(address(ACCOUNT_IMPL), "");
             // point proxy to actual implementation and init plugins
             UpgradeableModularAccount(payable(addr)).initializeWithValidation(
-                ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION, entityId, true, true),
+                ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS, entityId, true, true),
                 new bytes4[](0),
                 pluginInstallData,
                 new bytes[](0)

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -10,7 +10,7 @@ import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {KnownSelectors} from "../helpers/KnownSelectors.sol";
 import {ModuleEntityLib} from "../helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
-import {ExecutionManifest, ManifestExecutionHook} from "../interfaces/IExecution.sol";
+import {ExecutionManifest, ManifestExecutionHook} from "../interfaces/IExecutionModule.sol";
 import {IModule} from "../interfaces/IModule.sol";
 import {HookConfig, IModuleManager, ModuleEntity, ValidationConfig} from "../interfaces/IModuleManager.sol";
 import {

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -9,13 +9,14 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
 
-import {IExecution} from "../interfaces/IExecution.sol";
-import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
+import {IExecutionHookModule} from "../interfaces/IExecutionHookModule.sol";
+import {IExecutionModule} from "../interfaces/IExecutionModule.sol";
 import {IModule} from "../interfaces/IModule.sol";
 import {IModuleManager} from "../interfaces/IModuleManager.sol";
 import {IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
-import {IValidation} from "../interfaces/IValidation.sol";
-import {IValidationHook} from "../interfaces/IValidationHook.sol";
+
+import {IValidationHookModule} from "../interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "../interfaces/IValidationModule.sol";
 
 /// @dev Library to help to check if a selector is a know function selector of the modular account or ERC-4337
 /// contract.
@@ -49,11 +50,13 @@ library KnownSelectors {
 
     function isIModuleFunction(bytes4 selector) internal pure returns (bool) {
         return selector == IModule.onInstall.selector || selector == IModule.onUninstall.selector
-            || selector == IExecution.executionManifest.selector || selector == IModule.moduleMetadata.selector
-            || selector == IExecutionHook.preExecutionHook.selector
-            || selector == IExecutionHook.postExecutionHook.selector || selector == IValidation.validateUserOp.selector
-            || selector == IValidation.validateRuntime.selector || selector == IValidation.validateSignature.selector
-            || selector == IValidationHook.preUserOpValidationHook.selector
-            || selector == IValidationHook.preRuntimeValidationHook.selector;
+            || selector == IExecutionModule.executionManifest.selector || selector == IModule.moduleMetadata.selector
+            || selector == IExecutionHookModule.preExecutionHook.selector
+            || selector == IExecutionHookModule.postExecutionHook.selector
+            || selector == IValidationModule.validateUserOp.selector
+            || selector == IValidationModule.validateRuntime.selector
+            || selector == IValidationModule.validateSignature.selector
+            || selector == IValidationHookModule.preUserOpValidationHook.selector
+            || selector == IValidationHookModule.preRuntimeValidationHook.selector;
     }
 }

--- a/src/interfaces/IExecutionHookModule.sol
+++ b/src/interfaces/IExecutionHookModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import {IModule} from "./IModule.sol";
 
-interface IExecutionHook is IModule {
+interface IExecutionHookModule is IModule {
     /// @notice Run the pre execution hook specified by the `entityId`.
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param entityId An identifier that routes the call to different internal implementations, should there

--- a/src/interfaces/IExecutionModule.sol
+++ b/src/interfaces/IExecutionModule.sol
@@ -31,7 +31,7 @@ struct ExecutionManifest {
     bytes4[] interfaceIds;
 }
 
-interface IExecution is IModule {
+interface IExecutionModule is IModule {
     /// @notice Describe the contents and intended configuration of the module.
     /// @dev This manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the module.

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.25;
 
-import {ExecutionManifest} from "./IExecution.sol";
+import {ExecutionManifest} from "./IExecutionModule.sol";
 
 type ModuleEntity is bytes24;
 

--- a/src/interfaces/IValidationHookModule.sol
+++ b/src/interfaces/IValidationHookModule.sol
@@ -5,28 +5,26 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {IModule} from "./IModule.sol";
 
-interface IValidation is IModule {
-    /// @notice Run the user operation validationFunction specified by the `entityId`.
+interface IValidationHookModule is IModule {
+    /// @notice Run the pre user operation validation hook specified by the `entityId`.
+    /// @dev Pre user operation validation hooks MUST NOT return an authorizer value other than 0 or 1.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
     /// be more than one.
     /// @param userOp The user operation.
     /// @param userOpHash The user operation hash.
     /// @return Packed validation data for validAfter (6 bytes), validUntil (6 bytes), and authorizer (20 bytes).
-    function validateUserOp(uint32 entityId, PackedUserOperation calldata userOp, bytes32 userOpHash)
+    function preUserOpValidationHook(uint32 entityId, PackedUserOperation calldata userOp, bytes32 userOpHash)
         external
         returns (uint256);
 
-    /// @notice Run the runtime validationFunction specified by the `entityId`.
+    /// @notice Run the pre runtime validation hook specified by the `entityId`.
     /// @dev To indicate the entire call should revert, the function MUST revert.
-    /// @param account the account to validate for.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
     /// be more than one.
     /// @param sender The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
-    /// @param authorization Additional data for the validation function to use.
-    function validateRuntime(
-        address account,
+    function preRuntimeValidationHook(
         uint32 entityId,
         address sender,
         uint256 value,
@@ -34,20 +32,18 @@ interface IValidation is IModule {
         bytes calldata authorization
     ) external;
 
-    /// @notice Validates a signature using ERC-1271.
-    /// @dev To indicate the entire call should revert, the function MUST revert.
-    /// @param account the account to validate for.
+    // TODO: support this hook type within the account & in the manifest
+
+    /// @notice Run the pre signature validation hook specified by the `entityId`.
+    /// @dev To indicate the call should revert, the function MUST revert.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
     /// be more than one.
-    /// @param sender the address that sent the ERC-1271 request to the smart account
-    /// @param hash the hash of the ERC-1271 request
-    /// @param signature the signature of the ERC-1271 request
-    /// @return the ERC-1271 `MAGIC_VALUE` if the signature is valid, or 0xFFFFFFFF if invalid.
-    function validateSignature(
-        address account,
-        uint32 entityId,
-        address sender,
-        bytes32 hash,
-        bytes calldata signature
-    ) external view returns (bytes4);
+    /// @param sender The caller address.
+    /// @param hash The hash of the message being signed.
+    /// @param signature The signature of the message.
+    // function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata
+    // signature)
+    //     external
+    //     view
+    //     returns (bytes4);
 }

--- a/src/modules/ERC20TokenLimitModule.sol
+++ b/src/modules/ERC20TokenLimitModule.sol
@@ -12,7 +12,7 @@ import {
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
+import {IExecutionHookModule} from "../interfaces/IExecutionHookModule.sol";
 import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 
@@ -25,7 +25,7 @@ import {BaseModule, IERC165} from "./BaseModule.sol";
 /// Note: this module is opinionated on what selectors can be called for token contracts to guard against weird
 /// edge cases like DAI. You wouldn't be able to use uni v2 pairs directly as the pair contract is also the LP
 /// token contract
-contract ERC20TokenLimitModule is BaseModule, IExecutionHook {
+contract ERC20TokenLimitModule is BaseModule, IExecutionHookModule {
     using UserOperationLib for PackedUserOperation;
     using EnumerableSet for EnumerableSet.AddressSet;
     using AssociatedLinkedListSetLib for AssociatedLinkedListSet;
@@ -51,7 +51,7 @@ contract ERC20TokenLimitModule is BaseModule, IExecutionHook {
         limits[entityId][token][msg.sender] = newLimit;
     }
 
-    /// @inheritdoc IExecutionHook
+    /// @inheritdoc IExecutionHookModule
     function preExecutionHook(uint32 entityId, address, uint256, bytes calldata data)
         external
         override
@@ -108,7 +108,7 @@ contract ERC20TokenLimitModule is BaseModule, IExecutionHook {
         return tokens;
     }
 
-    /// @inheritdoc IExecutionHook
+    /// @inheritdoc IExecutionHookModule
     function postExecutionHook(uint32, bytes calldata) external pure override {
         revert NotImplemented();
     }

--- a/src/modules/NativeTokenLimitModule.sol
+++ b/src/modules/NativeTokenLimitModule.sol
@@ -5,11 +5,11 @@ import {UserOperationLib} from "@eth-infinitism/account-abstraction/core/UserOpe
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {IExecutionHook} from "../interfaces/IExecutionHook.sol";
+import {IExecutionHookModule} from "../interfaces/IExecutionHookModule.sol";
 import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {Call, IStandardExecutor} from "../interfaces/IStandardExecutor.sol";
 
-import {IValidationHook} from "../interfaces/IValidationHook.sol";
+import {IValidationHookModule} from "../interfaces/IValidationHookModule.sol";
 import {BaseModule, IERC165} from "./BaseModule.sol";
 
 /// @title Native Token Limit Module
@@ -18,7 +18,7 @@ import {BaseModule, IERC165} from "./BaseModule.sol";
 /// It tracks a total spend limit across UserOperation gas limits and native token transfers.
 /// If a non whitelisted paymaster is used, UO gas would not cause the limit to decrease.
 /// If a whitelisted paymaster is used, gas is still counted towards the limit
-contract NativeTokenLimitModule is BaseModule, IExecutionHook, IValidationHook {
+contract NativeTokenLimitModule is BaseModule, IExecutionHookModule, IValidationHookModule {
     using UserOperationLib for PackedUserOperation;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
@@ -42,7 +42,7 @@ contract NativeTokenLimitModule is BaseModule, IExecutionHook, IValidationHook {
         specialPaymasters[paymaster][msg.sender] = allowed;
     }
 
-    /// @inheritdoc IValidationHook
+    /// @inheritdoc IValidationHookModule
     function preUserOpValidationHook(uint32 entityId, PackedUserOperation calldata userOp, bytes32)
         external
         returns (uint256)
@@ -72,7 +72,7 @@ contract NativeTokenLimitModule is BaseModule, IExecutionHook, IValidationHook {
         return 0;
     }
 
-    /// @inheritdoc IExecutionHook
+    /// @inheritdoc IExecutionHookModule
     function preExecutionHook(uint32 entityId, address, uint256, bytes calldata data)
         external
         override
@@ -103,7 +103,7 @@ contract NativeTokenLimitModule is BaseModule, IExecutionHook, IValidationHook {
         }
     }
 
-    /// @inheritdoc IExecutionHook
+    /// @inheritdoc IExecutionHookModule
     function postExecutionHook(uint32, bytes calldata) external pure override {
         revert NotImplemented();
     }
@@ -135,7 +135,7 @@ contract NativeTokenLimitModule is BaseModule, IExecutionHook, IValidationHook {
 
     /// @inheritdoc BaseModule
     function supportsInterface(bytes4 interfaceId) public view override(BaseModule, IERC165) returns (bool) {
-        return interfaceId == type(IExecutionHook).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _checkAndDecrementLimit(uint32 entityId, bytes calldata data) internal returns (bytes memory) {

--- a/src/modules/TokenReceiverModule.sol
+++ b/src/modules/TokenReceiverModule.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.25;
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {ExecutionManifest, ManifestExecutionFunction} from "../interfaces/IExecution.sol";
-import {ExecutionManifest, IExecution} from "../interfaces/IExecution.sol";
+import {ExecutionManifest, ManifestExecutionFunction} from "../interfaces/IExecutionModule.sol";
+import {ExecutionManifest, IExecutionModule} from "../interfaces/IExecutionModule.sol";
 import {IModule, ModuleMetadata} from "../interfaces/IModule.sol";
 import {BaseModule} from "./BaseModule.sol";
 
@@ -13,7 +13,7 @@ import {BaseModule} from "./BaseModule.sol";
 /// @author ERC-6900 Authors
 /// @notice This module allows modular accounts to receive various types of tokens by implementing
 /// required token receiver interfaces.
-contract TokenReceiverModule is BaseModule, IExecution, IERC721Receiver, IERC1155Receiver {
+contract TokenReceiverModule is BaseModule, IExecutionModule, IERC721Receiver, IERC1155Receiver {
     string internal constant _NAME = "Token Receiver Module";
     string internal constant _VERSION = "1.0.0";
     string internal constant _AUTHOR = "ERC-6900 Authors";
@@ -56,7 +56,7 @@ contract TokenReceiverModule is BaseModule, IExecution, IERC721Receiver, IERC115
     // solhint-disable-next-line no-empty-blocks
     function onUninstall(bytes calldata) external pure override {}
 
-    /// @inheritdoc IExecution
+    /// @inheritdoc IExecutionModule
     function executionManifest() external pure override returns (ExecutionManifest memory) {
         ExecutionManifest memory manifest;
 

--- a/src/modules/permissionhooks/AllowlistModule.sol
+++ b/src/modules/permissionhooks/AllowlistModule.sol
@@ -6,10 +6,10 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 import {ModuleMetadata} from "../../interfaces/IModule.sol";
 
 import {Call, IStandardExecutor} from "../../interfaces/IStandardExecutor.sol";
-import {IValidationHook} from "../../interfaces/IValidationHook.sol";
+import {IValidationHookModule} from "../../interfaces/IValidationHookModule.sol";
 import {BaseModule} from "../../modules/BaseModule.sol";
 
-contract AllowlistModule is IValidationHook, BaseModule {
+contract AllowlistModule is IValidationHookModule, BaseModule {
     struct AllowlistInit {
         address target;
         bool hasSelectorAllowlist;

--- a/src/modules/validation/ISingleSignerValidationModule.sol
+++ b/src/modules/validation/ISingleSignerValidationModule.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {IValidation} from "../../interfaces/IValidation.sol";
+import {IValidationModule} from "../../interfaces/IValidationModule.sol";
 
-interface ISingleSignerValidation is IValidation {
+interface ISingleSignerValidationModule is IValidationModule {
     /// @notice This event is emitted when Signer of the account's validation changes.
     /// @param account The account whose validation Signer changed.
     /// @param entityId The entityId for the account and the signer.

--- a/src/modules/validation/SingleSignerValidationModule.sol
+++ b/src/modules/validation/SingleSignerValidationModule.sol
@@ -6,9 +6,9 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 import {IModule, ModuleMetadata} from "../../interfaces/IModule.sol";
-import {IValidation} from "../../interfaces/IValidation.sol";
+import {IValidationModule} from "../../interfaces/IValidationModule.sol";
 import {BaseModule} from "../BaseModule.sol";
-import {ISingleSignerValidation} from "./ISingleSignerValidation.sol";
+import {ISingleSignerValidationModule} from "./ISingleSignerValidationModule.sol";
 
 /// @title ECSDA Validation
 /// @author ERC-6900 Authors
@@ -23,7 +23,7 @@ import {ISingleSignerValidation} from "./ISingleSignerValidation.sol";
 ///
 /// - This validation supports composition that other validation can relay on entities in this validation
 /// to validate partially or fully.
-contract SingleSignerValidation is ISingleSignerValidation, BaseModule {
+contract SingleSignerValidationModule is ISingleSignerValidationModule, BaseModule {
     using MessageHashUtils for bytes32;
 
     string internal constant _NAME = "SingleSigner Validation";
@@ -39,7 +39,7 @@ contract SingleSignerValidation is ISingleSignerValidation, BaseModule {
 
     mapping(uint32 entityId => mapping(address account => address)) public signers;
 
-    /// @inheritdoc ISingleSignerValidation
+    /// @inheritdoc ISingleSignerValidationModule
     function transferSigner(uint32 entityId, address newSigner) external {
         _transferSigner(entityId, newSigner);
     }
@@ -57,7 +57,7 @@ contract SingleSignerValidation is ISingleSignerValidation, BaseModule {
         _transferSigner(abi.decode(data, (uint32)), address(0));
     }
 
-    /// @inheritdoc IValidation
+    /// @inheritdoc IValidationModule
     function validateUserOp(uint32 entityId, PackedUserOperation calldata userOp, bytes32 userOpHash)
         external
         view
@@ -75,7 +75,7 @@ contract SingleSignerValidation is ISingleSignerValidation, BaseModule {
         return _SIG_VALIDATION_FAILED;
     }
 
-    /// @inheritdoc IValidation
+    /// @inheritdoc IValidationModule
     function validateRuntime(
         address account,
         uint32 entityId,
@@ -91,7 +91,7 @@ contract SingleSignerValidation is ISingleSignerValidation, BaseModule {
         return;
     }
 
-    /// @inheritdoc IValidation
+    /// @inheritdoc IValidationModule
     /// @dev The signature is valid if it is signed by the owner's private key
     /// (if the owner is an EOA) or if it is a valid ERC-1271 signature from the
     /// owner (if the owner is a contract). Note that unlike the signature

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
+import {IExecutionHookModule} from "../../src/interfaces/IExecutionHookModule.sol";
 import {
     ExecutionManifest,
     IModule,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "../../src/interfaces/IExecution.sol";
-import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
+} from "../../src/interfaces/IExecutionModule.sol";
 
 import {MockModule} from "../mocks/MockModule.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
@@ -58,7 +58,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(
             abi.encodeWithSelector(
-                IExecutionHook.preExecutionHook.selector,
+                IExecutionHookModule.preExecutionHook.selector,
                 _PRE_HOOK_FUNCTION_ID_1,
                 address(this), // caller
                 uint256(0), // msg.value in call to account
@@ -97,7 +97,7 @@ contract AccountExecHooksTest is AccountTestBase {
         // pre hook call
         emit ReceivedCall(
             abi.encodeWithSelector(
-                IExecutionHook.preExecutionHook.selector,
+                IExecutionHookModule.preExecutionHook.selector,
                 _BOTH_HOOKS_FUNCTION_ID_3,
                 address(this), // caller
                 uint256(0), // msg.value in call to account
@@ -111,7 +111,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         // post hook call
         emit ReceivedCall(
-            abi.encodeCall(IExecutionHook.postExecutionHook, (_BOTH_HOOKS_FUNCTION_ID_3, "")),
+            abi.encodeCall(IExecutionHookModule.postExecutionHook, (_BOTH_HOOKS_FUNCTION_ID_3, "")),
             0 // msg value in call to module
         );
 
@@ -143,7 +143,7 @@ contract AccountExecHooksTest is AccountTestBase {
 
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(
-            abi.encodeCall(IExecutionHook.postExecutionHook, (_POST_HOOK_FUNCTION_ID_2, "")),
+            abi.encodeCall(IExecutionHookModule.postExecutionHook, (_POST_HOOK_FUNCTION_ID_2, "")),
             0 // msg value in call to module
         );
 

--- a/test/account/AccountFactory.t.sol
+++ b/test/account/AccountFactory.t.sol
@@ -11,7 +11,7 @@ contract AccountFactoryTest is AccountTestBase {
 
     function setUp() public {
         _account = new UpgradeableModularAccount(entryPoint);
-        _factory = new AccountFactory(entryPoint, _account, address(singleSignerValidation), address(this));
+        _factory = new AccountFactory(entryPoint, _account, address(singleSignerValidationModule), address(this));
     }
 
     function test_createAccount() public {

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -68,7 +68,7 @@ contract AccountReturnDataTest is AccountTestBase {
                 (address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()))
             ),
             _encodeSignature(
-                ModuleEntityLib.pack(address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID),
+                ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID),
                 GLOBAL_VALIDATION,
                 ""
             )
@@ -96,7 +96,7 @@ contract AccountReturnDataTest is AccountTestBase {
         bytes memory retData = account1.executeWithAuthorization(
             abi.encodeCall(account1.executeBatch, (calls)),
             _encodeSignature(
-                ModuleEntityLib.pack(address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID),
+                ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID),
                 GLOBAL_VALIDATION,
                 ""
             )

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -27,7 +27,7 @@ contract GlobalValidationTest is AccountTestBase {
         vm.deal(address(account2), 100 ether);
 
         _signerValidation =
-            ModuleEntityLib.pack(address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID);
+            ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID);
 
         ethRecipient = makeAddr("ethRecipient");
         vm.deal(ethRecipient, 1 wei);

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -13,7 +13,7 @@ import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 import {ModuleEntity} from "../../src/interfaces/IModuleManager.sol";
 import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
-import {SingleSignerValidation} from "../../src/modules/validation/SingleSignerValidation.sol";
+import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";
@@ -22,13 +22,13 @@ contract MultiValidationTest is AccountTestBase {
     using ECDSA for bytes32;
     using MessageHashUtils for bytes32;
 
-    SingleSignerValidation public validator2;
+    SingleSignerValidationModule public validator2;
 
     address public owner2;
     uint256 public owner2Key;
 
     function setUp() public {
-        validator2 = new SingleSignerValidation();
+        validator2 = new SingleSignerValidationModule();
 
         (owner2, owner2Key) = makeAddrAndKey("owner2");
     }
@@ -43,7 +43,8 @@ contract MultiValidationTest is AccountTestBase {
         );
 
         ModuleEntity[] memory validations = new ModuleEntity[](2);
-        validations[0] = ModuleEntityLib.pack(address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID);
+        validations[0] =
+            ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID);
         validations[1] = ModuleEntityLib.pack(address(validator2), TEST_DEFAULT_VALIDATION_ENTITY_ID);
 
         bytes4[] memory selectors0 = account1.getValidationData(validations[0]).selectors;

--- a/test/mocks/MockModule.sol
+++ b/test/mocks/MockModule.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.19;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
-import {IExecutionHook} from "../../src/interfaces/IExecutionHook.sol";
+import {IExecutionHookModule} from "../../src/interfaces/IExecutionHookModule.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
 import {IModule, ModuleMetadata} from "../../src/interfaces/IModule.sol";
-import {IValidation} from "../../src/interfaces/IValidation.sol";
+import {IValidationModule} from "../../src/interfaces/IValidationModule.sol";
 
 contract MockModule is ERC165 {
     // It's super inefficient to hold the entire abi-encoded manifest in storage, but this is fine since it's
@@ -82,8 +82,9 @@ contract MockModule is ERC165 {
     fallback() external payable {
         emit ReceivedCall(msg.data, msg.value);
         if (
-            msg.sig == IValidation.validateUserOp.selector || msg.sig == IValidation.validateRuntime.selector
-                || msg.sig == IExecutionHook.preExecutionHook.selector
+            msg.sig == IValidationModule.validateUserOp.selector
+                || msg.sig == IValidationModule.validateRuntime.selector
+                || msg.sig == IExecutionHookModule.preExecutionHook.selector
         ) {
             // return 0 for userOp/runtimeVal case, return bytes("") for preExecutionHook case
             assembly ("memory-safe") {

--- a/test/mocks/SingleSignerFactoryFixture.sol
+++ b/test/mocks/SingleSignerFactoryFixture.sol
@@ -7,14 +7,14 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {SingleSignerValidation} from "../../src/modules/validation/SingleSignerValidation.sol";
+import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
 import {OptimizedTest} from "../utils/OptimizedTest.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";
 
 contract SingleSignerFactoryFixture is OptimizedTest {
     UpgradeableModularAccount public accountImplementation;
-    SingleSignerValidation public singleSignerValidation;
+    SingleSignerValidationModule public singleSignerValidationModule;
     bytes32 private immutable _PROXY_BYTECODE_HASH;
 
     uint32 public constant UNSTAKE_DELAY = 1 weeks;
@@ -23,13 +23,13 @@ contract SingleSignerFactoryFixture is OptimizedTest {
 
     address public self;
 
-    constructor(IEntryPoint _entryPoint, SingleSignerValidation _singleSignerValidation) {
+    constructor(IEntryPoint _entryPoint, SingleSignerValidationModule _singleSignerValidationModule) {
         entryPoint = _entryPoint;
         accountImplementation = _deployUpgradeableModularAccount(_entryPoint);
         _PROXY_BYTECODE_HASH = keccak256(
             abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(address(accountImplementation), ""))
         );
-        singleSignerValidation = _singleSignerValidation;
+        singleSignerValidationModule = _singleSignerValidationModule;
         self = address(this);
     }
 
@@ -52,7 +52,7 @@ contract SingleSignerFactoryFixture is OptimizedTest {
             // point proxy to actual implementation and init modules
             UpgradeableModularAccount(payable(addr)).initializeWithValidation(
                 ValidationConfigLib.pack(
-                    address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID, true, true
+                    address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID, true, true
                 ),
                 new bytes4[](0),
                 moduleInstallData,

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -5,20 +5,27 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {
     ExecutionManifest,
-    IExecution,
+    IExecutionModule,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "../../../src/interfaces/IExecution.sol";
+} from "../../../src/interfaces/IExecutionModule.sol";
 
-import {IExecution} from "../../../src/interfaces/IExecution.sol";
-import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
+import {IExecutionHookModule} from "../../../src/interfaces/IExecutionHookModule.sol";
+import {IExecutionModule} from "../../../src/interfaces/IExecutionModule.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
-import {IValidation} from "../../../src/interfaces/IValidation.sol";
-import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
+
+import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "../../../src/interfaces/IValidationModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
-contract ComprehensiveModule is IExecution, IValidation, IValidationHook, IExecutionHook, BaseModule {
+contract ComprehensiveModule is
+    IExecutionModule,
+    IValidationModule,
+    IValidationHookModule,
+    IExecutionHookModule,
+    BaseModule
+{
     enum EntityId {
         PRE_VALIDATION_HOOK_1,
         PRE_VALIDATION_HOOK_2,

--- a/test/mocks/modules/DirectCallModule.sol
+++ b/test/mocks/modules/DirectCallModule.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {IExecutionHook} from "../../../src/interfaces/IExecutionHook.sol";
+import {IExecutionHookModule} from "../../../src/interfaces/IExecutionHookModule.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
-contract DirectCallModule is BaseModule, IExecutionHook {
+contract DirectCallModule is BaseModule, IExecutionHookModule {
     bool public preHookRan = false;
     bool public postHookRan = false;
 

--- a/test/mocks/modules/MockAccessControlHookModule.sol
+++ b/test/mocks/modules/MockAccessControlHookModule.sol
@@ -5,14 +5,14 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
-import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
+import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
 // A pre validaiton hook module that uses per-hook data.
 // This example enforces that the target of an `execute` call must only be the previously specified address.
 // This is just a mock - it does not enforce this over `executeBatch` and other methods of making calls, and should
 // not be used in production..
-contract MockAccessControlHookModule is IValidationHook, BaseModule {
+contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
     enum EntityId {
         PRE_VALIDATION_HOOK
     }

--- a/test/mocks/modules/PermittedCallMocks.sol
+++ b/test/mocks/modules/PermittedCallMocks.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {ExecutionManifest, IExecution, ManifestExecutionFunction} from "../../../src/interfaces/IExecution.sol";
+import {
+    ExecutionManifest,
+    IExecutionModule,
+    ManifestExecutionFunction
+} from "../../../src/interfaces/IExecutionModule.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 import {ResultCreatorModule} from "./ReturnDataModuleMocks.sol";
 
-contract PermittedCallerModule is IExecution, BaseModule {
+contract PermittedCallerModule is IExecutionModule, BaseModule {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -3,13 +3,17 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {ExecutionManifest, IExecution, ManifestExecutionFunction} from "../../../src/interfaces/IExecution.sol";
+import {
+    ExecutionManifest,
+    IExecutionModule,
+    ManifestExecutionFunction
+} from "../../../src/interfaces/IExecutionModule.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../../src/helpers/Constants.sol";
 
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
-import {IValidation} from "../../../src/interfaces/IValidation.sol";
+import {IValidationModule} from "../../../src/interfaces/IValidationModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
@@ -23,7 +27,7 @@ contract RegularResultContract {
     }
 }
 
-contract ResultCreatorModule is IExecution, BaseModule {
+contract ResultCreatorModule is IExecutionModule, BaseModule {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}
@@ -57,7 +61,7 @@ contract ResultCreatorModule is IExecution, BaseModule {
     function moduleMetadata() external pure override returns (ModuleMetadata memory) {}
 }
 
-contract ResultConsumerModule is IExecution, BaseModule, IValidation {
+contract ResultConsumerModule is IExecutionModule, BaseModule, IValidationModule {
     ResultCreatorModule public immutable RESULT_CREATOR;
     RegularResultContract public immutable REGULAR_RESULT_CONTRACT;
 

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -3,13 +3,23 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {ExecutionManifest, IExecution, ManifestExecutionFunction} from "../../../src/interfaces/IExecution.sol";
+import {
+    ExecutionManifest,
+    IExecutionModule,
+    ManifestExecutionFunction
+} from "../../../src/interfaces/IExecutionModule.sol";
 import {ModuleMetadata} from "../../../src/interfaces/IModule.sol";
-import {IValidation} from "../../../src/interfaces/IValidation.sol";
-import {IValidationHook} from "../../../src/interfaces/IValidationHook.sol";
+
+import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "../../../src/interfaces/IValidationModule.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
-abstract contract MockBaseUserOpValidationModule is IExecution, IValidation, IValidationHook, BaseModule {
+abstract contract MockBaseUserOpValidationModule is
+    IExecutionModule,
+    IValidationModule,
+    IValidationHookModule,
+    BaseModule
+{
     enum EntityId {
         USER_OP_VALIDATION,
         PRE_VALIDATION_HOOK_1,

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -12,7 +12,7 @@ import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
 import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {ERC20TokenLimitModule} from "../../src/modules/ERC20TokenLimitModule.sol";
 import {MockModule} from "../mocks/MockModule.sol";

--- a/test/module/NativeTokenLimitModule.t.sol
+++ b/test/module/NativeTokenLimitModule.t.sol
@@ -10,7 +10,7 @@ import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
-import {ExecutionManifest} from "../../src/interfaces/IExecution.sol";
+import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
 import {Call, IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {NativeTokenLimitModule} from "../../src/modules/NativeTokenLimitModule.sol";
 import {MockModule} from "../mocks/MockModule.sol";

--- a/test/module/SingleSignerValidation.t.sol
+++ b/test/module/SingleSignerValidation.t.sol
@@ -52,7 +52,7 @@ contract SingleSignerValidationTest is AccountTestBase {
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
         userOp.signature = _encodeSignature(
-            ModuleEntityLib.pack(address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID),
+            ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID),
             GLOBAL_VALIDATION,
             abi.encodePacked(r, s, v)
         );
@@ -70,7 +70,7 @@ contract SingleSignerValidationTest is AccountTestBase {
         account.executeWithAuthorization(
             abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
-                ModuleEntityLib.pack(address(singleSignerValidation), TEST_DEFAULT_VALIDATION_ENTITY_ID),
+                ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID),
                 GLOBAL_VALIDATION,
                 ""
             )
@@ -83,9 +83,9 @@ contract SingleSignerValidationTest is AccountTestBase {
         vm.prank(address(entryPoint));
 
         vm.expectEmit(true, true, true, true);
-        emit ValidationInstalled(address(singleSignerValidation), newEntityId);
+        emit ValidationInstalled(address(singleSignerValidationModule), newEntityId);
         account.installValidation(
-            ValidationConfigLib.pack(address(singleSignerValidation), newEntityId, true, false),
+            ValidationConfigLib.pack(address(singleSignerValidationModule), newEntityId, true, false),
             new bytes4[](0),
             abi.encode(newEntityId, owner2),
             new bytes[](0)
@@ -95,7 +95,7 @@ contract SingleSignerValidationTest is AccountTestBase {
         account.executeWithAuthorization(
             abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
-                ModuleEntityLib.pack(address(singleSignerValidation), newEntityId), GLOBAL_VALIDATION, ""
+                ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_VALIDATION, ""
             )
         );
         assertEq(ethRecipient.balance, 1 wei);
@@ -112,19 +112,19 @@ contract SingleSignerValidationTest is AccountTestBase {
 
         // sig check should fail
         assertEq(
-            singleSignerValidation.validateSignature(
+            singleSignerValidationModule.validateSignature(
                 accountAddr, TEST_DEFAULT_VALIDATION_ENTITY_ID, address(this), digest, abi.encodePacked(r, s, v)
             ),
             bytes4(0xFFFFFFFF)
         );
 
         // transfer ownership to signer
-        singleSignerValidation.transferSigner(TEST_DEFAULT_VALIDATION_ENTITY_ID, signer);
-        assertEq(signer, singleSignerValidation.signers(TEST_DEFAULT_VALIDATION_ENTITY_ID, accountAddr));
+        singleSignerValidationModule.transferSigner(TEST_DEFAULT_VALIDATION_ENTITY_ID, signer);
+        assertEq(signer, singleSignerValidationModule.signers(TEST_DEFAULT_VALIDATION_ENTITY_ID, accountAddr));
 
         // sig check should pass
         assertEq(
-            singleSignerValidation.validateSignature(
+            singleSignerValidationModule.validateSignature(
                 accountAddr, TEST_DEFAULT_VALIDATION_ENTITY_ID, address(this), digest, abi.encodePacked(r, s, v)
             ),
             _1271_MAGIC_VALUE
@@ -134,10 +134,10 @@ contract SingleSignerValidationTest is AccountTestBase {
     function testFuzz_isValidSignatureForContractOwner(bytes32 digest) public {
         address accountAddr = address(account);
         vm.startPrank(accountAddr);
-        singleSignerValidation.transferSigner(TEST_DEFAULT_VALIDATION_ENTITY_ID, address(contractOwner));
+        singleSignerValidationModule.transferSigner(TEST_DEFAULT_VALIDATION_ENTITY_ID, address(contractOwner));
         bytes memory signature = contractOwner.sign(digest);
         assertEq(
-            singleSignerValidation.validateSignature(
+            singleSignerValidationModule.validateSignature(
                 accountAddr, TEST_DEFAULT_VALIDATION_ENTITY_ID, address(this), digest, signature
             ),
             _1271_MAGIC_VALUE

--- a/test/module/SingleSignerValidationModule.t.sol
+++ b/test/module/SingleSignerValidationModule.t.sol
@@ -12,7 +12,7 @@ import {ContractOwner} from "../mocks/ContractOwner.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";
 
-contract SingleSignerValidationTest is AccountTestBase {
+contract SingleSignerValidationModuleTest is AccountTestBase {
     using MessageHashUtils for bytes32;
 
     bytes4 internal constant _1271_MAGIC_VALUE = 0x1626ba7e;

--- a/test/module/TokenReceiverModule.t.sol
+++ b/test/module/TokenReceiverModule.t.sol
@@ -36,7 +36,7 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
     function setUp() public {
         entryPoint = new EntryPoint();
         SingleSignerFactoryFixture factory =
-            new SingleSignerFactoryFixture(entryPoint, _deploySingleSignerValidation());
+            new SingleSignerFactoryFixture(entryPoint, _deploySingleSignerValidationModule());
 
         acct = factory.createAccount(address(this), 0);
         module = _deployTokenReceiverModule();

--- a/test/script/Deploy.s.t.sol
+++ b/test/script/Deploy.s.t.sol
@@ -11,7 +11,7 @@ import {DeployScript} from "../../script/Deploy.s.sol";
 
 import {AccountFactory} from "../../src/account/AccountFactory.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {SingleSignerValidation} from "../../src/modules/validation/SingleSignerValidation.sol";
+import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
 contract DeployTest is Test {
     DeployScript internal _deployScript;
@@ -21,7 +21,7 @@ contract DeployTest is Test {
     address internal _owner;
 
     address internal _accountImpl;
-    address internal _singleSignerValidation;
+    address internal _singleSignerValidationModuleAddress;
     address internal _factory;
 
     function setUp() public {
@@ -42,8 +42,10 @@ contract DeployTest is Test {
             CREATE2_FACTORY
         );
 
-        _singleSignerValidation = Create2.computeAddress(
-            bytes32(0), keccak256(abi.encodePacked(type(SingleSignerValidation).creationCode)), CREATE2_FACTORY
+        _singleSignerValidationModuleAddress = Create2.computeAddress(
+            bytes32(0),
+            keccak256(abi.encodePacked(type(SingleSignerValidationModule).creationCode)),
+            CREATE2_FACTORY
         );
 
         _factory = Create2.computeAddress(
@@ -51,7 +53,7 @@ contract DeployTest is Test {
             keccak256(
                 abi.encodePacked(
                     type(AccountFactory).creationCode,
-                    abi.encode(address(_entryPoint), _accountImpl, _singleSignerValidation, _owner)
+                    abi.encode(address(_entryPoint), _accountImpl, _singleSignerValidationModuleAddress, _owner)
                 )
             ),
             CREATE2_FACTORY
@@ -59,11 +61,11 @@ contract DeployTest is Test {
 
         vm.setEnv("ACCOUNT_IMPL", vm.toString(address(_accountImpl)));
         vm.setEnv("FACTORY", vm.toString(address(_factory)));
-        vm.setEnv("SINGLE_SIGNER_VALIDATION", vm.toString(address(_singleSignerValidation)));
+        vm.setEnv("SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS", vm.toString(_singleSignerValidationModuleAddress));
 
         vm.setEnv("ACCOUNT_IMPL_SALT", vm.toString(uint256(0)));
         vm.setEnv("FACTORY_SALT", vm.toString(uint256(0)));
-        vm.setEnv("SINGLE_SIGNER_VALIDATION_SALT", vm.toString(uint256(0)));
+        vm.setEnv("SINGLE_SIGNER_VALIDATION_MODULE_SALT", vm.toString(uint256(0)));
 
         _deployScript = new DeployScript();
 
@@ -75,12 +77,12 @@ contract DeployTest is Test {
 
         assertTrue(_accountImpl.code.length > 0);
         assertTrue(_factory.code.length > 0);
-        assertTrue(_singleSignerValidation.code.length > 0);
+        assertTrue(_singleSignerValidationModuleAddress.code.length > 0);
 
         assertEq(
-            _singleSignerValidation.code,
-            type(SingleSignerValidation).runtimeCode,
-            "SingleSignerValidation runtime code mismatch"
+            _singleSignerValidationModuleAddress.code,
+            type(SingleSignerValidationModule).runtimeCode,
+            "SingleSignerValidationModule runtime code mismatch"
         );
 
         // Check factory stake

--- a/test/script/Deploy.s.t.sol
+++ b/test/script/Deploy.s.t.sol
@@ -21,7 +21,7 @@ contract DeployTest is Test {
     address internal _owner;
 
     address internal _accountImpl;
-    address internal _singleSignerValidationModuleAddress;
+    address internal _singleSignerValidationModule;
     address internal _factory;
 
     function setUp() public {
@@ -42,7 +42,7 @@ contract DeployTest is Test {
             CREATE2_FACTORY
         );
 
-        _singleSignerValidationModuleAddress = Create2.computeAddress(
+        _singleSignerValidationModule = Create2.computeAddress(
             bytes32(0),
             keccak256(abi.encodePacked(type(SingleSignerValidationModule).creationCode)),
             CREATE2_FACTORY
@@ -53,7 +53,7 @@ contract DeployTest is Test {
             keccak256(
                 abi.encodePacked(
                     type(AccountFactory).creationCode,
-                    abi.encode(address(_entryPoint), _accountImpl, _singleSignerValidationModuleAddress, _owner)
+                    abi.encode(address(_entryPoint), _accountImpl, _singleSignerValidationModule, _owner)
                 )
             ),
             CREATE2_FACTORY
@@ -61,7 +61,7 @@ contract DeployTest is Test {
 
         vm.setEnv("ACCOUNT_IMPL", vm.toString(address(_accountImpl)));
         vm.setEnv("FACTORY", vm.toString(address(_factory)));
-        vm.setEnv("SINGLE_SIGNER_VALIDATION_MODULE_ADDRESS", vm.toString(_singleSignerValidationModuleAddress));
+        vm.setEnv("SINGLE_SIGNER_VALIDATION_MODULE", vm.toString(_singleSignerValidationModule));
 
         vm.setEnv("ACCOUNT_IMPL_SALT", vm.toString(uint256(0)));
         vm.setEnv("FACTORY_SALT", vm.toString(uint256(0)));
@@ -77,10 +77,10 @@ contract DeployTest is Test {
 
         assertTrue(_accountImpl.code.length > 0);
         assertTrue(_factory.code.length > 0);
-        assertTrue(_singleSignerValidationModuleAddress.code.length > 0);
+        assertTrue(_singleSignerValidationModule.code.length > 0);
 
         assertEq(
-            _singleSignerValidationModuleAddress.code,
+            _singleSignerValidationModule.code,
             type(SingleSignerValidationModule).runtimeCode,
             "SingleSignerValidationModule runtime code mismatch"
         );

--- a/test/utils/OptimizedTest.sol
+++ b/test/utils/OptimizedTest.sol
@@ -8,7 +8,7 @@ import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntry
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {TokenReceiverModule} from "../../src/modules/TokenReceiverModule.sol";
-import {SingleSignerValidation} from "../../src/modules/validation/SingleSignerValidation.sol";
+import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
 /// @dev This contract provides functions to deploy optimized (via IR) precompiled contracts. By compiling just
 /// the source contracts (excluding the test suite) via IR, and using the resulting bytecode within the tests
@@ -51,11 +51,11 @@ abstract contract OptimizedTest is Test {
             : new TokenReceiverModule();
     }
 
-    function _deploySingleSignerValidation() internal returns (SingleSignerValidation) {
+    function _deploySingleSignerValidationModule() internal returns (SingleSignerValidationModule) {
         return _isOptimizedTest()
-            ? SingleSignerValidation(
-                deployCode("out-optimized/SingleSignerValidation.sol/SingleSignerValidation.json")
+            ? SingleSignerValidationModule(
+                deployCode("out-optimized/SingleSignerValidationModule.sol/SingleSignerValidationModule.json")
             )
-            : new SingleSignerValidation();
+            : new SingleSignerValidationModule();
     }
 }


### PR DESCRIPTION
Open to pushback on this. I personally think this makes things clearer in understanding that all of these things are modules, and unifies file/contract naming across our module types.