### PR TITLE
refactor: rename UpgradeableModularAccount to ReferenceModularAccount

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -8,8 +8,8 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {AccountFactory} from "../src/account/AccountFactory.sol";
 
+import {ReferenceModularAccount} from "../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../src/account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../src/account/UpgradeableModularAccount.sol";
 import {SingleSignerValidationModule} from "../src/modules/validation/SingleSignerValidationModule.sol";
 
 contract DeployScript is Script {
@@ -51,7 +51,7 @@ contract DeployScript is Script {
 
         address addr = Create2.computeAddress(
             salt,
-            keccak256(abi.encodePacked(type(UpgradeableModularAccount).creationCode, abi.encode(entryPoint))),
+            keccak256(abi.encodePacked(type(ReferenceModularAccount).creationCode, abi.encode(entryPoint))),
             CREATE2_FACTORY
         );
         if (addr != expected) {
@@ -63,7 +63,7 @@ contract DeployScript is Script {
 
         if (addr.code.length == 0) {
             console.log("No code found at expected address, deploying...");
-            UpgradeableModularAccount deployed = new UpgradeableModularAccount{salt: salt}(entryPoint);
+            ReferenceModularAccount deployed = new ReferenceModularAccount{salt: salt}(entryPoint);
 
             if (address(deployed) != expected) {
                 console.log("Deployed address mismatch");
@@ -166,7 +166,7 @@ contract DeployScript is Script {
             console.log("No code found at expected address, deploying...");
             AccountFactory deployed = new AccountFactory{salt: salt}(
                 entryPoint,
-                UpgradeableModularAccount(payable(accountImpl)),
+                ReferenceModularAccount(payable(accountImpl)),
                 SemiModularAccount(payable(semiModularAccountImpl)),
                 singleSignerValidationModule,
                 owner

--- a/src/account/AccountFactory.sol
+++ b/src/account/AccountFactory.sol
@@ -7,14 +7,14 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
+import {ReferenceModularAccount} from "../account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../account/UpgradeableModularAccount.sol";
 import {ValidationConfigLib} from "../helpers/ValidationConfigLib.sol";
 
 import {LibClone} from "solady/utils/LibClone.sol";
 
 contract AccountFactory is Ownable {
-    UpgradeableModularAccount public immutable ACCOUNT_IMPL;
+    ReferenceModularAccount public immutable ACCOUNT_IMPL;
     SemiModularAccount public immutable SEMI_MODULAR_ACCOUNT_IMPL;
     bytes32 private immutable _PROXY_BYTECODE_HASH;
     IEntryPoint public immutable ENTRY_POINT;
@@ -25,7 +25,7 @@ contract AccountFactory is Ownable {
 
     constructor(
         IEntryPoint _entryPoint,
-        UpgradeableModularAccount _accountImpl,
+        ReferenceModularAccount _accountImpl,
         SemiModularAccount _semiModularImpl,
         address _singleSignerValidationModule,
         address owner
@@ -47,7 +47,7 @@ contract AccountFactory is Ownable {
      */
     function createAccount(address owner, uint256 salt, uint32 entityId)
         external
-        returns (UpgradeableModularAccount)
+        returns (ReferenceModularAccount)
     {
         bytes32 combinedSalt = getSalt(owner, salt, entityId);
         address addr = Create2.computeAddress(combinedSalt, _PROXY_BYTECODE_HASH);
@@ -58,7 +58,7 @@ contract AccountFactory is Ownable {
             // not necessary to check return addr since next call will fail if so
             new ERC1967Proxy{salt: combinedSalt}(address(ACCOUNT_IMPL), "");
             // point proxy to actual implementation and init plugins
-            UpgradeableModularAccount(payable(addr)).initializeWithValidation(
+            ReferenceModularAccount(payable(addr)).initializeWithValidation(
                 ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION_MODULE, entityId, true, true),
                 new bytes4[](0),
                 pluginInstallData,
@@ -67,7 +67,7 @@ contract AccountFactory is Ownable {
             emit ModularAccountDeployed(addr, owner, salt);
         }
 
-        return UpgradeableModularAccount(payable(addr));
+        return ReferenceModularAccount(payable(addr));
     }
 
     function createSemiModularAccount(address owner, uint256 salt) external returns (SemiModularAccount) {

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -5,8 +5,8 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 
 import {HookConfig, ModuleEntity} from "../interfaces/IModularAccount.sol";
 
-// bytes = keccak256("ERC6900.UpgradeableModularAccount.Storage")
-bytes32 constant _ACCOUNT_STORAGE_SLOT = 0x9f09680beaa4e5c9f38841db2460c401499164f368baef687948c315d9073e40;
+// bytes = keccak256("ERC6900.ReferenceModularAccount.Storage")
+bytes32 constant _ACCOUNT_STORAGE_SLOT = 0xc531f081ecdb5a90f38c197521797881a6e5c752a7d451780f325a95f8b91f45;
 
 // Represents data associated with a specifc function selector.
 struct ExecutionData {

--- a/src/account/ReferenceModularAccount.sol
+++ b/src/account/ReferenceModularAccount.sol
@@ -29,7 +29,7 @@ import {AccountStorage, getAccountStorage, toHookConfig, toSetValue} from "./Acc
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
 import {ModuleManagerInternals} from "./ModuleManagerInternals.sol";
 
-contract UpgradeableModularAccount is
+contract ReferenceModularAccount is
     IModularAccount,
     AccountExecutor,
     AccountLoupe,

--- a/src/account/SemiModularAccount.sol
+++ b/src/account/SemiModularAccount.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {UpgradeableModularAccount} from "./UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "./ReferenceModularAccount.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
@@ -13,7 +13,7 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import {LibClone} from "solady/utils/LibClone.sol";
 
-contract SemiModularAccount is UpgradeableModularAccount {
+contract SemiModularAccount is ReferenceModularAccount {
     using MessageHashUtils for bytes32;
     using ModuleEntityLib for ModuleEntity;
 
@@ -46,7 +46,7 @@ contract SemiModularAccount is UpgradeableModularAccount {
     error FallbackSignerDisabled();
     error InitializerDisabled();
 
-    constructor(IEntryPoint anEntryPoint) UpgradeableModularAccount(anEntryPoint) {}
+    constructor(IEntryPoint anEntryPoint) ReferenceModularAccount(anEntryPoint) {}
 
     /// @notice Updates the fallback signer address in storage.
     /// @dev This function causes the fallback signer getter to ignore the bytecode signer if it is nonzero. It can

--- a/test/account/AccountFactory.t.sol
+++ b/test/account/AccountFactory.t.sol
@@ -3,17 +3,17 @@ pragma solidity ^0.8.19;
 
 import {AccountFactory} from "../../src/account/AccountFactory.sol";
 
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
 contract AccountFactoryTest is AccountTestBase {
     AccountFactory internal _factory;
-    UpgradeableModularAccount internal _account;
+    ReferenceModularAccount internal _account;
     SemiModularAccount internal _semiModularAccount;
 
     function setUp() public {
-        _account = new UpgradeableModularAccount(entryPoint);
+        _account = new ReferenceModularAccount(entryPoint);
         _semiModularAccount = new SemiModularAccount(entryPoint);
 
         _factory = new AccountFactory(
@@ -22,23 +22,23 @@ contract AccountFactoryTest is AccountTestBase {
     }
 
     function test_createAccount() public {
-        UpgradeableModularAccount account = _factory.createAccount(address(this), 100, 0);
+        ReferenceModularAccount account = _factory.createAccount(address(this), 100, 0);
 
         assertEq(address(account.entryPoint()), address(entryPoint));
     }
 
     function test_createAccountAndGetAddress() public {
-        UpgradeableModularAccount account = _factory.createAccount(address(this), 100, 0);
+        ReferenceModularAccount account = _factory.createAccount(address(this), 100, 0);
 
         assertEq(address(account), address(_factory.createAccount(address(this), 100, 0)));
     }
 
     function test_multipleDeploy() public {
-        UpgradeableModularAccount account = _factory.createAccount(address(this), 100, 0);
+        ReferenceModularAccount account = _factory.createAccount(address(this), 100, 0);
 
         uint256 startGas = gasleft();
 
-        UpgradeableModularAccount account2 = _factory.createAccount(address(this), 100, 0);
+        ReferenceModularAccount account2 = _factory.createAccount(address(this), 100, 0);
 
         // Assert that the 2nd deployment call cost less than 1 sstore
         // Implies that no deployment was done on the second calls

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
@@ -155,6 +155,6 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     }
 
     function _buildDirectCallDisallowedError(bytes4 selector) internal pure returns (bytes memory) {
-        return abi.encodeWithSelector(UpgradeableModularAccount.ValidationFunctionMissing.selector, selector);
+        return abi.encodeWithSelector(ReferenceModularAccount.ValidationFunctionMissing.selector, selector);
     }
 }

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.25;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
@@ -17,13 +17,13 @@ contract GlobalValidationTest is AccountTestBase {
     // A separate account and owner that isn't deployed yet, used to test initcode
     address public owner2;
     uint256 public owner2Key;
-    UpgradeableModularAccount public account2;
+    ReferenceModularAccount public account2;
 
     function setUp() public {
         (owner2, owner2Key) = makeAddrAndKey("owner2");
 
         // Compute counterfactual address
-        account2 = UpgradeableModularAccount(payable(factory.getAddress(owner2, 0)));
+        account2 = ReferenceModularAccount(payable(factory.getAddress(owner2, 0)));
         vm.deal(address(account2), 100 ether);
 
         _signerValidation =
@@ -38,7 +38,7 @@ contract GlobalValidationTest is AccountTestBase {
             sender: address(account2),
             nonce: 0,
             initCode: abi.encodePacked(address(factory), abi.encodeCall(factory.createAccount, (owner2, 0))),
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -65,7 +65,7 @@ contract GlobalValidationTest is AccountTestBase {
 
         vm.prank(owner2);
         account2.executeWithAuthorization(
-            abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
 

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -7,7 +7,7 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
@@ -62,7 +62,7 @@ contract MultiValidationTest is AccountTestBase {
         vm.prank(owner1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                UpgradeableModularAccount.RuntimeValidationFunctionReverted.selector,
+                ReferenceModularAccount.RuntimeValidationFunctionReverted.selector,
                 address(validator2),
                 TEST_DEFAULT_VALIDATION_ENTITY_ID,
                 abi.encodeWithSignature("NotAuthorized()")
@@ -93,7 +93,7 @@ contract MultiValidationTest is AccountTestBase {
             sender: address(account1),
             nonce: 0,
             initCode: "",
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (address(0), 0, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (address(0), 0, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -5,7 +5,7 @@ import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntry
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
@@ -134,7 +134,7 @@ contract PerHookDataTest is CustomValidationTestBase {
             sender: address(account1),
             nonce: 0,
             initCode: "",
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (beneficiary, 1 wei, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (beneficiary, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -228,8 +228,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.prank(owner1);
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
-                (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -247,7 +246,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.prank(owner1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
+                ReferenceModularAccount.PreRuntimeValidationHookFailed.selector,
                 _accessControlHookModule,
                 uint32(MockAccessControlHookModule.EntityId.PRE_VALIDATION_HOOK),
                 abi.encodeWithSignature("Error(string)", "Proof doesn't match target")
@@ -255,8 +254,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
-                (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -266,7 +264,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.prank(owner1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
+                ReferenceModularAccount.PreRuntimeValidationHookFailed.selector,
                 _accessControlHookModule,
                 uint32(MockAccessControlHookModule.EntityId.PRE_VALIDATION_HOOK),
                 abi.encodeWithSignature("Error(string)", "Proof doesn't match target")
@@ -274,8 +272,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
-                (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
@@ -292,8 +289,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
-                (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -308,14 +304,14 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.prank(owner1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
+                ReferenceModularAccount.PreRuntimeValidationHookFailed.selector,
                 _accessControlHookModule,
                 uint32(MockAccessControlHookModule.EntityId.PRE_VALIDATION_HOOK),
                 abi.encodeWithSignature("Error(string)", "Target not allowed")
             )
         );
         account1.executeWithAuthorization(
-            abi.encodeCall(UpgradeableModularAccount.execute, (beneficiary, 1 wei, "")),
+            abi.encodeCall(ReferenceModularAccount.execute, (beneficiary, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
     }
@@ -328,8 +324,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector));
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
-                (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -343,8 +338,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector));
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
-                (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             abi.encodePacked(
                 _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, ""), "extra data"
@@ -406,7 +400,7 @@ contract PerHookDataTest is CustomValidationTestBase {
             nonce: 0,
             initCode: "",
             callData: abi.encodeCall(
-                UpgradeableModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,

--- a/test/account/PermittedCallPermissions.t.sol
+++ b/test/account/PermittedCallPermissions.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {PermittedCallerModule} from "../mocks/modules/PermittedCallMocks.sol";
 import {ResultCreatorModule} from "../mocks/modules/ReturnDataModuleMocks.sol";
@@ -46,7 +46,7 @@ contract PermittedCallPermissionsTest is AccountTestBase {
     function test_permittedCall_NotAllowed() public {
         vm.expectRevert(
             abi.encodeWithSelector(
-                UpgradeableModularAccount.ValidationFunctionMissing.selector, ResultCreatorModule.bar.selector
+                ReferenceModularAccount.ValidationFunctionMissing.selector, ResultCreatorModule.bar.selector
             )
         );
         PermittedCallerModule(address(account1)).usePermittedCallNotAllowed();

--- a/test/account/ReferenceModularAccount.t.sol
+++ b/test/account/ReferenceModularAccount.t.sol
@@ -11,8 +11,8 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 
 import {ModuleManagerInternals} from "../../src/account/ModuleManagerInternals.sol";
 
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
 
@@ -29,7 +29,7 @@ import {ComprehensiveModule} from "../mocks/modules/ComprehensiveModule.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID} from "../utils/TestConstants.sol";
 
-contract UpgradeableModularAccountTest is AccountTestBase {
+contract ReferenceModularAccountTest is AccountTestBase {
     using ECDSA for bytes32;
     using MessageHashUtils for bytes32;
 
@@ -38,7 +38,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     // A separate account and owner that isn't deployed yet, used to test initcode
     address public owner2;
     uint256 public owner2Key;
-    UpgradeableModularAccount public account2;
+    ReferenceModularAccount public account2;
 
     address public ethRecipient;
     Counter public counter;
@@ -54,7 +54,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         (owner2, owner2Key) = makeAddrAndKey("owner2");
 
         // Compute counterfactual address
-        account2 = UpgradeableModularAccount(payable(factory.getAddress(owner2, 0)));
+        account2 = ReferenceModularAccount(payable(factory.getAddress(owner2, 0)));
         vm.deal(address(account2), 100 ether);
 
         ethRecipient = makeAddr("ethRecipient");
@@ -72,7 +72,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             sender: address(account1),
             nonce: 0,
             initCode: "",
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -97,7 +97,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         bytes memory callData = vm.envOr("SMA_TEST", false)
             ? abi.encodeCall(SemiModularAccount(payable(account1)).updateFallbackSigner, (owner2))
             : abi.encodeCall(
-                UpgradeableModularAccount.execute,
+                ReferenceModularAccount.execute,
                 (
                     address(singleSignerValidationModule),
                     0,
@@ -137,7 +137,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             sender: address(account2),
             nonce: 0,
             initCode: abi.encodePacked(address(factory), abi.encodeCall(factory.createAccount, (owner2, 0))),
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (recipient, 1 wei, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (recipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -158,12 +158,12 @@ contract UpgradeableModularAccountTest is AccountTestBase {
         assertEq(recipient.balance, 1 wei);
     }
 
-    function test_debug_upgradeableModularAccount_storageAccesses() public {
+    function test_debug_ReferenceModularAccount_storageAccesses() public {
         PackedUserOperation memory userOp = PackedUserOperation({
             sender: address(account1),
             nonce: 0,
             initCode: "",
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -200,7 +200,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             nonce: 0,
             initCode: "",
             callData: abi.encodeCall(
-                UpgradeableModularAccount.execute, (address(counter), 0, abi.encodeCall(counter.increment, ()))
+                ReferenceModularAccount.execute, (address(counter), 0, abi.encodeCall(counter.increment, ()))
             ),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
@@ -232,7 +232,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             sender: address(account1),
             nonce: 0,
             initCode: "",
-            callData: abi.encodeCall(UpgradeableModularAccount.executeBatch, (calls)),
+            callData: abi.encodeCall(ReferenceModularAccount.executeBatch, (calls)),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -358,7 +358,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
 
     function test_upgradeToAndCall() public {
         vm.startPrank(address(entryPoint));
-        UpgradeableModularAccount account3 = new UpgradeableModularAccount(entryPoint);
+        ReferenceModularAccount account3 = new ReferenceModularAccount(entryPoint);
         bytes32 slot = account3.proxiableUUID();
 
         // account has impl from factory

--- a/test/account/ReplaceModule.t.sol
+++ b/test/account/ReplaceModule.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.25;
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 
@@ -189,7 +189,7 @@ contract UpgradeModuleTest is AccountTestBase {
         // Test if old validation still works, expect fail
         vm.expectRevert(
             abi.encodePacked(
-                UpgradeableModularAccount.ValidationFunctionMissing.selector,
+                ReferenceModularAccount.ValidationFunctionMissing.selector,
                 abi.encode(IModularAccount.execute.selector)
             )
         );

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -5,7 +5,7 @@ import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IA
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
@@ -50,7 +50,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(
-                    UpgradeableModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
+                    ReferenceModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
                 )
             )
         );
@@ -65,7 +65,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(
-                    UpgradeableModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
+                    ReferenceModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
                 )
             )
         );
@@ -76,7 +76,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         _runtimeCall(
             abi.encodeCall(ComprehensiveModule.foo, ()),
             abi.encodeWithSelector(
-                UpgradeableModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
+                ReferenceModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
             )
         );
     }
@@ -85,14 +85,14 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         // Using global validation, self-call bypasses custom validation needed for ComprehensiveModule.foo
         _runUserOp(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
+                ReferenceModularAccount.execute,
                 (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
             ),
             abi.encodeWithSelector(
                 IEntryPoint.FailedOpWithRevert.selector,
                 0,
                 "AA23 reverted",
-                abi.encodeWithSelector(UpgradeableModularAccount.SelfCallRecursionDepthExceeded.selector)
+                abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector)
             )
         );
 
@@ -106,7 +106,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(
-                    UpgradeableModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
+                    ReferenceModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
                 )
             )
         );
@@ -118,7 +118,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
             abi.encodePacked(
                 IAccountExecute.executeUserOp.selector,
                 abi.encodeCall(
-                    UpgradeableModularAccount.execute,
+                    ReferenceModularAccount.execute,
                     (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
                 )
             ),
@@ -126,7 +126,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 IEntryPoint.FailedOpWithRevert.selector,
                 0,
                 "AA23 reverted",
-                abi.encodeWithSelector(UpgradeableModularAccount.SelfCallRecursionDepthExceeded.selector)
+                abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector)
             )
         );
 
@@ -142,7 +142,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(
-                    UpgradeableModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
+                    ReferenceModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
                 )
             )
         );
@@ -152,10 +152,10 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         // Using global validation, self-call bypasses custom validation needed for ComprehensiveModule.foo
         _runtimeCall(
             abi.encodeCall(
-                UpgradeableModularAccount.execute,
+                ReferenceModularAccount.execute,
                 (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
             ),
-            abi.encodeWithSelector(UpgradeableModularAccount.SelfCallRecursionDepthExceeded.selector)
+            abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector)
         );
 
         Call[] memory calls = new Call[](1);
@@ -164,7 +164,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         _runtimeExecBatchExpFail(
             calls,
             abi.encodeWithSelector(
-                UpgradeableModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
+                ReferenceModularAccount.ValidationFunctionMissing.selector, ComprehensiveModule.foo.selector
             )
         );
     }
@@ -241,7 +241,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 IEntryPoint.FailedOpWithRevert.selector,
                 0,
                 "AA23 reverted",
-                abi.encodeWithSelector(UpgradeableModularAccount.SelfCallRecursionDepthExceeded.selector)
+                abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector)
             )
         );
         entryPoint.handleOps(userOps, beneficiary);
@@ -270,7 +270,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
                 IEntryPoint.FailedOpWithRevert.selector,
                 0,
                 "AA23 reverted",
-                abi.encodeWithSelector(UpgradeableModularAccount.SelfCallRecursionDepthExceeded.selector)
+                abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector)
             )
         );
         entryPoint.handleOps(userOps, beneficiary);
@@ -285,7 +285,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         Call[] memory outerCalls = new Call[](1);
         outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IModularAccount.executeBatch, (innerCalls)));
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeableModularAccount.SelfCallRecursionDepthExceeded.selector));
+        vm.expectRevert(abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector));
         account1.executeWithAuthorization(
             abi.encodeCall(IModularAccount.executeBatch, (outerCalls)),
             _encodeSignature(comprehensiveModuleValidation, SELECTOR_ASSOCIATED_VALIDATION, "")
@@ -302,7 +302,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         vm.prank(owner1);
         account1.executeWithAuthorization(
             abi.encodeCall(
-                UpgradeableModularAccount.installValidation,
+                ReferenceModularAccount.installValidation,
                 (
                     ValidationConfigLib.pack(comprehensiveModuleValidation, false, false),
                     selectors,

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
@@ -199,7 +199,7 @@ contract ValidationIntersectionTest is AccountTestBase {
         vm.prank(address(entryPoint));
         vm.expectRevert(
             abi.encodeWithSelector(
-                UpgradeableModularAccount.UnexpectedAggregator.selector,
+                ReferenceModularAccount.UnexpectedAggregator.selector,
                 address(oneHookModule),
                 MockBaseUserOpValidationModule.EntityId.PRE_VALIDATION_HOOK_1,
                 badAuthorizer

--- a/test/libraries/AccountStorage.t.sol
+++ b/test/libraries/AccountStorage.t.sol
@@ -7,7 +7,7 @@ import {MockDiamondStorageContract} from "../mocks/MockDiamondStorageContract.so
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Test} from "forge-std/Test.sol";
 
-// Test implementation of AccountStorageInitializable which is contained in UpgradeableModularAccount
+// Test implementation of AccountStorageInitializable which is contained in ReferenceModularAccount
 contract AccountStorageTest is Test {
     MockDiamondStorageContract public impl;
     address public proxy;

--- a/test/module/AllowlistModule.t.sol
+++ b/test/module/AllowlistModule.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {Call} from "../../src/interfaces/IModularAccount.sol";
@@ -230,7 +230,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
                         )
                 ) {
                     return abi.encodeWithSelector(
-                        UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
+                        ReferenceModularAccount.PreRuntimeValidationHookFailed.selector,
                         address(allowlistModule),
                         HOOK_ENTITY_ID,
                         abi.encodeWithSelector(AllowlistModule.SelectorNotAllowed.selector)
@@ -238,7 +238,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
                 }
             } else {
                 return abi.encodeWithSelector(
-                    UpgradeableModularAccount.PreRuntimeValidationHookFailed.selector,
+                    ReferenceModularAccount.PreRuntimeValidationHookFailed.selector,
                     address(allowlistModule),
                     HOOK_ENTITY_ID,
                     abi.encodeWithSelector(AllowlistModule.TargetNotAllowed.selector)

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -5,7 +5,7 @@ import {MockERC20} from "../mocks/MockERC20.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {ModuleEntity} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
@@ -27,7 +27,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
     MockModule public validationModule = new MockModule(_m);
     ModuleEntity public validationFunction;
 
-    UpgradeableModularAccount public acct;
+    ReferenceModularAccount public acct;
     ERC20TokenLimitModule public module = new ERC20TokenLimitModule();
     uint256 public spendLimit = 10 ether;
 
@@ -64,7 +64,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
             sender: address(acct),
             nonce: 0,
             initCode: "",
-            callData: abi.encodePacked(UpgradeableModularAccount.executeUserOp.selector, callData),
+            callData: abi.encodePacked(ReferenceModularAccount.executeUserOp.selector, callData),
             accountGasLimits: bytes32(bytes16(uint128(200_000))) | bytes32(uint256(200_000)),
             preVerificationGas: 200_000,
             gasFees: bytes32(uint256(uint128(0))),
@@ -75,7 +75,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
 
     function _getExecuteWithSpend(uint256 value) internal view returns (bytes memory) {
         return abi.encodeCall(
-            UpgradeableModularAccount.execute,
+            ReferenceModularAccount.execute,
             (address(erc20), 0, abi.encodeCall(IERC20.transfer, (recipient, value)))
         );
     }

--- a/test/module/NativeTokenLimitModule.t.sol
+++ b/test/module/NativeTokenLimitModule.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {ModuleEntity} from "../../src/helpers/ModuleEntityLib.sol";
 
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
@@ -24,7 +24,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
     MockModule public validationModule = new MockModule(_m);
     ModuleEntity public validationFunction;
 
-    UpgradeableModularAccount public acct;
+    ReferenceModularAccount public acct;
     NativeTokenLimitModule public module = new NativeTokenLimitModule();
     uint256 public spendLimit = 10 ether;
 
@@ -62,7 +62,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
     }
 
     function _getExecuteWithValue(uint256 value) internal view returns (bytes memory) {
-        return abi.encodeCall(UpgradeableModularAccount.execute, (recipient, value, ""));
+        return abi.encodeCall(ReferenceModularAccount.execute, (recipient, value, ""));
     }
 
     function _getPackedUO(uint256 gas1, uint256 gas2, uint256 gas3, uint256 gasPrice, bytes memory callData)
@@ -74,7 +74,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
             sender: address(acct),
             nonce: 0,
             initCode: "",
-            callData: abi.encodePacked(UpgradeableModularAccount.executeUserOp.selector, callData),
+            callData: abi.encodePacked(ReferenceModularAccount.executeUserOp.selector, callData),
             accountGasLimits: bytes32(bytes16(uint128(gas1))) | bytes32(uint256(gas2)),
             preVerificationGas: gas3,
             gasFees: bytes32(uint256(uint128(gasPrice))),
@@ -112,7 +112,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
         // uses 5e + 1wei of native tokens
         vm.expectRevert(
             abi.encodePacked(
-                UpgradeableModularAccount.PreExecHookReverted.selector,
+                ReferenceModularAccount.PreExecHookReverted.selector,
                 abi.encode(
                     address(module),
                     uint32(0),

--- a/test/module/SingleSignerValidationModule.t.sol
+++ b/test/module/SingleSignerValidationModule.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 
@@ -20,7 +20,7 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
     address public ethRecipient;
     address public owner2;
     uint256 public owner2Key;
-    UpgradeableModularAccount public account;
+    ReferenceModularAccount public account;
 
     ContractOwner public contractOwner;
 
@@ -44,7 +44,7 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
             sender: address(account),
             nonce: 0,
             initCode: "",
-            callData: abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -72,7 +72,7 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
     function test_runtimeValidate() public {
         vm.prank(owner1);
         account.executeWithAuthorization(
-            abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID),
                 GLOBAL_VALIDATION,
@@ -99,7 +99,7 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
 
         vm.prank(owner2);
         account.executeWithAuthorization(
-            abi.encodeCall(UpgradeableModularAccount.execute, (ethRecipient, 1 wei, "")),
+            abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_VALIDATION, ""
             )

--- a/test/module/TokenReceiverModule.t.sol
+++ b/test/module/TokenReceiverModule.t.sol
@@ -6,7 +6,7 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {TokenReceiverModule} from "../../src/modules/TokenReceiverModule.sol";
 
 import {MockERC1155} from "../mocks/MockERC1155.sol";
@@ -17,7 +17,7 @@ import {OptimizedTest} from "../utils/OptimizedTest.sol";
 
 contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
     EntryPoint public entryPoint;
-    UpgradeableModularAccount public acct;
+    ReferenceModularAccount public acct;
     TokenReceiverModule public module;
 
     MockERC721 public t0;
@@ -63,7 +63,7 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
     function test_failERC721Transfer() public {
         vm.expectRevert(
             abi.encodePacked(
-                UpgradeableModularAccount.UnrecognizedFunction.selector,
+                ReferenceModularAccount.UnrecognizedFunction.selector,
                 IERC721Receiver.onERC721Received.selector,
                 bytes28(0)
             )
@@ -82,7 +82,7 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
         // for 1155, reverts are caught in a try catch and bubbled up with the reason from the account
         vm.expectRevert(
             abi.encodePacked(
-                UpgradeableModularAccount.UnrecognizedFunction.selector,
+                ReferenceModularAccount.UnrecognizedFunction.selector,
                 IERC1155Receiver.onERC1155Received.selector,
                 bytes28(0)
             )
@@ -92,7 +92,7 @@ contract TokenReceiverModuleTest is OptimizedTest, IERC1155Receiver {
         // for 1155, reverts are caught in a try catch and bubbled up with the reason from the account
         vm.expectRevert(
             abi.encodePacked(
-                UpgradeableModularAccount.UnrecognizedFunction.selector,
+                ReferenceModularAccount.UnrecognizedFunction.selector,
                 IERC1155Receiver.onERC1155BatchReceived.selector,
                 bytes28(0)
             )

--- a/test/script/Deploy.s.t.sol
+++ b/test/script/Deploy.s.t.sol
@@ -11,8 +11,8 @@ import {DeployScript} from "../../script/Deploy.s.sol";
 
 import {AccountFactory} from "../../src/account/AccountFactory.sol";
 
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
 contract DeployTest is Test {
@@ -40,7 +40,7 @@ contract DeployTest is Test {
         _accountImpl = Create2.computeAddress(
             bytes32(0),
             keccak256(
-                abi.encodePacked(type(UpgradeableModularAccount).creationCode, abi.encode(address(_entryPoint)))
+                abi.encodePacked(type(ReferenceModularAccount).creationCode, abi.encode(address(_entryPoint)))
             ),
             CREATE2_FACTORY
         );

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -5,8 +5,8 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
 import {Call, IModularAccount} from "../../src/interfaces/IModularAccount.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
@@ -17,7 +17,7 @@ import {TEST_DEFAULT_VALIDATION_ENTITY_ID as EXT_CONST_TEST_DEFAULT_VALIDATION_E
 
 import {SingleSignerFactoryFixture} from "../mocks/SingleSignerFactoryFixture.sol";
 
-/// @dev This contract handles common boilerplate setup for tests using UpgradeableModularAccount with
+/// @dev This contract handles common boilerplate setup for tests using ReferenceModularAccount with
 /// SingleSignerValidationModule.
 abstract contract AccountTestBase is OptimizedTest {
     using ModuleEntityLib for ModuleEntity;
@@ -31,7 +31,7 @@ abstract contract AccountTestBase is OptimizedTest {
 
     address public owner1;
     uint256 public owner1Key;
-    UpgradeableModularAccount public account1;
+    ReferenceModularAccount public account1;
 
     ModuleEntity internal _signerValidation;
 

--- a/test/utils/CustomValidationTestBase.sol
+++ b/test/utils/CustomValidationTestBase.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {ModuleEntity} from "../../src/helpers/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";
 
@@ -26,7 +26,7 @@ abstract contract CustomValidationTestBase is AccountTestBase {
 
         address accountImplementation = address(factory.accountImplementation());
 
-        account1 = UpgradeableModularAccount(payable(new ERC1967Proxy{salt: 0}(accountImplementation, "")));
+        account1 = ReferenceModularAccount(payable(new ERC1967Proxy{salt: 0}(accountImplementation, "")));
 
         if (vm.envOr("SMA_TEST", false)) {
             vm.prank(address(entryPoint));

--- a/test/utils/OptimizedTest.sol
+++ b/test/utils/OptimizedTest.sol
@@ -5,8 +5,8 @@ import {Test} from "forge-std/Test.sol";
 
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
+import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 
 import {TokenReceiverModule} from "../../src/modules/TokenReceiverModule.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
@@ -30,30 +30,27 @@ abstract contract OptimizedTest is Test {
         return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
     }
 
-    function _deployUpgradeableModularAccount(IEntryPoint entryPoint)
-        internal
-        returns (UpgradeableModularAccount)
-    {
+    function _deployReferenceModularAccount(IEntryPoint entryPoint) internal returns (ReferenceModularAccount) {
         return _isOptimizedTest()
-            ? UpgradeableModularAccount(
+            ? ReferenceModularAccount(
                 payable(
                     deployCode(
-                        "out-optimized/UpgradeableModularAccount.sol/UpgradeableModularAccount.json",
+                        "out-optimized/ReferenceModularAccount.sol/ReferenceModularAccount.json",
                         abi.encode(entryPoint)
                     )
                 )
             )
-            : new UpgradeableModularAccount(entryPoint);
+            : new ReferenceModularAccount(entryPoint);
     }
 
-    function _deploySemiModularAccount(IEntryPoint entryPoint) internal returns (UpgradeableModularAccount) {
+    function _deploySemiModularAccount(IEntryPoint entryPoint) internal returns (ReferenceModularAccount) {
         return _isOptimizedTest()
-            ? UpgradeableModularAccount(
+            ? ReferenceModularAccount(
                 payable(
                     deployCode("out-optimized/SemiModularAccount.sol/SemiModularAccount.json", abi.encode(entryPoint))
                 )
             )
-            : UpgradeableModularAccount(new SemiModularAccount(entryPoint));
+            : ReferenceModularAccount(new SemiModularAccount(entryPoint));
     }
 
     function _deployTokenReceiverModule() internal returns (TokenReceiverModule) {


### PR DESCRIPTION
## Motivation

The name `UpgradeableModularAccount` is a relic from when 6900 shifted from diamond proxies to regular ERC-1967 proxies, and is no longer a distinguishing name.

## Solution

Rename UpgradeableModularAccount to ReferenceModularAccount.