### PR TITLE
fix: add missing isUserOpValidation to ValidationDataView in spec

### DIFF
--- a/src/interfaces/IModularAccountView.sol
+++ b/src/interfaces/IModularAccountView.sol
@@ -24,7 +24,7 @@ struct ValidationDataView {
     bool isGlobal;
     // Whether or not this validation function is a signature validator.
     bool isSignatureValidation;
-    // Whether or not this validation is a user operation validator.
+    // Whether or not this validation function is a user operation validation function.
     bool isUserOpValidation;
     // The pre validation hooks for this validation function.
     ModuleEntity[] preValidationHooks;

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -243,6 +243,8 @@ struct ValidationDataView {
     bool isGlobal;
     // Whether or not this validation function is a signature validator.
     bool isSignatureValidation;
+    // Whether or not this validation function is a user operation validation function.
+    bool isUserOpValidation;
     // The pre validation hooks for this validation function.
     ModuleEntity[] preValidationHooks;
     // Execution hooks to run with this validation function.
@@ -551,7 +553,7 @@ User op validation and runtime validation functions have a configurable range of
 
 If the selector being checked is `execute` or `executeBatch`, the modular account MUST perform additional checking. If the target of `execute` is the modular account's own address, or if the target of any `Call` within `executeBatch` is the account, validation MUST either revert or check that validation applies to the selector(s) being called.
 
-Installed validation functions have two flag variables indicating what they may be used for. If a validation function is attempted to be used for user op validation and the flag `isUserOpValidation` is set to false, validation MUST revert. If the validation function is attempted to be used for signature validation and the flag `isSignatureValidation` is set to false, validation MUST revert.
+Installed validation functions have two additional flag variables indicating what they may be used for. If a validation function is attempted to be used for user op validation and the flag `isUserOpValidation` is set to false, validation MUST revert. If the validation function is attempted to be used for signature validation and the flag `isSignatureValidation` is set to false, validation MUST revert.
 
 #### Direct Call Validation
 


### PR DESCRIPTION
This was missing in the spec. Adding it in.