### PR TITLE
fix: EIP Walidator errors

### DIFF
--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -273,7 +273,7 @@ interface IModularAccountView {
 
 #### `IModule.sol`
 
-Module interface. Modules MUST implement this interface to support module management and interactions with ERC-6900 modular accounts.
+Module interface. Modules MUST implement this interface to support module management and interactions with [ERC-6900](./eip-6900.md) modular accounts.
 
 ```solidity
 interface IModule is IERC165 {
@@ -591,9 +591,8 @@ ERC-4337 compatible accounts must implement the `IAccount` interface, which cons
 This proposal includes several interfaces that build on ERC-4337. First, we standardize a set of modular functions that allow smart contract developers greater flexibility in bundling validation, execution, and hook logic. We also propose interfaces that provide methods for querying execution functions, validation functions, and hooks on a modular account. The rest of the interfaces describe a module's methods for exposing its modular functions and desired configuration, and the modular account's methods for installing and removing modules and allowing execution across modules and external addresses.
 
 ### ERC-4337 Dependency
-	
+
 ERC-6900's main objective is to create a secure and interoperable foundation through modular accounts and modules to increase the velocity and security of the smart account ecosystem, and ultimately the wallet ecosystem. Currently, the standard prescribes ERC-4337 for one of its [modular account call flows](#overview). However, this does not dictate that ERC-6900 will continue to be tied to ERC-4337.
-	
 It is likely that smart account builders will want to develop modular accounts that do not use ERC-4337 in the future (e.g., native account abstraction on rollups). Moreover, it is expected that ERC-4337 and its interfaces and contracts will continue to evolve until there is a protocol-level account abstraction.
 
 In the current state of the AA ecosystem, it is tough to predict the direction the builders and industry will take, so ERC-6900 will evolve together with the space's research, development, and adoption. The standard will do its best to address the objectives and create a secure foundation for modular accounts that may eventually be abstracted away from the infrastructure mechanism used.
@@ -602,11 +601,11 @@ In the current state of the AA ecosystem, it is tough to predict the direction t
 
 While this standard has largely been the result of collaboration among the coauthors, there have been noteworthy contributions from others in the community with respect to improvements, education, and experimentation. Thank you to the contributors:
 
-- [@gpersoon](https://github.com/gpersoon) Gerard Persoon
-- [@sm-stack](https://github.com/sm-stack) Harry Jeon
-- [@ZhiyuCircle](https://github.com/ZhiyuCircle) Zhiyu Zhang
-- [@cruzdanilo](https://github.com/cruzdanilo) Danilo Neves Cruz
-- [@ialberquilla](https://github.com/ialberquilla) Iván Alberquilla
+- Gerard Persoon (@gpersoon)
+- Harry Jeon (@sm-stack)
+- Zhiyu Zhang (@ZhiyuCircle)
+- Danilo Neves Cruz (@cruzdanilo)
+- Iván Alberquilla (@ialberquilla)
 
 We host community calls and working groups to discuss standard improvements and invite anyone with questions or contributions into our discussion.
 


### PR DESCRIPTION
EIP Walidator does not allow non-relative links and also requires that the first instance of a pattern match of an EIP or ERC includes a link (even to itself).