### PR TITLE
feat: pack hook config

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -76,7 +76,7 @@ function toSetValue(HookConfig hookConfig) pure returns (bytes32) {
 }
 
 function toHookConfig(bytes32 setValue) pure returns (HookConfig) {
-    return HookConfig.wrap(bytes26(setValue));
+    return HookConfig.wrap(bytes25(setValue));
 }
 
 function toSetValue(bytes4 selector) pure returns (bytes32) {

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -8,7 +8,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {HookConfig, IModularAccount, ModuleEntity} from "../interfaces/IModularAccount.sol";
 import {ExecutionDataView, IModularAccountView, ValidationDataView} from "../interfaces/IModularAccountView.sol";
-import {ExecutionData, ValidationData, getAccountStorage} from "./AccountStorage.sol";
+import {ExecutionData, ValidationData, getAccountStorage, toHookConfig} from "./AccountStorage.sol";
 
 abstract contract ModularAccountView is IModularAccountView {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -34,7 +34,7 @@ abstract contract ModularAccountView is IModularAccountView {
             uint256 executionHooksLen = executionData.executionHooks.length();
             data.executionHooks = new HookConfig[](executionHooksLen);
             for (uint256 i = 0; i < executionHooksLen; ++i) {
-                data.executionHooks[i] = HookConfig.wrap(bytes26(executionData.executionHooks.at(i)));
+                data.executionHooks[i] = toHookConfig(executionData.executionHooks.at(i));
             }
         }
     }
@@ -55,7 +55,7 @@ abstract contract ModularAccountView is IModularAccountView {
         uint256 permissionHooksLen = validationData.permissionHooks.length();
         data.permissionHooks = new HookConfig[](permissionHooksLen);
         for (uint256 i = 0; i < permissionHooksLen; ++i) {
-            data.permissionHooks[i] = HookConfig.wrap(bytes26(validationData.permissionHooks.at(i)));
+            data.permissionHooks[i] = toHookConfig(validationData.permissionHooks.at(i));
         }
 
         bytes32[] memory selectors = validationData.selectors.values();

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -229,8 +229,8 @@ abstract contract ModuleManagerInternals is IModularAccount {
         ModuleEntity moduleEntity = validationConfig.moduleEntity();
 
         for (uint256 i = 0; i < hooks.length; ++i) {
-            HookConfig hookConfig = HookConfig.wrap(bytes26(hooks[i][:26]));
-            bytes calldata hookData = hooks[i][26:];
+            HookConfig hookConfig = HookConfig.wrap(bytes25(hooks[i][:25]));
+            bytes calldata hookData = hooks[i][25:];
 
             if (hookConfig.isValidationHook()) {
                 _validationData.preValidationHooks.push(hookConfig.moduleEntity());

--- a/src/interfaces/IModularAccount.sol
+++ b/src/interfaces/IModularAccount.sol
@@ -24,7 +24,18 @@ type ValidationConfig is bytes25;
 // 0b______B_ // isSignatureValidation
 // 0b_______C // isUserOpValidation
 
-type HookConfig is bytes26;
+type HookConfig is bytes25;
+// HookConfig is a packed representation of a hook function and flags for its configuration.
+// Layout:
+// 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA________________________ // Address
+// 0x________________________________________BBBBBBBB________________ // Entity ID
+// 0x________________________________________________CC______________ // Hook Flags
+//
+// Hook flags layout:
+// 0b00000___ // unused
+// 0b_____A__ // hasPre (exec only)
+// 0b______B_ // hasPost (exec only)
+// 0b_______C // hook type (0 for exec, 1 for validation)
 
 struct Call {
     // The target address for the account to call.
@@ -82,7 +93,7 @@ interface IModularAccount {
     /// @param selectors The selectors to install the validation function for.
     /// @param installData Optional data to be decoded and used by the module to setup initial module state.
     /// @param hooks Optional hooks to install, associated with the validation function. These may be
-    /// pre validation hooks or execution hooks. The expected format is a bytes26 HookConfig, followed by the
+    /// pre validation hooks or execution hooks. The expected format is a bytes25 HookConfig, followed by the
     /// install data, if any.
     function installValidation(
         ValidationConfig validationConfig,


### PR DESCRIPTION
## Motivation

In #160 we packed `ValidationConfig` efficiently into a `bytes25` type. For consistency, we should do the same for the `HookConfig` type.

## Solution

Change `HookConfig` to a `bytes25` type.

Pack all flags efficiently in the final byte, rather that spreading it out over 2 bytes.

Update usage in the account and tests.