### PR TITLE
style: re-run udpated forge fmt

### DIFF
--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -481,7 +481,7 @@ contract UpgradeableModularAccount is
         )
         // forgefmt: disable-start
         // solhint-disable-next-line no-empty-blocks
-        {} catch (bytes memory revertReason) {
+        {} catch (bytes memory revertReason){
         // forgefmt: disable-end
             revert RuntimeValidationFunctionReverted(module, entityId, revertReason);
         }
@@ -571,7 +571,7 @@ contract UpgradeableModularAccount is
         )
         // forgefmt: disable-start
         // solhint-disable-next-line no-empty-blocks
-        {} catch (bytes memory revertReason) {
+        {} catch (bytes memory revertReason){
         // forgefmt: disable-end
             revert PreRuntimeValidationHookFailed(hookModule, hookEntityId, revertReason);
         }


### PR DESCRIPTION
## Motivation

A foundry update changed how catch statements are formatted.

## Solution

Update foundry and re-run `forge fmt`.