### PR TITLE
feat: skip signature length encoding on final sig and add type safety

### DIFF
--- a/src/libraries/ValidationConfigLib.sol
+++ b/src/libraries/ValidationConfigLib.sol
@@ -3,6 +3,13 @@ pragma solidity ^0.8.20;
 
 import {ModuleEntity, ValidationConfig} from "../interfaces/IModularAccount.sol";
 
+// Validation flags layout:
+// 0b00000___ // unused
+// 0b_____A__ // isGlobal
+// 0b______B_ // isSignatureValidation
+// 0b_______C // isUserOpValidation
+type ValidationFlags is uint8;
+
 // Validation config is a packed representation of a validation function and flags for its configuration.
 // Layout:
 // 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA________________________ // Address
@@ -63,22 +70,22 @@ library ValidationConfigLib {
     function unpackUnderlying(ValidationConfig config)
         internal
         pure
-        returns (address _module, uint32 _entityId, uint8 flags)
+        returns (address _module, uint32 _entityId, ValidationFlags flags)
     {
         bytes25 configBytes = ValidationConfig.unwrap(config);
         _module = address(bytes20(configBytes));
         _entityId = uint32(bytes4(configBytes << 160));
-        flags = uint8(configBytes[24]);
+        flags = ValidationFlags.wrap(uint8(configBytes[24]));
     }
 
     function unpack(ValidationConfig config)
         internal
         pure
-        returns (ModuleEntity _validationFunction, uint8 flags)
+        returns (ModuleEntity _validationFunction, ValidationFlags flags)
     {
         bytes25 configBytes = ValidationConfig.unwrap(config);
         _validationFunction = ModuleEntity.wrap(bytes24(configBytes));
-        flags = uint8(configBytes[24]);
+        flags = ValidationFlags.wrap(uint8(configBytes[24]));
     }
 
     function module(ValidationConfig config) internal pure returns (address) {
@@ -97,23 +104,23 @@ library ValidationConfigLib {
         return ValidationConfig.unwrap(config) & _VALIDATION_FLAG_IS_GLOBAL != 0;
     }
 
-    function isGlobal(uint8 flags) internal pure returns (bool) {
-        return flags & 0x04 != 0;
+    function isGlobal(ValidationFlags flags) internal pure returns (bool) {
+        return ValidationFlags.unwrap(flags) & 0x04 != 0;
     }
 
     function isSignatureValidation(ValidationConfig config) internal pure returns (bool) {
         return ValidationConfig.unwrap(config) & _VALIDATION_FLAG_IS_SIGNATURE != 0;
     }
 
-    function isSignatureValidation(uint8 flags) internal pure returns (bool) {
-        return flags & 0x02 != 0;
+    function isSignatureValidation(ValidationFlags flags) internal pure returns (bool) {
+        return ValidationFlags.unwrap(flags) & 0x02 != 0;
     }
 
     function isUserOpValidation(ValidationConfig config) internal pure returns (bool) {
         return ValidationConfig.unwrap(config) & _VALIDATION_FLAG_IS_USER_OP != 0;
     }
 
-    function isUserOpValidation(uint8 flags) internal pure returns (bool) {
-        return flags & 0x01 != 0;
+    function isUserOpValidation(ValidationFlags flags) internal pure returns (bool) {
+        return ValidationFlags.unwrap(flags) & 0x01 != 0;
     }
 }

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -112,7 +112,7 @@ contract AccountReturnDataTest is AccountTestBase {
 
     // Tests the ability to read data via executeWithRuntimeValidation
     function test_returnData_authorized_exec() public {
-        bool result = ResultConsumerModule(address(account1)).checkResultExecuteWithAuthorization(
+        bool result = ResultConsumerModule(address(account1)).checkResultExecuteWithRuntimeValidation(
             address(regularResultContract), keccak256("bar")
         );
 

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -246,34 +246,6 @@ contract PerHookDataTest is CustomValidationTestBase {
         entryPoint.handleOps(userOps, beneficiary);
     }
 
-    function test_failPerHookData_excessData_userOp() public {
-        (PackedUserOperation memory userOp, bytes32 userOpHash) = _getCounterUserOP();
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Key, userOpHash.toEthSignedMessageHash());
-
-        PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
-        preValidationHookData[0] = PreValidationHookData({index: 0, validationData: abi.encodePacked(_counter)});
-
-        userOp.signature = abi.encodePacked(
-            _encodeSignature(
-                _signerValidation, GLOBAL_VALIDATION, preValidationHookData, abi.encodePacked(r, s, v)
-            ),
-            "extra data"
-        );
-
-        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = userOp;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IEntryPoint.FailedOpWithRevert.selector,
-                0,
-                "AA23 reverted",
-                abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector)
-            )
-        );
-        entryPoint.handleOps(userOps, beneficiary);
-    }
-
     function test_passAccessControl_runtime() public {
         assertEq(_counter.number(), 0);
 
@@ -417,22 +389,6 @@ contract PerHookDataTest is CustomValidationTestBase {
                 ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
-        );
-    }
-
-    function test_failPerHookData_excessData_runtime() public {
-        PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
-        preValidationHookData[0] = PreValidationHookData({index: 0, validationData: abi.encodePacked(_counter)});
-
-        vm.prank(owner1);
-        vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector));
-        account1.executeWithRuntimeValidation(
-            abi.encodeCall(
-                ReferenceModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
-            ),
-            abi.encodePacked(
-                _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, ""), "extra data"
-            )
         );
     }
 

