### PR TITLE
feat: rename executeWithAuthorization to executeWithRuntimeValidation

### DIFF
--- a/src/account/ReferenceModularAccount.sol
+++ b/src/account/ReferenceModularAccount.sol
@@ -184,7 +184,7 @@ contract ReferenceModularAccount is
     }
 
     /// @inheritdoc IModularAccount
-    function executeWithAuthorization(bytes calldata data, bytes calldata authorization)
+    function executeWithRuntimeValidation(bytes calldata data, bytes calldata authorization)
         external
         payable
         returns (bytes memory)
@@ -704,7 +704,7 @@ contract ReferenceModularAccount is
                         // To prevent arbitrarily-deep recursive checking, we limit the depth of self-calls to one
                         // for the purposes of batching.
                         // This means that all self-calls must occur at the top level of the batch.
-                        // Note that modules of other contracts using `executeWithAuthorization` may still
+                        // Note that modules of other contracts using `executeWithRuntimeValidation` may still
                         // independently call into this account with a different validation function, allowing
                         // composition of multiple batches.
                         revert SelfCallRecursionDepthExceeded();

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -28,7 +28,7 @@ library KnownSelectors {
             || selector == IModularAccount.installValidation.selector
             || selector == IModularAccount.uninstallValidation.selector || selector == IModularAccount.execute.selector
             || selector == IModularAccount.executeBatch.selector
-            || selector == IModularAccount.executeWithAuthorization.selector
+            || selector == IModularAccount.executeWithRuntimeValidation.selector
             || selector == IModularAccount.accountId.selector
         // check against IERC165 methods
         || selector == IERC165.supportsInterface.selector

--- a/src/interfaces/IModularAccount.sol
+++ b/src/interfaces/IModularAccount.sol
@@ -70,7 +70,7 @@ interface IModularAccount {
     /// @param data The calldata to send to the account.
     /// @param authorization The authorization data to use for the call. The first 24 bytes specifies which runtime
     /// validation to use, and the rest is sent as a parameter to runtime validation.
-    function executeWithAuthorization(bytes calldata data, bytes calldata authorization)
+    function executeWithRuntimeValidation(bytes calldata data, bytes calldata authorization)
         external
         payable
         returns (bytes memory);

--- a/src/interfaces/IValidationHookModule.sol
+++ b/src/interfaces/IValidationHookModule.sol
@@ -24,7 +24,7 @@ interface IValidationHookModule is IModule {
     /// @param sender The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
-    /// @param authorization Additional data for the validation function to use.
+    /// @param authorization Additional data for the hook to use.
     function preRuntimeValidationHook(
         uint32 entityId,
         address sender,

--- a/src/interfaces/IValidationHookModule.sol
+++ b/src/interfaces/IValidationHookModule.sol
@@ -24,6 +24,7 @@ interface IValidationHookModule is IModule {
     /// @param sender The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
+    /// @param authorization Additional data for the validation function to use.
     function preRuntimeValidationHook(
         uint32 entityId,
         address sender,

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -372,7 +372,7 @@ interface IValidationHookModule is IModule {
     /// @param sender The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
-    /// @param authorization Additional data for the validation function to use.
+    /// @param authorization Additional data for the hook to use.
     function preRuntimeValidationHook(
         uint32 entityId,
         address sender,

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -154,7 +154,7 @@ interface IModularAccount {
     /// @param data The calldata to send to the account.
     /// @param authorization The authorization data to use for the call. The first 24 bytes specifies which runtime
     /// validation to use, and the rest is sent as a parameter to runtime validation.
-    function executeWithAuthorization(bytes calldata data, bytes calldata authorization)
+    function executeWithRuntimeValidation(bytes calldata data, bytes calldata authorization)
         external
         payable
         returns (bytes memory);
@@ -372,6 +372,7 @@ interface IValidationHookModule is IModule {
     /// @param sender The caller address.
     /// @param value The call value.
     /// @param data The calldata sent.
+    /// @param authorization Additional data for the validation function to use.
     function preRuntimeValidationHook(
         uint32 entityId,
         address sender,
@@ -517,10 +518,11 @@ During execution uninstallation, the account MUST correctly clear flags and othe
 #### Execution Hooks Data Format
 
 For accounts that implement execution hooks, accounts MUST conform to these execution hook formats:
+
 1. For `executeUserOp` calls, for execution hooks associated with a validation function, accounts MUST send the full `msg.data`, including the `executeUserOp` selector.
 2. For `executeUserOp` calls, for execution hooks associated with a selector, accounts MUST send `PackedUserOperation.callData` for `executeUserOp` calls, excluding `executeUserOp.selector` and the rest of the `PackedUserOperation`.
-3. For `executeWithAuthorization` calls, for all execution hooks, accounts MUST send the inner `data`.
-4. For all other calls, for execution hooks associated with a selector, accounts MUST send over `msg.data`. 
+3. For `executeWithRuntimeValidation` calls, for all execution hooks, accounts MUST send the inner `data`.
+4. For all other calls, for execution hooks associated with a selector, accounts MUST send over `msg.data`.
 
 #### Hook Execution Order
 
@@ -528,7 +530,7 @@ It is RECOMMENDED that an account implementer runs hooks in first installed firs
 
 ### Validation Call Flow
 
-Modular accounts support three different calls flows for validation: user op validation, runtime validation, and signature validation. User op validation happens within the account's implementation of the function `validateUserOp`, defined in the ERC-4337 interface `IAccount`. Runtime validation happens through the dispatcher function `executeWithAuthorization`, or when using direct call validation. Signature validation happens within the account's implementation of the function `isValidSignature`, defined in ERC-1271.
+Modular accounts support three different calls flows for validation: user op validation, runtime validation, and signature validation. User op validation happens within the account's implementation of the function `validateUserOp`, defined in the ERC-4337 interface `IAccount`. Runtime validation happens through the dispatcher function `executeWithRuntimeValidation`, or when using direct call validation. Signature validation happens within the account's implementation of the function `isValidSignature`, defined in ERC-1271.
 
 For each of these validation types, an account implementation MAY specify its own format for selecting which validation function to use, as well as any per-hook data for validation hooks.
 
@@ -552,13 +554,13 @@ Installed validations have two flag variables indicating what they may be used f
 
 #### Direct Call Validation
 
-If a validation function is installed with the entity ID of `0xffffffff`, it may be used as direct call validation. This occurs when a module or other address calls a function on the modular account, without wrapping its call in the dispatcher function `executeWithAuthorization` to use as a selection mechanism for a runtime validation function.
+If a validation function is installed with the entity ID of `0xffffffff`, it may be used as direct call validation. This occurs when a module or other address calls a function on the modular account, without wrapping its call in the dispatcher function `executeWithRuntimeValidation` to use as a selection mechanism for a runtime validation function.
 
 To implement direct call validation, the modular account MUST treat direct function calls that are not from the modular account itself or the EntryPoint as an attempt to validate using the caller's address and the entity ID of `0xffffffff`. If such a validation function is installed, and applies to the function intended to be called, the modular account MUST allow it to continue, without performing runtime validation. Any pre validation hooks and execution hooks installed to this validation function MUST still run.
 
 ### Execution Call Flow
 
-For all non-view functions within `IModularAccount` except `executeWithAuthorization`, all module-defined execution functions, and any additional native functions that the modular account MAY wish to include, the modular account MUST adhere to these steps during execution:
+For all non-view functions within `IModularAccount` except `executeWithRuntimeValidation`, all module-defined execution functions, and any additional native functions that the modular account MAY wish to include, the modular account MUST adhere to these steps during execution:
 
 If the caller is not the EntryPoint or the account, the account MUST check access control for direct call validation.
 

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -62,7 +62,7 @@ contract AccountReturnDataTest is AccountTestBase {
 
     // Tests the ability to read the results of contracts called via IModularAccount.execute
     function test_returnData_singular_execute() public {
-        bytes memory returnData = account1.executeWithAuthorization(
+        bytes memory returnData = account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 account1.execute,
                 (address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()))
@@ -89,7 +89,7 @@ contract AccountReturnDataTest is AccountTestBase {
             data: abi.encodeCall(RegularResultContract.bar, ())
         });
 
-        bytes memory retData = account1.executeWithAuthorization(
+        bytes memory retData = account1.executeWithRuntimeValidation(
             abi.encodeCall(account1.executeBatch, (calls)),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
@@ -110,7 +110,7 @@ contract AccountReturnDataTest is AccountTestBase {
         assertTrue(result);
     }
 
-    // Tests the ability to read data via executeWithAuthorization
+    // Tests the ability to read data via executeWithRuntimeValidation
     function test_returnData_authorized_exec() public {
         bool result = ResultConsumerModule(address(account1)).checkResultExecuteWithAuthorization(
             address(regularResultContract), keccak256("bar")

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -64,7 +64,7 @@ contract GlobalValidationTest is AccountTestBase {
         factory.createAccount(owner2, 0);
 
         vm.prank(owner2);
-        account2.executeWithAuthorization(
+        account2.executeWithRuntimeValidation(
             abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -68,7 +68,7 @@ contract MultiValidationTest is AccountTestBase {
                 abi.encodeWithSignature("NotAuthorized()")
             )
         );
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.execute, (address(0), 0, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(validator2), TEST_DEFAULT_VALIDATION_ENTITY_ID), GLOBAL_VALIDATION, ""
@@ -76,7 +76,7 @@ contract MultiValidationTest is AccountTestBase {
         );
 
         vm.prank(owner2);
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.execute, (address(0), 0, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(validator2), TEST_DEFAULT_VALIDATION_ENTITY_ID), GLOBAL_VALIDATION, ""

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -281,7 +281,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         preValidationHookData[0] = PreValidationHookData({index: 0, validationData: abi.encodePacked(_counter)});
 
         vm.prank(owner1);
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -307,7 +307,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 abi.encodeWithSignature("Error(string)", "Proof doesn't match target")
             )
         );
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -325,7 +325,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 abi.encodeWithSignature("Error(string)", "Proof doesn't match target")
             )
         );
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -342,7 +342,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.expectRevert(
             abi.encodeWithSelector(SparseCalldataSegmentLib.ValidationSignatureSegmentMissing.selector)
         );
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -360,7 +360,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         preValidationHookData[1] = PreValidationHookData({index: 1, validationData: abi.encodePacked(_counter)});
 
         vm.prank(owner1);
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -379,7 +379,7 @@ contract PerHookDataTest is CustomValidationTestBase {
 
         vm.prank(owner1);
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.SegmentOutOfOrder.selector));
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -400,7 +400,7 @@ contract PerHookDataTest is CustomValidationTestBase {
                 abi.encodeWithSignature("Error(string)", "Target not allowed")
             )
         );
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(ReferenceModularAccount.execute, (beneficiary, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -412,7 +412,7 @@ contract PerHookDataTest is CustomValidationTestBase {
 
         vm.prank(owner1);
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector));
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
@@ -426,7 +426,7 @@ contract PerHookDataTest is CustomValidationTestBase {
 
         vm.prank(owner1);
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector));
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),

--- a/test/account/ReferenceModularAccount.t.sol
+++ b/test/account/ReferenceModularAccount.t.sol
@@ -497,7 +497,7 @@ contract ReferenceModularAccountTest is AccountTestBase {
 
         //show working rt validation
         vm.startPrank(address(owner1));
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_VALIDATION, ""

--- a/test/account/ReplaceModule.t.sol
+++ b/test/account/ReplaceModule.t.sol
@@ -82,7 +82,7 @@ contract UpgradeModuleTest is AccountTestBase {
                 IModularAccount.installExecution, (address(moduleV2), moduleV2.executionManifest(), "")
             )
         });
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(account1.executeBatch, (calls)),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
@@ -147,7 +147,7 @@ contract UpgradeModuleTest is AccountTestBase {
             ),
             0
         );
-        account1.executeWithAuthorization(callData, _encodeSignature(currModuleEntity, GLOBAL_VALIDATION, ""));
+        account1.executeWithRuntimeValidation(callData, _encodeSignature(currModuleEntity, GLOBAL_VALIDATION, ""));
         assertEq(target.balance, sendAmount);
 
         // upgrade module by batching uninstall + install calls
@@ -181,7 +181,7 @@ contract UpgradeModuleTest is AccountTestBase {
                 )
             )
         });
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(account1.executeBatch, (calls)),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
@@ -193,7 +193,7 @@ contract UpgradeModuleTest is AccountTestBase {
                 abi.encode(IModularAccount.execute.selector)
             )
         );
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.execute, (target, sendAmount, "")),
             _encodeSignature(currModuleEntity, GLOBAL_VALIDATION, "")
         );
@@ -213,7 +213,7 @@ contract UpgradeModuleTest is AccountTestBase {
             ),
             0
         );
-        account1.executeWithAuthorization(callData, _encodeSignature(newModuleEntity, GLOBAL_VALIDATION, ""));
+        account1.executeWithRuntimeValidation(callData, _encodeSignature(newModuleEntity, GLOBAL_VALIDATION, ""));
         assertEq(target.balance, 2 * sendAmount);
     }
 }

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -214,7 +214,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         calls[1] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
         vm.expectCall(address(comprehensiveModule), abi.encodeCall(ComprehensiveModule.foo, ()), 2);
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.executeBatch, (calls)),
             _encodeSignature(comprehensiveModuleValidation, SELECTOR_ASSOCIATED_VALIDATION, "")
         );
