### PR TITLE
feat(SingleSignerValidation): index additional event fields and mark anonymous [1/2]

### DIFF
--- a/src/modules/validation/ISingleSignerValidationModule.sol
+++ b/src/modules/validation/ISingleSignerValidationModule.sol
@@ -7,11 +7,11 @@ interface ISingleSignerValidationModule is IValidationModule {
     /// @notice This event is emitted when Signer of the account's validation changes.
     /// @param account The account whose validation Signer changed.
     /// @param entityId The entityId for the account and the signer.
-    /// @param previousSigner The address of the previous signer.
     /// @param newSigner The address of the new signer.
+    /// @param previousSigner The address of the previous signer.
     event SignerTransferred(
-        address indexed account, uint32 indexed entityId, address previousSigner, address newSigner
-    );
+        address indexed account, uint32 indexed entityId, address indexed newSigner, address previousSigner
+    ) anonymous;
 
     error NotAuthorized();
 

--- a/src/modules/validation/SingleSignerValidationModule.sol
+++ b/src/modules/validation/SingleSignerValidationModule.sol
@@ -94,10 +94,7 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, BaseModu
     /// @inheritdoc IValidationModule
     /// @dev The signature is valid if it is signed by the owner's private key
     /// (if the owner is an EOA) or if it is a valid ERC-1271 signature from the
-    /// owner (if the owner is a contract). Note that unlike the signature
-    /// validation used in `validateUserOp`, this does///*not** wrap the digest in
-    /// an "Ethereum Signed Message" envelope before checking the signature in
-    /// the EOA-owner case.
+    /// owner (if the owner is a contract). Note that the signature is wrapped in an EIP-191 message
     function validateSignature(address account, uint32 entityId, address, bytes32 digest, bytes calldata signature)
         external
         view
@@ -130,6 +127,6 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, BaseModu
     function _transferSigner(uint32 entityId, address newSigner) internal {
         address previousSigner = signers[entityId][msg.sender];
         signers[entityId][msg.sender] = newSigner;
-        emit SignerTransferred(msg.sender, entityId, previousSigner, newSigner);
+        emit SignerTransferred(msg.sender, entityId, newSigner, previousSigner);
     }
 }

--- a/test/module/SingleSignerValidationModule.t.sol
+++ b/test/module/SingleSignerValidationModule.t.sol
@@ -26,6 +26,10 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
 
     event ValidationInstalled(address indexed module, uint32 indexed entityId);
 
+    event SignerTransferred(
+        address indexed account, uint32 indexed entityId, address indexed newSigner, address previousSigner
+    ) anonymous;
+
     function setUp() public {
         ethRecipient = makeAddr("ethRecipient");
         (owner2, owner2Key) = makeAddrAndKey("owner2");
@@ -82,6 +86,8 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
         uint32 newEntityId = TEST_DEFAULT_VALIDATION_ENTITY_ID + 1;
         vm.prank(address(entryPoint));
 
+        vm.expectEmit(address(singleSignerValidationModule));
+        emit SignerTransferred(address(account), newEntityId, owner2, address(0));
         vm.expectEmit(true, true, true, true);
         emit ValidationInstalled(address(singleSignerValidationModule), newEntityId);
         account.installValidation(


### PR DESCRIPTION
## Motivation

For retrieving previously set owners by validation ID, it would help to index the new signer. Additionally, since there's only one event type emitted by the SingleSignerValidation contract, we can mark the event as `anonymous` and index the previous signer, rather than the event type.

## Solution

Update the `SignerTransferred` event to be anonymous, and index the previous and new signers.

Update tests to check using the new event signature instead, specifically coming from the SingleSignerValidation module address.