### PR TITLE
chore: rename constant

### DIFF
--- a/src/account/ReferenceModularAccount.sol
+++ b/src/account/ReferenceModularAccount.sol
@@ -12,7 +12,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {collectReturnData} from "../helpers/CollectReturnData.sol";
-import {DIRECT_CALL_VALIDATION_ENTITYID} from "../helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "../helpers/Constants.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationResHelpers.sol";
 import {IExecutionHookModule} from "../interfaces/IExecutionHookModule.sol";
 import {ExecutionManifest} from "../interfaces/IExecutionModule.sol";
@@ -562,7 +562,7 @@ contract ReferenceModularAccount is
                 && !_storage.executionStorage[msg.sig].skipRuntimeValidation
         ) {
             ModuleEntity directCallValidationKey =
-                ModuleEntityLib.pack(msg.sender, DIRECT_CALL_VALIDATION_ENTITYID);
+                ModuleEntityLib.pack(msg.sender, DIRECT_CALL_VALIDATION_ENTITY_ID);
 
             _checkIfValidationAppliesCallData(msg.data, directCallValidationKey, ValidationCheckingType.EITHER);
 

--- a/src/helpers/Constants.sol
+++ b/src/helpers/Constants.sol
@@ -8,4 +8,4 @@ uint8 constant RESERVED_VALIDATION_DATA_INDEX = type(uint8).max;
 uint8 constant MAX_VALIDATION_ASSOC_HOOKS = type(uint8).max;
 
 // Magic value for the Entity ID of direct call validation.
-uint32 constant DIRECT_CALL_VALIDATION_ENTITYID = type(uint32).max;
+uint32 constant DIRECT_CALL_VALIDATION_ENTITY_ID = type(uint32).max;

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../src/helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "../../src/helpers/Constants.sol";
 import {Call} from "../../src/interfaces/IModularAccount.sol";
 import {IModularAccount} from "../../src/interfaces/IModularAccount.sol";
 import {ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
@@ -44,7 +44,7 @@ contract AccountReturnDataTest is AccountTestBase {
         selectors[0] = IModularAccount.execute.selector;
         account1.installValidation(
             ValidationConfigLib.pack(
-                address(resultConsumerModule), DIRECT_CALL_VALIDATION_ENTITYID, false, false, true
+                address(resultConsumerModule), DIRECT_CALL_VALIDATION_ENTITY_ID, false, false, true
             ), // todo: does this need UO validation permission?
             selectors,
             "",

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -11,7 +11,7 @@ import {DirectCallModule} from "../mocks/modules/DirectCallModule.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
-import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../src/helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "../../src/helpers/Constants.sol";
 
 contract DirectCallsFromModuleTest is AccountTestBase {
     using ValidationConfigLib for ValidationConfig;
@@ -34,7 +34,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         _module = new DirectCallModule();
         assertFalse(_module.preHookRan());
         assertFalse(_module.postHookRan());
-        _moduleEntity = ModuleEntityLib.pack(address(_module), DIRECT_CALL_VALIDATION_ENTITYID);
+        _moduleEntity = ModuleEntityLib.pack(address(_module), DIRECT_CALL_VALIDATION_ENTITY_ID);
     }
 
     /* -------------------------------------------------------------------------- */
@@ -128,7 +128,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         vm.prank(address(entryPoint));
 
         account1.installValidation(
-            ValidationConfigLib.pack(extraOwner, DIRECT_CALL_VALIDATION_ENTITYID, false, false, false),
+            ValidationConfigLib.pack(extraOwner, DIRECT_CALL_VALIDATION_ENTITY_ID, false, false, false),
             selectors,
             "",
             new bytes[](0)

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../../src/helpers/Constants.sol";
+import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "../../../src/helpers/Constants.sol";
 import {
     ExecutionManifest,
     IExecutionModule,
@@ -106,7 +106,7 @@ contract ResultConsumerModule is IExecutionModule, BaseModule, IValidationModule
         // This result should be allowed based on the manifest permission request
         bytes memory returnData = IModularAccount(msg.sender).executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
-            _encodeSignature(ModuleEntityLib.pack(address(this), DIRECT_CALL_VALIDATION_ENTITYID), uint8(0), "")
+            _encodeSignature(ModuleEntityLib.pack(address(this), DIRECT_CALL_VALIDATION_ENTITY_ID), uint8(0), "")
         );
 
         bytes32 actual = abi.decode(abi.decode(returnData, (bytes)), (bytes32));


### PR DESCRIPTION
## Motivation
Rename `ENTITYID` to snake_case `ENTITY_ID` for readability.

## Solution
Rename the constant.
