### PR TITLE
feat: Add SMA Replay-Safe Hash

### DIFF
--- a/src/modules/ReplaySafeWrapper.sol
+++ b/src/modules/ReplaySafeWrapper.sol
@@ -26,7 +26,13 @@ abstract contract ReplaySafeWrapper is ModuleEIP712 {
         });
     }
 
-    function _hashStruct(bytes32 hash) internal view virtual returns (bytes32) {
-        return keccak256(abi.encode(_REPLAY_SAFE_HASH_TYPEHASH, hash));
+    function _hashStruct(bytes32 hash) internal pure virtual returns (bytes32) {
+        bytes32 res;
+        assembly ("memory-safe") {
+            mstore(0x00, _REPLAY_SAFE_HASH_TYPEHASH)
+            mstore(0x20, hash)
+            res := keccak256(0x00, 0x40)
+        }
+        return res;
     }
 }

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -402,17 +402,15 @@ contract UpgradeableModularAccountTest is AccountTestBase {
     function test_isValidSignature() public {
         bytes32 message = keccak256("hello world");
 
+        bytes32 replaySafeHash = vm.envOr("SMA_TEST", false)
+            ? SemiModularAccount(payable(account1)).replaySafeHash(message)
+            : singleSignerValidationModule.replaySafeHash(address(account1), message);
+
         uint8 v;
         bytes32 r;
         bytes32 s;
 
-        if (vm.envOr("SMA_TEST", false)) {
-            // todo: implement replay-safe hashing for SMA
-            (v, r, s) = vm.sign(owner1Key, message);
-        } else {
-            bytes32 replaySafeHash = singleSignerValidationModule.replaySafeHash(address(account1), message);
-            (v, r, s) = vm.sign(owner1Key, replaySafeHash);
-        }
+        (v, r, s) = vm.sign(owner1Key, replaySafeHash);
 
         bytes memory signature = _encode1271Signature(_signerValidation, abi.encodePacked(r, s, v));
 

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -406,11 +406,7 @@ contract UpgradeableModularAccountTest is AccountTestBase {
             ? SemiModularAccount(payable(account1)).replaySafeHash(message)
             : singleSignerValidationModule.replaySafeHash(address(account1), message);
 
-        uint8 v;
-        bytes32 r;
-        bytes32 s;
-
-        (v, r, s) = vm.sign(owner1Key, replaySafeHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, replaySafeHash);
 
         bytes memory signature = _encode1271Signature(_signerValidation, abi.encodePacked(r, s, v));
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently, two SMAs with the same fallback signer could be used to verify messages. This is problematic as signatures must be unique on a per-account basis. 

This has been addressed for modules already, and this PR addresses this for SMAs. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Add a `replaySafeHash()` function and related EIP712 functionality to the `SemiModularAccount`, which is computed upon ERC1271 signature validation. This means the fallback signer must sign the replay-safe hash, but the inner hash must be submitted in the transaction. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->