### PR TITLE
feat: move account deploy event to factory

### DIFF
--- a/src/account/AccountFactory.sol
+++ b/src/account/AccountFactory.sol
@@ -16,6 +16,8 @@ contract AccountFactory is Ownable {
     IEntryPoint public immutable ENTRY_POINT;
     address public immutable SINGLE_SIGNER_VALIDATION_MODULE;
 
+    event ModularAccountDeployed(address indexed account, address indexed owner, uint256 salt);
+
     constructor(
         IEntryPoint _entryPoint,
         UpgradeableModularAccount _accountImpl,
@@ -55,6 +57,7 @@ contract AccountFactory is Ownable {
                 pluginInstallData,
                 new bytes[](0)
             );
+            emit ModularAccountDeployed(addr, owner, salt);
         }
 
         return UpgradeableModularAccount(payable(addr));

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -67,8 +67,6 @@ contract UpgradeableModularAccount is
     bytes4 internal constant _1271_MAGIC_VALUE = 0x1626ba7e;
     bytes4 internal constant _1271_INVALID = 0xffffffff;
 
-    event ModularAccountInitialized(IEntryPoint indexed entryPoint);
-
     error NonCanonicalEncoding();
     error NotEntryPoint();
     error PostExecHookReverted(address module, uint32 entityId, bytes revertReason);
@@ -249,7 +247,6 @@ contract UpgradeableModularAccount is
         bytes[] calldata hooks
     ) external initializer {
         _installValidation(validationConfig, selectors, installData, hooks);
-        emit ModularAccountInitialized(_ENTRY_POINT);
     }
 
     /// @inheritdoc IModuleManager


### PR DESCRIPTION
## Motivation

For tracking deployed accounts of a specific type, it is preferable to emit the event from the factory, rather than the account address, because event signatures may be spoofed.

## Solution

Remove the `ModularAccountInitialized` event from `UpgradeableModularAccount`. The account already emits `ValidationInstalled(module, entityId)` and `Initialized(version)` during initialization.

Add `ModularAccountDeployed(account, owner, salt)` to the factory.

We could also depend on the [`AccountDeployed`](https://github.com/eth-infinitism/account-abstraction/blob/7af70c8993a6f42973f520ae0752386a5032abe7/contracts/interfaces/IEntryPoint.sol#L46) event from the EntryPoint, but this has some issues:
- Not indexed on the factory address
- Doesn't fire if the account is deployed directly from the factory, rather than from initCode.