### PR TITLE
feat: fix the manifest wording in the repo

### DIFF
--- a/src/interfaces/IModularAccount.sol
+++ b/src/interfaces/IModularAccount.sol
@@ -95,7 +95,6 @@ interface IModularAccount {
 
     /// @notice Installs a validation function across a set of execution selectors, and optionally mark it as a
     /// global validation function.
-    /// @dev This does not validate anything against the manifest - the caller must ensure validity.
     /// @param validationConfig The validation function to install, along with configuration flags.
     /// @param selectors The selectors to install the validation function for.
     /// @param installData Optional data to be used by the account to handle the initial validation setup. Data


### PR DESCRIPTION
We have some leftover wording from the old manifest setup in the code, so I removed that from the comment, as validation functions are no longer part of the manifest. 

I was going to update the wording in the standard itself from `manifest ` to `execution manifest`, as that more accurately reflects the current state of the manifest, but we use it interchangeably through the ERC, so I'm not too sure there. Should we commit to one of them? What do people think? 