--- a/test/libraries/SparseCalldataSegmentLib.t.sol
+++ b/test/libraries/SparseCalldataSegmentLib.t.sol
@@ -49,7 +49,7 @@ contract SparseCalldataSegmentLibTest is Test {
         bytes memory result = "";
 
         for (uint256 i = 0; i < segments.length; i++) {
-            result = abi.encodePacked(result, uint32(segments[i].length), segments[i]);
+            result = abi.encodePacked(result, uint8(0), uint32(segments[i].length), segments[i]);
         }
 
         return result;
@@ -65,7 +65,7 @@ contract SparseCalldataSegmentLibTest is Test {
         bytes memory result = "";
 
         for (uint256 i = 0; i < segments.length; i++) {
-            result = abi.encodePacked(result, uint32(segments[i].length + 1), indices[i], segments[i]);
+            result = abi.encodePacked(result, indices[i], uint32(segments[i].length), segments[i]);
         }
 
         return result;
@@ -99,10 +99,10 @@ contract SparseCalldataSegmentLibTest is Test {
 
         uint256 index = 0;
         while (remainder.length > 0) {
+            indices[index] = remainder.getIndex();
             bytes calldata segment;
             (segment, remainder) = remainder.getNextSegment();
-            bodies[index] = segment.getBody();
-            indices[index] = segment.getIndex();
+            bodies[index] = segment;
             index++;
         }
 

--- a/test/libraries/ValidationConfigLib.t.sol
+++ b/test/libraries/ValidationConfigLib.t.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 
 import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
-import {ValidationConfig, ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
+import {
+    ValidationConfig, ValidationConfigLib, ValidationFlags
+} from "../../src/libraries/ValidationConfigLib.sol";
 
 contract ValidationConfigLibTest is Test {
     using ModuleEntityLib for ModuleEntity;
@@ -23,7 +25,7 @@ contract ValidationConfigLibTest is Test {
             ValidationConfigLib.pack(module, entityId, isGlobal, isSignatureValidation, isUserOpValidation);
 
         // Test unpacking underlying
-        (address module2, uint32 entityId2, uint8 flags2) = validationConfig.unpackUnderlying();
+        (address module2, uint32 entityId2, ValidationFlags flags2) = validationConfig.unpackUnderlying();
 
         assertEq(module, module2, "module mismatch");
         assertEq(entityId, entityId2, "entityId mismatch");
@@ -35,7 +37,7 @@ contract ValidationConfigLibTest is Test {
 
         ModuleEntity expectedModuleEntity = ModuleEntityLib.pack(module, entityId);
 
-        (ModuleEntity validationFunction, uint8 flags3) = validationConfig.unpack();
+        (ModuleEntity validationFunction, ValidationFlags flags3) = validationConfig.unpack();
 
         assertEq(
             ModuleEntity.unwrap(validationFunction),
@@ -73,7 +75,7 @@ contract ValidationConfigLibTest is Test {
 
         (address expectedModule, uint32 expectedEntityId) = validationFunction.unpack();
 
-        (address module, uint32 entityId, uint8 flags2) = validationConfig.unpackUnderlying();
+        (address module, uint32 entityId, ValidationFlags flags2) = validationConfig.unpackUnderlying();
 
         assertEq(expectedModule, module, "module mismatch");
         assertEq(expectedEntityId, entityId, "entityId mismatch");
@@ -83,7 +85,7 @@ contract ValidationConfigLibTest is Test {
 
         // Test unpacking to ModuleEntity
 
-        (ModuleEntity validationFunction2, uint8 flags3) = validationConfig.unpack();
+        (ModuleEntity validationFunction2, ValidationFlags flags3) = validationConfig.unpack();
 
         assertEq(
             ModuleEntity.unwrap(validationFunction),

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -11,6 +11,7 @@ import {Call, IModularAccount} from "../../src/interfaces/IModularAccount.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
+import {ModuleSignatureUtils} from "./ModuleSignatureUtils.sol";
 import {OptimizedTest} from "./OptimizedTest.sol";
 import {TEST_DEFAULT_VALIDATION_ENTITY_ID as EXT_CONST_TEST_DEFAULT_VALIDATION_ENTITY_ID} from
     "./TestConstants.sol";
@@ -19,7 +20,7 @@ import {SingleSignerFactoryFixture} from "../mocks/SingleSignerFactoryFixture.so
 
 /// @dev This contract handles common boilerplate setup for tests using ReferenceModularAccount with
 /// SingleSignerValidationModule.
-abstract contract AccountTestBase is OptimizedTest {
+abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
     using ModuleEntityLib for ModuleEntity;
     using MessageHashUtils for bytes32;
 
@@ -35,19 +36,11 @@ abstract contract AccountTestBase is OptimizedTest {
 
     ModuleEntity internal _signerValidation;
 
-    uint8 public constant SELECTOR_ASSOCIATED_VALIDATION = 0;
-    uint8 public constant GLOBAL_VALIDATION = 1;
-
     // Re-declare the constant to prevent derived test contracts from having to import it
     uint32 public constant TEST_DEFAULT_VALIDATION_ENTITY_ID = EXT_CONST_TEST_DEFAULT_VALIDATION_ENTITY_ID;
 
     uint256 public constant CALL_GAS_LIMIT = 100_000;
     uint256 public constant VERIFICATION_GAS_LIMIT = 1_200_000;
-
-    struct PreValidationHookData {
-        uint8 index;
-        bytes validationData;
-    }
 
     constructor() {
         entryPoint = new EntryPoint();
@@ -196,85 +189,5 @@ abstract contract AccountTestBase is OptimizedTest {
     // helper function to compress 2 gas values into a single bytes32
     function _encodeGas(uint256 g1, uint256 g2) internal pure returns (bytes32) {
         return bytes32(uint256((g1 << 128) + uint128(g2)));
-    }
-
-    // helper function to encode a 1271 signature, according to the per-hook and per-validation data format.
-    function _encode1271Signature(
-        ModuleEntity validationFunction,
-        PreValidationHookData[] memory preValidationHookData,
-        bytes memory validationData
-    ) internal pure returns (bytes memory) {
-        bytes memory sig = abi.encodePacked(validationFunction);
-
-        sig = abi.encodePacked(sig, _packPreHookDatas(preValidationHookData));
-
-        sig = abi.encodePacked(sig, _packValidationResWithIndex(255, validationData));
-
-        return sig;
-    }
-
-    // helper function to encode a signature, according to the per-hook and per-validation data format.
-    function _encodeSignature(
-        ModuleEntity validationFunction,
-        uint8 globalOrNot,
-        PreValidationHookData[] memory preValidationHookData,
-        bytes memory validationData
-    ) internal pure returns (bytes memory) {
-        bytes memory sig = abi.encodePacked(validationFunction, globalOrNot);
-
-        sig = abi.encodePacked(sig, _packPreHookDatas(preValidationHookData));
-
-        sig = abi.encodePacked(sig, _packValidationResWithIndex(255, validationData));
-
-        return sig;
-    }
-
-    // overload for the case where there are no pre validation hooks
-    function _encodeSignature(ModuleEntity validationFunction, uint8 globalOrNot, bytes memory validationData)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        PreValidationHookData[] memory emptyPreValidationHookData = new PreValidationHookData[](0);
-        return _encodeSignature(validationFunction, globalOrNot, emptyPreValidationHookData, validationData);
-    }
-
-    // overload for the case where there are no pre validation hooks
-    function _encode1271Signature(ModuleEntity validationFunction, bytes memory validationData)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        PreValidationHookData[] memory emptyPreValidationHookData = new PreValidationHookData[](0);
-        return _encode1271Signature(validationFunction, emptyPreValidationHookData, validationData);
-    }
-
-    // helper function to pack pre validation hook datas, according to the sparse calldata segment spec.
-    function _packPreHookDatas(PreValidationHookData[] memory preValidationHookData)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        bytes memory res = "";
-
-        for (uint256 i = 0; i < preValidationHookData.length; ++i) {
-            res = abi.encodePacked(
-                res,
-                _packValidationResWithIndex(
-                    preValidationHookData[i].index, preValidationHookData[i].validationData
-                )
-            );
-        }
-
-        return res;
-    }
-
-    // helper function to pack validation data with an index, according to the sparse calldata segment spec.
-    function _packValidationResWithIndex(uint8 index, bytes memory validationData)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodePacked(uint32(validationData.length + 1), index, validationData);
     }
 }

--- a/test/utils/ModuleSignatureUtils.sol
+++ b/test/utils/ModuleSignatureUtils.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import {RESERVED_VALIDATION_DATA_INDEX} from "../../src/helpers/Constants.sol";
+import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
+
+/// @dev Utilities for encoding signatures for modular account validation. Used for encoding user op, runtime, and
+/// 1271 signatures.
+contract ModuleSignatureUtils {
+    using ModuleEntityLib for ModuleEntity;
+
+    struct PreValidationHookData {
+        uint8 index;
+        bytes validationData;
+    }
+
+    uint8 public constant SELECTOR_ASSOCIATED_VALIDATION = 0;
+    uint8 public constant GLOBAL_VALIDATION = 1;
+
+    bytes32 private constant _INSTALL_VALIDATION_TYPEHASH = keccak256(
+        "InstallValidation(bytes25 validationConfig,bytes4[] selectors,bytes installData,bytes[] hooks,"
+        "uint256 nonce,uint48 deadline)"
+    );
+
+    // helper function to encode a 1271 signature, according to the per-hook and per-validation data format.
+    function _encode1271Signature(
+        ModuleEntity validationFunction,
+        PreValidationHookData[] memory preValidationHookData,
+        bytes memory validationData
+    ) internal pure returns (bytes memory) {
+        bytes memory sig = abi.encodePacked(validationFunction);
+
+        sig = abi.encodePacked(sig, _packPreHookDatas(preValidationHookData));
+
+        sig = abi.encodePacked(sig, _packFinalSignature(validationData));
+
+        return sig;
+    }
+
+    // helper function to encode a signature, according to the per-hook and per-validation data format.
+    function _encodeSignature(
+        ModuleEntity validationFunction,
+        uint8 globalOrNot,
+        PreValidationHookData[] memory preValidationHookData,
+        bytes memory validationData
+    ) internal pure returns (bytes memory) {
+        bytes memory sig = abi.encodePacked(validationFunction, globalOrNot);
+
+        sig = abi.encodePacked(sig, _packPreHookDatas(preValidationHookData));
+
+        sig = abi.encodePacked(sig, _packFinalSignature(validationData));
+
+        return sig;
+    }
+
+    // overload for the case where there are no pre validation hooks
+    function _encodeSignature(ModuleEntity validationFunction, uint8 globalOrNot, bytes memory validationData)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        PreValidationHookData[] memory emptyPreValidationHookData = new PreValidationHookData[](0);
+        return _encodeSignature(validationFunction, globalOrNot, emptyPreValidationHookData, validationData);
+    }
+
+    // overload for the case where there are no pre validation hooks
+    function _encode1271Signature(ModuleEntity validationFunction, bytes memory validationData)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        PreValidationHookData[] memory emptyPreValidationHookData = new PreValidationHookData[](0);
+        return _encode1271Signature(validationFunction, emptyPreValidationHookData, validationData);
+    }
+
+    // helper function to pack pre validation hook datas, according to the sparse calldata segment spec.
+    function _packPreHookDatas(PreValidationHookData[] memory preValidationHookData)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes memory res = "";
+
+        for (uint256 i = 0; i < preValidationHookData.length; ++i) {
+            res = abi.encodePacked(
+                res,
+                _packSignatureWithIndex(preValidationHookData[i].index, preValidationHookData[i].validationData)
+            );
+        }
+
+        return res;
+    }
+
+    // helper function to pack validation data with an index, according to the sparse calldata segment spec.
+    function _packSignatureWithIndex(uint8 index, bytes memory validationData)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(index, uint32(validationData.length), validationData);
+    }
+
+    function _packFinalSignature(bytes memory sig) internal pure returns (bytes memory) {
+        return abi.encodePacked(RESERVED_VALIDATION_DATA_INDEX, sig);
+    }
+}


### PR DESCRIPTION
- Updated `SparseCalldataSegmentLib.sol` to include updates from https://github.com/alchemyplatform/modular-account/pull/215.
- Updated `ValidationConfigLib.sol` to include updates from https://github.com/alchemyplatform/modular-account/pull/208