### PR TITLE
Optimize Module Manager

### DIFF
--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -98,12 +98,6 @@ abstract contract ModuleManagerInternals is IModularAccount {
         _validationData.isGlobal = false;
         _validationData.isSignatureValidation = false;
         _validationData.isUserOpValidation = false;
-
-        // Clear the selectors
-        uint256 length = _validationData.selectors.length();
-        for (uint256 i = 0; i < length; ++i) {
-            _validationData.selectors.remove(_validationData.selectors.at(0));
-        }
     }
 
     function _addExecHooks(EnumerableSet.Bytes32Set storage hooks, HookConfig hookConfig) internal {

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -97,6 +97,7 @@ abstract contract ModuleManagerInternals is IModularAccount {
 
         _validationData.isGlobal = false;
         _validationData.isSignatureValidation = false;
+        _validationData.isUserOpValidation = false;
 
         // Clear the selectors
         uint256 length = _validationData.selectors.length();


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
This PR was created to resolve the 2 potential points in the code.
1. `validationData.isUserOpValidation` not getting properly uninitialized during uninstallation.
2. Redundant selector clearing code during uninstallation of Validation.
  - Identical actions were done twice.
  Here: https://github.com/erc6900/reference-implementation/blob/38231a3f7b365cc229c4947bea500c0ab1758c11/src/account/ModuleManagerInternals.sol#L102
  and here: https://github.com/erc6900/reference-implementation/blob/38231a3f7b365cc229c4947bea500c0ab1758c11/src/account/ModuleManagerInternals.sol#L322
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
1. Added logic to change the value of `isUserOpValidation` variable to false during uninstallation.
2. Removed redundant code. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->