### PR TITLE
feat: remove onchain 165 interface check during install

### DIFF
--- a/test/account/ReferenceModularAccount.t.sol
+++ b/test/account/ReferenceModularAccount.t.sol
@@ -280,19 +280,6 @@ contract ReferenceModularAccountTest is AccountTestBase {
         });
     }
 
-    function test_installExecution_interfaceNotSupported() public {
-        vm.startPrank(address(entryPoint));
-
-        address badModule = address(1);
-        vm.expectRevert(
-            abi.encodeWithSelector(ModuleManagerInternals.InterfaceNotSupported.selector, address(badModule))
-        );
-
-        ExecutionManifest memory m;
-
-        account1.installExecution({module: address(badModule), manifest: m, moduleInstallData: "a"});
-    }
-
     function test_installExecution_alreadyInstalled() public {
         ExecutionManifest memory m = tokenReceiverModule.executionManifest();
 


### PR DESCRIPTION
## Motivation

The ERC-6900 specification does not require that the account perform an ERC-165 interface check when installing a module, just that the module must implement that interface, Per a discussion in the working group and with the OpenZeppelin team, we will remove the onchain check during installation from the reference implementation to avoid encouraging this non-standard behavior.

## Solution

Remove the ERC-165 interface check during `_onInstall` in ModuleManagerInternals.