### PR TITLE
feat: modify spec to leave arbitrary data params open-ended

### DIFF
--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -101,6 +101,12 @@ type ModuleEntity is bytes24;
 /// Module address: 20 bytes
 /// Entity ID:      4 bytes
 /// Flags:          1 byte
+///
+/// Validation flags layout:
+/// 0b00000___ // unused
+/// 0b_____A__ // isGlobal
+/// 0b______B_ // isSignatureValidation
+/// 0b_______C // isUserOpValidation
 type ValidationConfig is bytes25;
 
 /// A packed representation of a hook function and its associated flags.
@@ -108,6 +114,12 @@ type ValidationConfig is bytes25;
 /// Module address: 20 bytes
 /// Entity ID:      4 bytes
 /// Flags:          1 byte
+///
+/// Hook flags layout:
+/// 0b00000___ // unused
+/// 0b_____A__ // hasPre (exec only)
+/// 0b______B_ // hasPost (exec only)
+/// 0b_______C // hook type (0 for exec, 1 for validation)
 type HookConfig is bytes25;
 
 struct Call {

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -163,7 +163,8 @@ interface IModularAccount {
     /// @notice Install a module to the modular account.
     /// @param module The module to install.
     /// @param manifest the manifest describing functions to install.
-    /// @param moduleInstallData Optional data to be arbitrarily used by the account to handle the initial execution setup.
+    /// @param moduleInstallData Optional data to be used by the account to handle the initial execution setup,
+    /// data encoding is implementation-specific.
     function installExecution(
         address module,
         ExecutionManifest calldata manifest,
@@ -175,8 +176,10 @@ interface IModularAccount {
     /// @dev This does not validate anything against the manifest - the caller must ensure validity.
     /// @param validationConfig The validation function to install, along with configuration flags.
     /// @param selectors The selectors to install the validation function for.
-    /// @param installData Optional data to be arbitrarily used by the account to handle the initial validation setup.
-    /// @param hooks Optional hooks to install and associate with the validation function.
+    /// @param installData Optional data to be used by the account to handle the initial validation setup, data
+    /// encoding is implementation-specific.
+    /// @param hooks Optional hooks to install and associate with the validation function, data encoding is
+    /// implementation-specific.
     function installValidation(
         ValidationConfig validationConfig,
         bytes4[] calldata selectors,
@@ -186,8 +189,10 @@ interface IModularAccount {
 
     /// @notice Uninstall a validation function from a set of execution selectors.
     /// @param validationFunction The validation function to uninstall.
-    /// @param uninstallData Optional data to be arbitrarily used by the account to handle the validation uninstallation.
-    /// @param hookUninstallData Optional data to be arbitrarily used by the account to handle hook uninstallation.
+    /// @param uninstallData Optional data to be used by the account to handle the validation uninstallation, data
+    /// encoding is implementation-specific.
+    /// @param hookUninstallData Optional data to be used by the account to handle hook uninstallation, data encoding
+    /// is implementation-specific.
     function uninstallValidation(
         ModuleEntity validationFunction,
         bytes calldata uninstallData,
@@ -197,7 +202,8 @@ interface IModularAccount {
     /// @notice Uninstall a module from the modular account.
     /// @param module The module to uninstall.
     /// @param manifest the manifest describing functions to uninstall.
-    /// @param moduleUninstallData Optional data to be arbitrarily used by the account to handle the execution uninstallation.
+    /// @param moduleUninstallData Optional data to be used by the account to handle the execution uninstallation, data
+    /// encoding is implementation-specific.
     function uninstallExecution(
         address module,
         ExecutionManifest calldata manifest,

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -90,7 +90,10 @@ Each step is modular, supporting different implementations, that allows for open
 Module execution and management interface. Modular Smart Contract Accounts **MUST** implement this interface to support installing and uninstalling modules, and open-ended execution.
 
 ```solidity
-
+/// A packed representation of a module function.
+/// Consists of the following, left-aligned:
+/// Module address: 20 bytes
+/// Entity ID:      4 bytes
 type ModuleEntity is bytes24;
 
 /// A packed representation of a validation function and its associated flags.

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -93,9 +93,19 @@ Module execution and management interface. Modular Smart Contract Accounts **MUS
 
 type ModuleEntity is bytes24;
 
-type ValidationConfig is bytes26;
+/// A packed representation of a validation function and its associated flags.
+/// Consists of the following, left-aligned:
+/// Module address: 20 bytes
+/// Entity ID:      4 bytes
+/// Flags:          1 byte
+type ValidationConfig is bytes25;
 
-type HookConfig is bytes26;
+/// A packed representation of a hook function and its associated flags.
+/// Consists of the following, left-aligned:
+/// Module address: 20 bytes
+/// Entity ID:      4 bytes
+/// Flags:          1 byte
+type HookConfig is bytes25;
 
 struct Call {
     // The target address for the account to call.
@@ -137,9 +147,8 @@ interface IModularAccount {
 
     /// @notice Install a module to the modular account.
     /// @param module The module to install.
-    /// @param manifest the manifest describing functions to install
-    /// @param moduleInstallData Optional data to be decoded and used by the module to setup initial module data
-    /// for the modular account.
+    /// @param manifest the manifest describing functions to install.
+    /// @param moduleInstallData Optional data to be arbitrarily used by the account to handle the initial execution setup.
     function installExecution(
         address module,
         ExecutionManifest calldata manifest,
@@ -151,10 +160,8 @@ interface IModularAccount {
     /// @dev This does not validate anything against the manifest - the caller must ensure validity.
     /// @param validationConfig The validation function to install, along with configuration flags.
     /// @param selectors The selectors to install the validation function for.
-    /// @param installData Optional data to be decoded and used by the module to setup initial module state.
-    /// @param hooks Optional hooks to install, associated with the validation function. These may be
-    /// pre validation hooks or execution hooks. The expected format is a bytes26 HookConfig, followed by the
-    /// install data, if any.
+    /// @param installData Optional data to be arbitrarily used by the account to handle the initial validation setup.
+    /// @param hooks Optional hooks to install and associate with the validation function.
     function installValidation(
         ValidationConfig validationConfig,
         bytes4[] calldata selectors,
@@ -164,11 +171,8 @@ interface IModularAccount {
 
     /// @notice Uninstall a validation function from a set of execution selectors.
     /// @param validationFunction The validation function to uninstall.
-    /// @param uninstallData Optional data to be decoded and used by the module to clear module data for the
-    /// account.
-    /// @param hookUninstallData Optional data to be used by hooks for cleanup. If any are provided, the array must
-    /// be of a length equal to existing pre validation hooks plus permission hooks. Hooks are indexed by
-    /// pre validation hook order first, then permission hooks.
+    /// @param uninstallData Optional data to be arbitrarily used by the account to handle the validation uninstallation.
+    /// @param hookUninstallData Optional data to be arbitrarily used by the account to handle hook uninstallation.
     function uninstallValidation(
         ModuleEntity validationFunction,
         bytes calldata uninstallData,
@@ -178,8 +182,7 @@ interface IModularAccount {
     /// @notice Uninstall a module from the modular account.
     /// @param module The module to uninstall.
     /// @param manifest the manifest describing functions to uninstall.
-    /// @param moduleUninstallData Optional data to be decoded and used by the module to clear module data for the
-    /// modular account.
+    /// @param moduleUninstallData Optional data to be arbitrarily used by the account to handle the execution uninstallation.
     function uninstallExecution(
         address module,
         ExecutionManifest calldata manifest,
@@ -378,8 +381,6 @@ interface IValidationHookModule is IModule {
         bytes calldata authorization
     ) external;
 
-    // TODO: support this hook type within the account & in the manifest
-
     /// @notice Run the pre signature validation hook specified by the `entityId`.
     /// @dev To indicate the call should revert, the function MUST revert.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
@@ -387,11 +388,10 @@ interface IValidationHookModule is IModule {
     /// @param sender The caller address.
     /// @param hash The hash of the message being signed.
     /// @param signature The signature of the message.
-    // function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata
-    // signature)
-    //     external
-    //     view
-    //     returns (bytes4);
+    function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata signature)
+        external
+        view
+        returns (bytes4);
 }
 ```
 
@@ -462,8 +462,6 @@ interface IExecutionHookModule is IModule {
 
 ### Expected behavior
 
-TODO for v0.8
-
 #### Validations and their installation /uninstallation
 
 An account can have more than one validation module/function installed.
@@ -508,18 +506,6 @@ During execution uninstallation, the account MUST correctly clear flags and othe
 - the account MUST remove all supported interfaces as specified in the manifest.
 - the account SHOULD call `onUnInstall` on the execution module to initialize the states and track call success if required by user.
 - the account MUST emit `ExecutionUninstalled` as defined in the interface for all uninstalled executions.
-
-#### Responsibilties of `StandardExecutor` and `ModuleExecutor`
-
-`StandardExecutor` functions are used for open-ended calls to external addresses.
-
-`ModuleExecutor` functions are specifically used by modules to request the account to execute with account's context. Explicit permissions are required for modules to use `ModuleExecutor`.
-
-The following behavior MUST be followed:
-
-- `StandardExecutor` can NOT call module execution functions and/or `ModuleExecutor`. This is guaranteed by checking whether the call's target implements the `IModule` interface via ERC-165 as required.
-- `StandardExecutor` can NOT be called by module execution functions and/or `ModuleExecutor`.
-- Module execution functions MUST NOT request access to `StandardExecutor`, they MAY request access to `ModuleExecutor`.
 
 ### Validation Call Flow
 
@@ -569,7 +555,7 @@ Module execution functions where the field `isPublic` is set to true, or native 
 
 ### Extension
 
-#### Semi-modular account
+#### Semi-Modular Account
 
 Account implementers MAY choose to design a semi-modular account, where certain features, such as default validation, are integrated into the core account. This approach SHOULD ensure compatibility with fully modular accounts, as defined in this proposal, to maintain interoperability across different implementations.
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently, the spec dictates the encoding of certain arbitrary `bytes` and `bytes[]` parameters. However, it may be beneficial to leave the encoding schemes up to individual accounts. 

This clarifies that accounts have the option to require that these parameters be encoded as they see fit, as long as the behaviour specified in the spec is upheld.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Mostly, this change just removes a few lines of comments from the spec. I also took the liberty to remove some TODOs which are already complete, and add comments explaining the `HookConfig` and `ValidationConfig` data types.

