### PR TITLE
feat: Add 7702 Semi-Modular Account Support

### DIFF
--- a/src/account/ReferenceModularAccount.sol
+++ b/src/account/ReferenceModularAccount.sol
@@ -305,6 +305,7 @@ contract ReferenceModularAccount is
     function upgradeToAndCall(address newImplementation, bytes memory data)
         public
         payable
+        virtual
         override
         onlyProxy
         wrapNativeFunction

--- a/src/account/SemiModularAccount.sol
+++ b/src/account/SemiModularAccount.sol
@@ -92,7 +92,7 @@ contract SemiModularAccount is ReferenceModularAccount {
     }
 
     /// @inheritdoc IModularAccount
-    function accountId() external pure override returns (string memory) {
+    function accountId() external pure virtual override returns (string memory) {
         return "erc6900.reference-semi-modular-account.0.8.0";
     }
 
@@ -177,6 +177,7 @@ contract SemiModularAccount is ReferenceModularAccount {
     function _retrieveFallbackSignerUnchecked(SemiModularAccountStorage storage _storage)
         internal
         view
+        virtual
         returns (address)
     {
         address storageFallbackSigner = _storage.fallbackSigner;

--- a/src/account/SemiModularAccount7702.sol
+++ b/src/account/SemiModularAccount7702.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import {IModularAccount} from "../interfaces/IModularAccount.sol";
+import {SemiModularAccount} from "./SemiModularAccount.sol";
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+
+contract SemiModularAccount7702 is SemiModularAccount {
+    constructor(IEntryPoint anEntryPoint) SemiModularAccount(anEntryPoint) {}
+
+    /// @inheritdoc IModularAccount
+    function accountId() external pure virtual override returns (string memory) {
+        return "erc6900.reference-semi-modular-account-7702.0.8.0";
+    }
+
+    /// @dev If the fallback signer is set in storage, ignore the 7702 signer.
+    function _retrieveFallbackSignerUnchecked(SemiModularAccountStorage storage _storage)
+        internal
+        view
+        override
+        returns (address)
+    {
+        address storageFallbackSigner = _storage.fallbackSigner;
+        if (storageFallbackSigner != address(0)) {
+            return storageFallbackSigner;
+        }
+
+        // To support 7702, we default to address(this) as the fallback signer.
+        return address(this);
+    }
+}

--- a/src/account/SemiModularAccount7702.sol
+++ b/src/account/SemiModularAccount7702.sol
@@ -6,11 +6,18 @@ import {SemiModularAccount} from "./SemiModularAccount.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
 contract SemiModularAccount7702 is SemiModularAccount {
+    error UpgradeNotAllowed();
+
     constructor(IEntryPoint anEntryPoint) SemiModularAccount(anEntryPoint) {}
 
     /// @inheritdoc IModularAccount
     function accountId() external pure virtual override returns (string memory) {
         return "erc6900.reference-semi-modular-account-7702.0.8.0";
+    }
+
+    /// @dev To prevent accidental self-calls, upgrades are disabled in 7702 accounts.
+    function upgradeToAndCall(address, bytes memory) public payable override {
+        revert UpgradeNotAllowed();
     }
 
     /// @dev If the fallback signer is set in storage, ignore the 7702 signer.


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

With [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) around the corner, developers would benefit from having a simple example of a Semi-Modular Account with a fallback signer that defaults to the address of the account itself.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Implement a variant of the Semi-Modular Account which includes the address of the account itself as the fallback signer rather than reading from bytecode as is done in the standard Semi-Modular Account.

This PR also affects the base Semi-Modular Account contract by making the account ID and unchecked fallback signer getter functions virtual as they must be overriden in the 7702 variant. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->