### PR TITLE
feat: add interface checks for validations and hooks

### DIFF
--- a/src/modules/ERC20TokenLimitModule.sol
+++ b/src/modules/ERC20TokenLimitModule.sol
@@ -120,7 +120,7 @@ contract ERC20TokenLimitModule is BaseModule, IExecutionHookModule {
 
     /// @inheritdoc BaseModule
     function supportsInterface(bytes4 interfaceId) public view override(BaseModule, IERC165) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        return interfaceId == type(IExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _decrementLimit(uint32 entityId, address token, bytes memory innerCalldata) internal {

--- a/src/modules/permissionhooks/AllowlistModule.sol
+++ b/src/modules/permissionhooks/AllowlistModule.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
 import {IModule} from "../../interfaces/IModule.sol";
 
@@ -116,6 +117,16 @@ contract AllowlistModule is IValidationHookModule, BaseModule {
                 _checkCallPermission(entityId, msg.sender, calls[i].target, calls[i].data);
             }
         }
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(BaseModule, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _checkCallPermission(uint32 entityId, address account, address target, bytes memory data)

--- a/src/modules/validation/SingleSignerValidationModule.sol
+++ b/src/modules/validation/SingleSignerValidationModule.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
 import {IModule} from "../../interfaces/IModule.sol";
 import {IValidationModule} from "../../interfaces/IValidationModule.sol";
 import {BaseModule} from "../BaseModule.sol";
 
 import {ReplaySafeWrapper} from "../ReplaySafeWrapper.sol";
 import {ISingleSignerValidationModule} from "./ISingleSignerValidationModule.sol";
-import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
-import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 /// @title ECSDA Validation
 /// @author ERC-6900 Authors
@@ -113,6 +115,16 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, ReplaySa
     /// @inheritdoc IModule
     function moduleId() external pure returns (string memory) {
         return "erc6900/single-signer-validation-module/1.0.0";
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(BaseModule, IERC165)
+        returns (bool)
+    {
+        return (interfaceId == type(IValidationModule).interfaceId || super.supportsInterface(interfaceId));
     }
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -162,7 +162,7 @@ contract AccountExecHooksTest is AccountTestBase {
         mockModule1 = new MockModule(_m1);
 
         vm.expectEmit(true, true, true, true);
-        emit ReceivedCall(abi.encodeCall(IModule.onInstall, (bytes(""))), 0);
+        emit ReceivedCall(abi.encodeCall(IModule.onInstall, (bytes("a"))), 0);
         vm.expectEmit(true, true, true, true);
         emit ExecutionInstalled(address(mockModule1), _m1);
 
@@ -170,19 +170,19 @@ contract AccountExecHooksTest is AccountTestBase {
         account1.installExecution({
             module: address(mockModule1),
             manifest: mockModule1.executionManifest(),
-            moduleInstallData: bytes("")
+            moduleInstallData: bytes("a")
         });
         vm.stopPrank();
     }
 
     function _uninstallExecution(MockModule module) internal {
         vm.expectEmit(true, true, true, true);
-        emit ReceivedCall(abi.encodeCall(IModule.onUninstall, (bytes(""))), 0);
+        emit ReceivedCall(abi.encodeCall(IModule.onUninstall, (bytes("b"))), 0);
         vm.expectEmit(true, true, true, true);
         emit ExecutionUninstalled(address(module), true, module.executionManifest());
 
         vm.startPrank(address(entryPoint));
-        account1.uninstallExecution(address(module), module.executionManifest(), bytes(""));
+        account1.uninstallExecution(address(module), module.executionManifest(), bytes("b"));
         vm.stopPrank();
     }
 }

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -288,7 +288,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
         address badModule = address(1);
         vm.expectRevert(
-            abi.encodeWithSelector(ModuleManagerInternals.ModuleInterfaceNotSupported.selector, address(badModule))
+            abi.encodeWithSelector(ModuleManagerInternals.InterfaceNotSupported.selector, address(badModule))
         );
 
         ExecutionManifest memory m;

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -293,7 +293,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
         ExecutionManifest memory m;
 
-        account1.installExecution({module: address(badModule), manifest: m, moduleInstallData: ""});
+        account1.installExecution({module: address(badModule), manifest: m, moduleInstallData: "a"});
     }
 
     function test_installExecution_alreadyInstalled() public {

--- a/test/mocks/modules/DirectCallModule.sol
+++ b/test/mocks/modules/DirectCallModule.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+
 import {IExecutionHookModule} from "../../../src/interfaces/IExecutionHookModule.sol";
 import {IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
@@ -41,5 +43,15 @@ contract DirectCallModule is BaseModule, IExecutionHookModule {
             "mock direct call post permission hook failed"
         );
         postHookRan = true;
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(BaseModule, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/test/mocks/modules/MockAccessControlHookModule.sol
+++ b/test/mocks/modules/MockAccessControlHookModule.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
 import {IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
 import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
@@ -85,5 +86,15 @@ contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
 
     function moduleId() external pure returns (string memory) {
         return "erc6900/mock-access-control-hook-module/1.0.0";
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(BaseModule, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## Motivation

We've been discussing how to do sanity-checking on addresses provided to be used as modules, and decided to encourage, but not enforce, ERC-165 interface checking in the standard.

## Solution

This PR adds behavior to the reference implementation to check interface support for the addresses provided to be used as validation modules, validation hooks, and execution hooks. The account already performed this check for execution modules.

Also update any modules used in tests that were missing the appropriate interfaceId support.

This PR does not yet update the spec document - will follow up with a second PR for the spec update.