### PR TITLE
feat: add signature validation hooks [2/2]

### DIFF
--- a/src/interfaces/IValidationHookModule.sol
+++ b/src/interfaces/IValidationHookModule.sol
@@ -32,8 +32,6 @@ interface IValidationHookModule is IModule {
         bytes calldata authorization
     ) external;
 
-    // TODO: support this hook type within the account & in the manifest
-
     /// @notice Run the pre signature validation hook specified by the `entityId`.
     /// @dev To indicate the call should revert, the function MUST revert.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
@@ -41,9 +39,7 @@ interface IValidationHookModule is IModule {
     /// @param sender The caller address.
     /// @param hash The hash of the message being signed.
     /// @param signature The signature of the message.
-    // function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata
-    // signature)
-    //     external
-    //     view
-    //     returns (bytes4);
+    function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata signature)
+        external
+        view;
 }

--- a/src/modules/NativeTokenLimitModule.sol
+++ b/src/modules/NativeTokenLimitModule.sol
@@ -116,6 +116,9 @@ contract NativeTokenLimitModule is BaseModule, IExecutionHookModule, IValidation
         override
     {} // solhint-disable-line no-empty-blocks
 
+    // solhint-disable-next-line no-empty-blocks
+    function preSignatureValidationHook(uint32, address, bytes32, bytes calldata) external pure override {}
+
     /// @inheritdoc IModule
     function moduleMetadata() external pure virtual override returns (ModuleMetadata memory) {
         ModuleMetadata memory metadata;

--- a/src/modules/permissionhooks/AllowlistModule.sol
+++ b/src/modules/permissionhooks/AllowlistModule.sol
@@ -85,6 +85,9 @@ contract AllowlistModule is IValidationHookModule, BaseModule {
         return;
     }
 
+    // solhint-disable-next-line no-empty-blocks
+    function preSignatureValidationHook(uint32, address, bytes32, bytes calldata) external pure override {}
+
     function moduleMetadata() external pure override returns (ModuleMetadata memory) {
         ModuleMetadata memory metadata;
         metadata.name = "Allowlist Module";

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -397,7 +397,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
         // singleSignerValidationModule.ownerOf(address(account1));
 
-        bytes memory signature = abi.encodePacked(_signerValidation, r, s, v);
+        bytes memory signature = _encode1271Signature(_signerValidation, abi.encodePacked(r, s, v));
 
         bytes4 validationResult = IERC1271(address(account1)).isValidSignature(message, signature);
 

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -104,6 +104,10 @@ contract ComprehensiveModule is
         revert NotImplemented();
     }
 
+    function preSignatureValidationHook(uint32, address, bytes32, bytes calldata) external pure override {
+        return;
+    }
+
     function validateSignature(address, uint32 entityId, address, bytes32, bytes calldata)
         external
         pure

--- a/test/mocks/modules/MockAccessControlHookModule.sol
+++ b/test/mocks/modules/MockAccessControlHookModule.sol
@@ -72,5 +72,17 @@ contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
         revert NotImplemented();
     }
 
+    function preSignatureValidationHook(uint32, address, bytes32 hash, bytes calldata signature)
+        external
+        pure
+        override
+    {
+        // Simulates some signature checking by requiring a preimage of the hash.
+
+        require(keccak256(signature) == hash, "Preimage not provided");
+
+        return;
+    }
+
     function moduleMetadata() external pure override returns (ModuleMetadata memory) {}
 }

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -64,6 +64,8 @@ abstract contract MockBaseUserOpValidationModule is
         revert NotImplemented();
     }
 
+    function preSignatureValidationHook(uint32, address, bytes32, bytes calldata) external pure override {}
+
     function validateSignature(address, uint32, address, bytes32, bytes calldata)
         external
         pure


### PR DESCRIPTION
## Motivation

We have had a stub pre validation hook type for 1271 signatures for a while, but never implemented it.

## Solution

Define the interface and implement the logic for calling these hooks in the base account.

Add test cases for using the hooks, and sending per-hook data.

Also removes old todo comments about the interface functions.