### PR TITLE
fix: address compiler warnings

### DIFF
--- a/src/account/SemiModularAccount.sol
+++ b/src/account/SemiModularAccount.sol
@@ -40,15 +40,6 @@ contract SemiModularAccount is UpgradeableModularAccount {
 
     constructor(IEntryPoint anEntryPoint) UpgradeableModularAccount(anEntryPoint) {}
 
-    /// Override reverts on initialization, effectively disabling the initializer.
-    function initializeWithValidation(ValidationConfig, bytes4[] calldata, bytes calldata, bytes[] calldata)
-        external
-        override
-        initializer
-    {
-        revert InitializerDisabled();
-    }
-
     /// @notice Updates the fallback signer address in storage.
     /// @dev This function causes the fallback signer getter to ignore the bytecode signer if it is nonzero. It can
     /// also be used to revert back to the bytecode signer by setting to zero.
@@ -81,6 +72,15 @@ contract SemiModularAccount is UpgradeableModularAccount {
     /// @return The fallback signer address, either overriden in storage, or read from bytecode.
     function getFallbackSigner() external view returns (address) {
         return _retrieveFallbackSignerUnchecked(_getSemiModularAccountStorage());
+    }
+
+    /// Override reverts on initialization, effectively disabling the initializer.
+    function initializeWithValidation(ValidationConfig, bytes4[] calldata, bytes calldata, bytes[] calldata)
+        external
+        pure
+        override
+    {
+        revert InitializerDisabled();
     }
 
     function _execUserOpValidation(

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";


### PR DESCRIPTION
## Motivation

We have two small compiler warnings in our current code on `develop`:
- `SPDX license identifier not provided in source file. ...` in `DirectCallsFromModule.t.sol`
- ```
  Warning (5740): Unreachable code.
    --> src/account/AccountStorageInitializable.sol:49:9:
     |
  49 |         if (isTopLevelCall) {
     |         ^ (Relevant source part starts here and spans across multiple lines).
  ```

## Solution

Add an SPDX identifier to the test file.

Remove the `initializer` modifier from the overwritten initializer function in SemiModularAccount, and reorder functions due to the new `pure` visibility.