@@ -286,7 +286,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IModularAccount.executeBatch, (innerCalls)));
 
         vm.expectRevert(abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector));
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.executeBatch, (outerCalls)),
             _encodeSignature(comprehensiveModuleValidation, SELECTOR_ASSOCIATED_VALIDATION, "")
         );
@@ -300,7 +300,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         selectors[0] = IModularAccount.executeBatch.selector;
 
         vm.prank(owner1);
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 ReferenceModularAccount.installValidation,
                 (

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -104,7 +104,7 @@ contract ResultConsumerModule is IExecutionModule, BaseModule, IValidationModule
     // Check the return data through the execute with authorization case
     function checkResultExecuteWithAuthorization(address target, bytes32 expected) external returns (bool) {
         // This result should be allowed based on the manifest permission request
-        bytes memory returnData = IModularAccount(msg.sender).executeWithAuthorization(
+        bytes memory returnData = IModularAccount(msg.sender).executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
             abi.encodePacked(this, DIRECT_CALL_VALIDATION_ENTITYID, uint8(0), uint32(1), uint8(255)) // Validation
                 // function of self,

--- a/test/module/ERC20TokenLimitModule.t.sol
+++ b/test/module/ERC20TokenLimitModule.t.sol
@@ -146,7 +146,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
 
     function test_runtime_executeLimit() public {
         assertEq(module.limits(0, address(erc20), address(acct)), 10 ether);
-        acct.executeWithAuthorization(
+        acct.executeWithRuntimeValidation(
             _getExecuteWithSpend(5 ether),
             _encodeSignature(ModuleEntityLib.pack(address(validationModule), 0), 1, "")
         );
@@ -166,7 +166,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         });
 
         assertEq(module.limits(0, address(erc20), address(acct)), 10 ether);
-        acct.executeWithAuthorization(
+        acct.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.executeBatch, (calls)),
             _encodeSignature(ModuleEntityLib.pack(address(validationModule), 0), 1, "")
         );

--- a/test/module/NativeTokenLimitModule.t.sol
+++ b/test/module/NativeTokenLimitModule.t.sol
@@ -176,7 +176,9 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
 
     function test_runtime_executeLimit() public {
         assertEq(module.limits(0, address(acct)), 10 ether);
-        acct.executeWithAuthorization(_getExecuteWithValue(5 ether), _encodeSignature(validationFunction, 1, ""));
+        acct.executeWithRuntimeValidation(
+            _getExecuteWithValue(5 ether), _encodeSignature(validationFunction, 1, "")
+        );
         assertEq(module.limits(0, address(acct)), 5 ether);
     }
 
@@ -187,7 +189,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
         calls[2] = Call({target: recipient, value: 5 ether + 100_000, data: ""});
 
         assertEq(module.limits(0, address(acct)), 10 ether);
-        acct.executeWithAuthorization(
+        acct.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.executeBatch, (calls)), _encodeSignature(validationFunction, 1, "")
         );
         assertEq(module.limits(0, address(acct)), 4 ether - 100_001);

--- a/test/module/SingleSignerValidationModule.t.sol
+++ b/test/module/SingleSignerValidationModule.t.sol
@@ -71,7 +71,7 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
 
     function test_runtimeValidate() public {
         vm.prank(owner1);
-        account.executeWithAuthorization(
+        account.executeWithRuntimeValidation(
             abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID),
@@ -98,7 +98,7 @@ contract SingleSignerValidationModuleTest is AccountTestBase {
         );
 
         vm.prank(owner2);
-        account.executeWithAuthorization(
+        account.executeWithRuntimeValidation(
             abi.encodeCall(ReferenceModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_VALIDATION, ""

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -156,7 +156,7 @@ abstract contract AccountTestBase is OptimizedTest {
         }
 
         vm.prank(owner1);
-        account1.executeWithAuthorization(callData, _encodeSignature(_signerValidation, GLOBAL_VALIDATION, ""));
+        account1.executeWithRuntimeValidation(callData, _encodeSignature(_signerValidation, GLOBAL_VALIDATION, ""));
     }
 
     // Always expects a revert, even if the revert data is zero-length.
@@ -164,20 +164,20 @@ abstract contract AccountTestBase is OptimizedTest {
         vm.expectRevert(expectedRevertData);
 
         vm.prank(owner1);
-        account1.executeWithAuthorization(callData, _encodeSignature(_signerValidation, GLOBAL_VALIDATION, ""));
+        account1.executeWithRuntimeValidation(callData, _encodeSignature(_signerValidation, GLOBAL_VALIDATION, ""));
     }
 
     function _transferOwnershipToTest() internal {
         // Transfer ownership to test contract for easier invocation.
         vm.prank(owner1);
         if (vm.envOr("SMA_TEST", false)) {
-            account1.executeWithAuthorization(
+            account1.executeWithRuntimeValidation(
                 abi.encodeCall(SemiModularAccount(payable(account1)).updateFallbackSigner, (address(this))),
                 _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
             );
             return;
         }
-        account1.executeWithAuthorization(
+        account1.executeWithRuntimeValidation(
             abi.encodeCall(
                 account1.execute,
                 (


### PR DESCRIPTION
As discussed in our working group sync. `executeWithRuntimeValidation` more clearly conveys the function's purpose.

> [!NOTE]  
> I think we still need to clean up the `authorization` parameter name across the interfaces and the codebase. Sometimes we mean the additional data that should be provided to the validation function, and sometimes we mean the entire validation config (address + selector + additional auth data).
