### PR TITLE
chore: rename validation associated hooks to module entity associated hooks

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -33,7 +33,7 @@ struct ValidationStorage {
     ValidationFlags validationFlags;
     // The validation hooks for this validation function.
     HookConfig[] validationHooks;
-    // Execution hooks to run with this validation function.
+    // Execution hooks associated with this entity, to be run when this validation is used.
     EnumerableSet.Bytes32Set executionHooks;
     // The set of selectors that may be validated by this validation function.
     EnumerableSet.Bytes32Set selectors;

--- a/src/helpers/Constants.sol
+++ b/src/helpers/Constants.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 // Index marking the start of the data for the validation function.
 uint8 constant RESERVED_VALIDATION_DATA_INDEX = type(uint8).max;
 
-// Maximum number of validation-associated hooks that can be registered.
+// Maximum number of entity associated hooks that can be registered.
 uint8 constant MAX_VALIDATION_ASSOC_HOOKS = type(uint8).max;
 
 // Magic value for the Entity ID of direct call validation.

--- a/src/interfaces/IExecutionHookModule.sol
+++ b/src/interfaces/IExecutionHookModule.sol
@@ -10,7 +10,7 @@ interface IExecutionHookModule is IModule {
     /// be more than one.
     /// @param sender The caller address.
     /// @param value The call value.
-    /// @param data The calldata sent. For `executeUserOp` calls of validation-associated hooks, hook modules
+    /// @param data The calldata sent. For `executeUserOp` calls of entity associated hooks, hook modules
     /// should receive the full calldata.
     /// @return Context to pass to a post execution hook, if present. An empty bytes array MAY be returned.
     function preExecutionHook(uint32 entityId, address sender, uint256 value, bytes calldata data)


### PR DESCRIPTION
The term "validation associated hooks" could potentially be confusing as it sounds like the hooks are run whenever a specific validation function are run. However, the hooks are actually associated to an entity, referenced by a (validation module + entity id) pair

I suggest we improve the framing to be around "entity associated hooks" as that's more accurate. This PR changes the variable names and comments to use "module entity associated hooks"