### PR TITLE
refactor: merge segment collection logic [1/2]

### DIFF
--- a/src/helpers/SparseCalldataSegmentLib.sol
+++ b/src/helpers/SparseCalldataSegmentLib.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
+import {RESERVED_VALIDATION_DATA_INDEX} from "./Constants.sol";
+
 /// @title Sparse Calldata Segment Library
 /// @notice Library for working with sparsely-packed calldata segments, identified with an index.
 /// @dev The first byte of each segment is the index of the segment.
 /// To prevent accidental stack-to-deep errors, the body and index of the segment are extracted separately, rather
 /// than inline as part of the tuple returned by `getNextSegment`.
 library SparseCalldataSegmentLib {
+    error NonCanonicalEncoding();
+    error SegmentOutOfOrder();
+    error ValidationSignatureSegmentMissing();
+
     /// @notice Splits out a segment of calldata, sparsely-packed.
     /// The expected format is:
     /// [uint32(len(segment0)), segment0, uint32(len(segment1)), segment1, ... uint32(len(segmentN)), segmentN]
@@ -31,6 +37,61 @@ library SparseCalldataSegmentLib {
 
         // The remainder is the rest of the calldata.
         remainder = source[remainderOffset:];
+    }
+
+    /// @notice If the index of the next segment in the source equals the provided index, return the next body and
+    /// advance the source by one segment.
+    /// @dev Reverts if the index of the next segment is less than the provided index, or if the extracted segment
+    /// has length 0.
+    /// @param source The calldata to extract the segment from.
+    /// @param index The index of the segment to extract.
+    /// @return A tuple containing the extracted segment's body, or an empty buffer if the index is not found, and
+    /// the remaining calldata.
+    function advanceSegmentIfAtIndex(bytes calldata source, uint8 index)
+        internal
+        pure
+        returns (bytes memory, bytes calldata)
+    {
+        uint8 nextIndex = peekIndex(source);
+
+        if (nextIndex < index) {
+            revert SegmentOutOfOrder();
+        }
+
+        if (nextIndex == index) {
+            (bytes calldata segment, bytes calldata remainder) = getNextSegment(source);
+
+            segment = getBody(segment);
+
+            if (segment.length == 0) {
+                revert NonCanonicalEncoding();
+            }
+
+            return (segment, remainder);
+        }
+
+        return ("", source);
+    }
+
+    function getFinalSegment(bytes calldata source) internal pure returns (bytes calldata) {
+        (bytes calldata segment, bytes calldata remainder) = getNextSegment(source);
+
+        if (getIndex(segment) != RESERVED_VALIDATION_DATA_INDEX) {
+            revert ValidationSignatureSegmentMissing();
+        }
+
+        if (remainder.length != 0) {
+            revert NonCanonicalEncoding();
+        }
+
+        return getBody(segment);
+    }
+
+    /// @notice Returns the index of the next segment in the source.
+    /// @param source The calldata to extract the index from.
+    /// @return The index of the next segment.
+    function peekIndex(bytes calldata source) internal pure returns (uint8) {
+        return uint8(source[4]);
     }
 
     /// @notice Extracts the index from a segment.


### PR DESCRIPTION
## Motivation

We have duplicate code for advancing signature segments in runtime and user op validation.

Additionally, there was one more failure case for the final segment - length that exceeds the final segment.

## Solution

Merge duplicate logic into `SparseCalldataSegmentLib`.

Add a check for the extra data past-the-end of the signature, and tests that verify this behavior.