### PR TITLE
feat: fix IModularAccount to return address of the account for native functions

### DIFF
--- a/src/interfaces/IModularAccountView.sol
+++ b/src/interfaces/IModularAccountView.sol
@@ -6,7 +6,7 @@ import {HookConfig, ModuleEntity, ValidationFlags} from "../interfaces/IModularA
 /// @dev Represents data associated with a specific function selector.
 struct ExecutionDataView {
     // The module that implements this execution function.
-    // If this is a native function, the address must remain address(0).
+    // If this is a native function, the address must be the address of the account.
     address module;
     // Whether or not the function needs runtime validation, or can be called by anyone. The function can still be
     // state changing if this flag is set to true.

--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -226,7 +226,7 @@ Module inspection interface. Modular accounts MAY implement this interface to su
 /// @dev Represents data associated with a specific function selector.
 struct ExecutionDataView {
     // The module that implements this execution function.
-    // If this is a native function, the address must remain address(0).
+    // If this is a native function, the address must be the address of the account.
     address module;
     // Whether or not the function needs runtime validation, or can be called by anyone. The function can still be
     // state changing if this flag is set to true.


### PR DESCRIPTION
The reference implementation currently returns `address(this)` which is the address of the account for `ExecutionDataView`'s `module` field. However, the standard currently contradicts this by saying we should return `address(0)` for native functions.

The better design seems to be to return the address of the account since the zero address would also be returned for nonexistent selectors, and it would be difficult to differentiate in those cases.

The client should have the address of the account handy so it'd be easy to compare it against what is returned to check if it's a native function or not.

Thanks @0xrubes for bringing this up!