### PR TITLE
refactor: rename loupe to view

### DIFF
--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -6,16 +6,16 @@ import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {HookConfigLib} from "../helpers/HookConfigLib.sol";
-import {ExecutionDataView, IAccountLoupe, ValidationDataView} from "../interfaces/IAccountLoupe.sol";
 import {HookConfig, IModularAccount, ModuleEntity} from "../interfaces/IModularAccount.sol";
+import {ExecutionDataView, IModularAccountView, ValidationDataView} from "../interfaces/IModularAccountView.sol";
 import {ExecutionData, ValidationData, getAccountStorage} from "./AccountStorage.sol";
 
-abstract contract AccountLoupe is IAccountLoupe {
+abstract contract ModularAccountView is IModularAccountView {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using EnumerableMap for EnumerableMap.AddressToUintMap;
     using HookConfigLib for HookConfig;
 
-    /// @inheritdoc IAccountLoupe
+    /// @inheritdoc IModularAccountView
     function getExecutionData(bytes4 selector) external view override returns (ExecutionDataView memory data) {
         if (
             selector == IModularAccount.execute.selector || selector == IModularAccount.executeBatch.selector
@@ -39,7 +39,7 @@ abstract contract AccountLoupe is IAccountLoupe {
         }
     }
 
-    /// @inheritdoc IAccountLoupe
+    /// @inheritdoc IModularAccountView
     function getValidationData(ModuleEntity validationFunction)
         external
         view

--- a/src/account/ReferenceModularAccount.sol
+++ b/src/account/ReferenceModularAccount.sol
@@ -24,15 +24,15 @@ import {Call, IModularAccount, ModuleEntity, ValidationConfig} from "../interfac
 import {IValidationHookModule} from "../interfaces/IValidationHookModule.sol";
 import {IValidationModule} from "../interfaces/IValidationModule.sol";
 import {AccountExecutor} from "./AccountExecutor.sol";
-import {AccountLoupe} from "./AccountLoupe.sol";
 import {AccountStorage, getAccountStorage, toHookConfig, toSetValue} from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
+import {ModularAccountView} from "./ModularAccountView.sol";
 import {ModuleManagerInternals} from "./ModuleManagerInternals.sol";
 
 contract ReferenceModularAccount is
     IModularAccount,
     AccountExecutor,
-    AccountLoupe,
+    ModularAccountView,
     AccountStorageInitializable,
     BaseAccount,
     IERC165,

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -7,10 +7,10 @@ import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymas
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
 import {IExecutionHookModule} from "../interfaces/IExecutionHookModule.sol";
 import {IExecutionModule} from "../interfaces/IExecutionModule.sol";
 import {IModularAccount} from "../interfaces/IModularAccount.sol";
+import {IModularAccountView} from "../interfaces/IModularAccountView.sol";
 import {IModule} from "../interfaces/IModule.sol";
 import {IValidationHookModule} from "../interfaces/IValidationHookModule.sol";
 import {IValidationModule} from "../interfaces/IValidationModule.sol";
@@ -35,9 +35,9 @@ library KnownSelectors {
         // check against UUPSUpgradeable methods
         || selector == UUPSUpgradeable.proxiableUUID.selector
             || selector == UUPSUpgradeable.upgradeToAndCall.selector
-        // check against IAccountLoupe methods
-        || selector == IAccountLoupe.getExecutionData.selector
-            || selector == IAccountLoupe.getValidationData.selector;
+        // check against IModularAccountView methods
+        || selector == IModularAccountView.getExecutionData.selector
+            || selector == IModularAccountView.getValidationData.selector;
     }
 
     function isErc4337Function(bytes4 selector) internal pure returns (bool) {

--- a/src/interfaces/IModularAccountView.sol
+++ b/src/interfaces/IModularAccountView.sol
@@ -32,7 +32,7 @@ struct ValidationDataView {
     bytes4[] selectors;
 }
 
-interface IAccountLoupe {
+interface IModularAccountView {
     /// @notice Get the execution data for a selector.
     /// @dev If the selector is a native function, the module address will be the address of the account.
     /// @param selector The selector to get the data for.

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -71,7 +71,7 @@ Each step is modular, supporting different implementations, that allows for open
 
 **Modular Smart Contract Accounts** **MAY** implement
 
-- `IAccountLoupe.sol` to support visibility in account states on-chain.
+- `IModularAccountView.sol` to support visibility in account states on-chain.
 - [ERC-165](./eip-165.md) for interfaces installed from modules.
 
 **Modules** **MUST** implement
@@ -195,7 +195,7 @@ interface IModularAccount {
 
 ```
 
-#### `IAccountLoupe.sol`
+#### `IModularAccountView.sol`
 
 Module inspection interface. Modular Smart Contract Accounts **MAY** implement this interface to support visibility in module configuration.
 
@@ -229,7 +229,7 @@ struct ValidationDataView {
     bytes4[] selectors;
 }
 
-interface IAccountLoupe {
+interface IModularAccountView {
     /// @notice Get the execution data for a selector.
     /// @dev If the selector is a native function, the module address will be the address of the account.
     /// @param selector The selector to get the data for.
@@ -524,7 +524,7 @@ The function SHOULD perform the following checks:
 - Revert if the hash of the manifest used at install time does not match the computed Keccak-256 hash of the module's current manifest. This prevents unclean removal of modules that attempt to force a removal of a different module configuration than the one that was originally approved by the client for installation. To allow for removal of such modules, the modular account MAY implement the capability for the manifest to be encoded in the config field as a parameter.
 - Revert if there is at least 1 other installed module that depends on validation functions added by this module. Modules used as dependencies SHOULD NOT be uninstalled while dependent modules exist.
 
-The function SHOULD update account storage to reflect the uninstall via inspection functions, such as those defined by `IAccountLoupe`. Each dependency's record SHOULD also be updated to reflect that it has no longer has this module as a dependent.
+The function SHOULD update account storage to reflect the uninstall via inspection functions, such as those defined by `IModularAccountView`. Each dependency's record SHOULD also be updated to reflect that it has no longer has this module as a dependent.
 
 The function MUST remove records for the module's manifest hash, dependencies, permitted function selectors, permitted external calls, and whether it can spend the account's native tokens.
 

--- a/test/account/ModularAccountView.t.sol
+++ b/test/account/ModularAccountView.t.sol
@@ -5,13 +5,14 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";
-import {ExecutionDataView, ValidationDataView} from "../../src/interfaces/IAccountLoupe.sol";
+
 import {HookConfig, IModularAccount} from "../../src/interfaces/IModularAccount.sol";
+import {ExecutionDataView, ValidationDataView} from "../../src/interfaces/IModularAccountView.sol";
 
 import {ComprehensiveModule} from "../mocks/modules/ComprehensiveModule.sol";
 import {CustomValidationTestBase} from "../utils/CustomValidationTestBase.sol";
 
-contract AccountLoupeTest is CustomValidationTestBase {
+contract ModularAccountViewTest is CustomValidationTestBase {
     ComprehensiveModule public comprehensiveModule;
 
     event ReceivedCall(bytes msgData, uint256 msgValue);
@@ -30,7 +31,7 @@ contract AccountLoupeTest is CustomValidationTestBase {
         vm.stopPrank();
     }
 
-    function test_moduleLoupe_getExecutionData_native() public {
+    function test_moduleView_getExecutionData_native() public {
         bytes4[] memory selectorsToCheck = new bytes4[](5);
 
         selectorsToCheck[0] = IModularAccount.execute.selector;
@@ -51,7 +52,7 @@ contract AccountLoupeTest is CustomValidationTestBase {
         }
     }
 
-    function test_moduleLoupe_getExecutionData_module() public {
+    function test_moduleView_getExecutionData_module() public {
         bytes4[] memory selectorsToCheck = new bytes4[](1);
         address[] memory expectedModuleAddress = new address[](1);
 
@@ -95,7 +96,7 @@ contract AccountLoupeTest is CustomValidationTestBase {
         }
     }
 
-    function test_moduleLoupe_getValidationData() public {
+    function test_moduleView_getValidationData() public {
         ValidationDataView memory data = account1.getValidationData(comprehensiveModuleValidation);
         bytes4[] memory selectors = data.selectors;
 

--- a/test/account/ReferenceModularAccount.t.sol
+++ b/test/account/ReferenceModularAccount.t.sol
@@ -16,8 +16,8 @@ import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
 
 import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
 
-import {ExecutionDataView} from "../../src/interfaces/IAccountLoupe.sol";
 import {Call} from "../../src/interfaces/IModularAccount.sol";
+import {ExecutionDataView} from "../../src/interfaces/IModularAccountView.sol";
 
 import {TokenReceiverModule} from "../../src/modules/TokenReceiverModule.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";


### PR DESCRIPTION
## Motivation

As discussed in the working group sync, since the removal of historical context for the diamond proxies, the use of "loupe" to refer to view functions doesn't have backing.

## Solution

Rename `IAccountLoupe` to `ModularAccountView`.

Renamed the abstract contract `AccountLoupe` to `ModularAccountView`.

Update other references to the "loupe" name.