### PR TITLE
refactor: add ERC6900 prefix to interfaces

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {HookConfig, ModuleEntity, ValidationFlags} from "../interfaces/IModularAccount.sol";
+import {HookConfig, ModuleEntity, ValidationFlags} from "../interfaces/IERC6900Account.sol";
 
 // bytes = keccak256("ERC6900.ReferenceModularAccount.Storage")
 bytes32 constant _ACCOUNT_STORAGE_SLOT = 0xc531f081ecdb5a90f38c197521797881a6e5c752a7d451780f325a95f8b91f45;

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -5,23 +5,23 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {HookConfig, IModularAccount, ModuleEntity} from "../interfaces/IModularAccount.sol";
-import {ExecutionDataView, IModularAccountView, ValidationDataView} from "../interfaces/IModularAccountView.sol";
+import {HookConfig, IERC6900Account, ModuleEntity} from "../interfaces/IERC6900Account.sol";
+import {ExecutionDataView, IERC6900AccountView, ValidationDataView} from "../interfaces/IERC6900AccountView.sol";
 import {HookConfigLib} from "../libraries/HookConfigLib.sol";
 import {ExecutionStorage, ValidationStorage, getAccountStorage, toHookConfig} from "./AccountStorage.sol";
 
-abstract contract ModularAccountView is IModularAccountView {
+abstract contract ModularAccountView is IERC6900AccountView {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using EnumerableMap for EnumerableMap.AddressToUintMap;
     using HookConfigLib for HookConfig;
 
-    /// @inheritdoc IModularAccountView
+    /// @inheritdoc IERC6900AccountView
     function getExecutionData(bytes4 selector) external view override returns (ExecutionDataView memory data) {
         if (
-            selector == IModularAccount.execute.selector || selector == IModularAccount.executeBatch.selector
+            selector == IERC6900Account.execute.selector || selector == IERC6900Account.executeBatch.selector
                 || selector == UUPSUpgradeable.upgradeToAndCall.selector
-                || selector == IModularAccount.installExecution.selector
-                || selector == IModularAccount.uninstallExecution.selector
+                || selector == IERC6900Account.installExecution.selector
+                || selector == IERC6900Account.uninstallExecution.selector
         ) {
             data.module = address(this);
             data.allowGlobalValidation = true;
@@ -39,7 +39,7 @@ abstract contract ModularAccountView is IModularAccountView {
         }
     }
 
-    /// @inheritdoc IModularAccountView
+    /// @inheritdoc IERC6900AccountView
     function getValidationData(ModuleEntity validationFunction)
         external
         view

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -5,15 +5,17 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 
 import {collectReturnData} from "../helpers/CollectReturnData.sol";
 import {MAX_VALIDATION_ASSOC_HOOKS} from "../helpers/Constants.sol";
-import {ExecutionManifest, ManifestExecutionHook} from "../interfaces/IExecutionModule.sol";
+
 import {
     HookConfig,
-    IModularAccount,
+    IERC6900Account,
     ModuleEntity,
     ValidationConfig,
     ValidationFlags
-} from "../interfaces/IModularAccount.sol";
-import {IModule} from "../interfaces/IModule.sol";
+} from "../interfaces/IERC6900Account.sol";
+
+import {ExecutionManifest, ManifestExecutionHook} from "../interfaces/IERC6900ExecutionModule.sol";
+import {IERC6900Module} from "../interfaces/IERC6900Module.sol";
 import {HookConfigLib} from "../libraries/HookConfigLib.sol";
 import {KnownSelectorsLib} from "../libraries/KnownSelectorsLib.sol";
 import {ModuleEntityLib} from "../libraries/ModuleEntityLib.sol";
@@ -28,7 +30,7 @@ import {
     toSetValue
 } from "./AccountStorage.sol";
 
-abstract contract ModuleManagerInternals is IModularAccount {
+abstract contract ModuleManagerInternals is IERC6900Account {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using ModuleEntityLib for ModuleEntity;
     using ValidationConfigLib for ValidationConfig;
@@ -67,7 +69,7 @@ abstract contract ModuleManagerInternals is IModularAccount {
             revert NativeFunctionNotAllowed(selector);
         }
 
-        // Make sure incoming execution function is not a function in IModule
+        // Make sure incoming execution function is not a function in IERC6900Module
         if (KnownSelectorsLib.isIModuleFunction(selector)) {
             revert IModuleFunctionNotAllowed(selector);
         }
@@ -194,7 +196,7 @@ abstract contract ModuleManagerInternals is IModularAccount {
     function _onInstall(address module, bytes calldata data) internal {
         if (data.length > 0) {
             // solhint-disable-next-line no-empty-blocks
-            try IModule(module).onInstall(data) {}
+            try IERC6900Module(module).onInstall(data) {}
             catch {
                 bytes memory revertReason = collectReturnData();
                 revert ModuleInstallCallbackFailed(module, revertReason);
@@ -207,7 +209,7 @@ abstract contract ModuleManagerInternals is IModularAccount {
         if (data.length > 0) {
             // Clear the module storage for the account.
             // solhint-disable-next-line no-empty-blocks
-            try IModule(module).onUninstall(data) {}
+            try IERC6900Module(module).onUninstall(data) {}
             catch {
                 onUninstallSuccess = false;
             }

--- a/src/account/SemiModularAccount.sol
+++ b/src/account/SemiModularAccount.sol
@@ -7,7 +7,7 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {ModuleEntityLib} from "../libraries/ModuleEntityLib.sol";
 
-import {IModularAccount, ModuleEntity, ValidationConfig} from "../interfaces/IModularAccount.sol";
+import {IERC6900Account, ModuleEntity, ValidationConfig} from "../interfaces/IERC6900Account.sol";
 
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
@@ -91,7 +91,7 @@ contract SemiModularAccount is ReferenceModularAccount {
         revert InitializerDisabled();
     }
 
-    /// @inheritdoc IModularAccount
+    /// @inheritdoc IERC6900Account
     function accountId() external pure virtual override returns (string memory) {
         return "erc6900.reference-semi-modular-account.0.8.0";
     }

--- a/src/account/SemiModularAccount7702.sol
+++ b/src/account/SemiModularAccount7702.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {IModularAccount} from "../interfaces/IModularAccount.sol";
+import {IERC6900Account} from "../interfaces/IERC6900Account.sol";
 import {SemiModularAccount} from "./SemiModularAccount.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
@@ -10,7 +10,7 @@ contract SemiModularAccount7702 is SemiModularAccount {
 
     constructor(IEntryPoint anEntryPoint) SemiModularAccount(anEntryPoint) {}
 
-    /// @inheritdoc IModularAccount
+    /// @inheritdoc IERC6900Account
     function accountId() external pure virtual override returns (string memory) {
         return "erc6900.reference-semi-modular-account-7702.0.8.0";
     }

--- a/src/interfaces/IERC6900Account.sol
+++ b/src/interfaces/IERC6900Account.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.20;
 
-import {ExecutionManifest} from "./IExecutionModule.sol";
+import {ExecutionManifest} from "./IERC6900ExecutionModule.sol";
 
 type ModuleEntity is bytes24;
 // ModuleEntity is a packed representation of a module function
@@ -47,7 +47,7 @@ struct Call {
     bytes data;
 }
 
-interface IModularAccount {
+interface IERC6900Account {
     event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
     event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
     event ValidationInstalled(address indexed module, uint32 indexed entityId);

--- a/src/interfaces/IERC6900AccountView.sol
+++ b/src/interfaces/IERC6900AccountView.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.20;
 
-import {HookConfig, ModuleEntity, ValidationFlags} from "../interfaces/IModularAccount.sol";
+import {HookConfig, ModuleEntity, ValidationFlags} from "../interfaces/IERC6900Account.sol";
 
 /// @dev Represents data associated with a specific function selector.
 struct ExecutionDataView {
@@ -34,7 +34,7 @@ struct ValidationDataView {
     bytes4[] selectors;
 }
 
-interface IModularAccountView {
+interface IERC6900AccountView {
     /// @notice Get the execution data for a selector.
     /// @dev If the selector is a native function, the module address will be the address of the account.
     /// @param selector The selector to get the data for.

--- a/src/interfaces/IERC6900ExecutionHookModule.sol
+++ b/src/interfaces/IERC6900ExecutionHookModule.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.20;
 
-import {IModule} from "./IModule.sol";
+import {IERC6900Module} from "./IERC6900Module.sol";
 
-interface IExecutionHookModule is IModule {
+interface IERC6900ExecutionHookModule is IERC6900Module {
     /// @notice Run the pre execution hook specified by the `entityId`.
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param entityId An identifier that routes the call to different internal implementations, should there

--- a/src/interfaces/IERC6900ExecutionModule.sol
+++ b/src/interfaces/IERC6900ExecutionModule.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.20;
 
-import {IModule} from "./IModule.sol";
+import {IERC6900Module} from "./IERC6900Module.sol";
 
 struct ManifestExecutionFunction {
     // The selector to install.
@@ -25,11 +25,11 @@ struct ExecutionManifest {
     ManifestExecutionFunction[] executionFunctions;
     ManifestExecutionHook[] executionHooks;
     // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
-    // IModule's interface ID.
+    // IERC6900Module's interface ID.
     bytes4[] interfaceIds;
 }
 
-interface IExecutionModule is IModule {
+interface IERC6900ExecutionModule is IERC6900Module {
     /// @notice Describe the contents and intended configuration of the module.
     /// @dev This manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the module.

--- a/src/interfaces/IERC6900Module.sol
+++ b/src/interfaces/IERC6900Module.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
-interface IModule is IERC165 {
+interface IERC6900Module is IERC165 {
     /// @notice Initialize module data for the modular account.
     /// @dev Called by the modular account during `installExecution`.
     /// @param data Optional bytes array to be decoded and used by the module to setup initial module data for the

--- a/src/interfaces/IERC6900ValidationHookModule.sol
+++ b/src/interfaces/IERC6900ValidationHookModule.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.20;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {IModule} from "./IModule.sol";
+import {IERC6900Module} from "./IERC6900Module.sol";
 
-interface IValidationHookModule is IModule {
+interface IERC6900ValidationHookModule is IERC6900Module {
     /// @notice Run the pre user operation validation hook specified by the `entityId`.
     /// @dev Pre user operation validation hooks MUST NOT return an authorizer value other than 0 or 1.
     /// @param entityId An identifier that routes the call to different internal implementations, should there

--- a/src/interfaces/IERC6900ValidationModule.sol
+++ b/src/interfaces/IERC6900ValidationModule.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.20;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {IModule} from "./IModule.sol";
+import {IERC6900Module} from "./IERC6900Module.sol";
 
-interface IValidationModule is IModule {
+interface IERC6900ValidationModule is IERC6900Module {
     /// @notice Run the user operation validation function specified by the `entityId`.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
     /// be more than one.

--- a/src/libraries/HookConfigLib.sol
+++ b/src/libraries/HookConfigLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {HookConfig, ModuleEntity} from "../interfaces/IModularAccount.sol";
+import {HookConfig, ModuleEntity} from "../interfaces/IERC6900Account.sol";
 
 // Hook types:
 // Exec hook: bools for hasPre, hasPost

--- a/src/libraries/KnownSelectorsLib.sol
+++ b/src/libraries/KnownSelectorsLib.sol
@@ -7,13 +7,16 @@ import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymas
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {IExecutionHookModule} from "../interfaces/IExecutionHookModule.sol";
-import {IExecutionModule} from "../interfaces/IExecutionModule.sol";
-import {IModularAccount} from "../interfaces/IModularAccount.sol";
-import {IModularAccountView} from "../interfaces/IModularAccountView.sol";
-import {IModule} from "../interfaces/IModule.sol";
-import {IValidationHookModule} from "../interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "../interfaces/IValidationModule.sol";
+import {IERC6900Account} from "../interfaces/IERC6900Account.sol";
+
+import {IERC6900AccountView} from "../interfaces/IERC6900AccountView.sol";
+
+import {IERC6900ExecutionHookModule} from "../interfaces/IERC6900ExecutionHookModule.sol";
+
+import {IERC6900ExecutionModule} from "../interfaces/IERC6900ExecutionModule.sol";
+import {IERC6900Module} from "../interfaces/IERC6900Module.sol";
+import {IERC6900ValidationHookModule} from "../interfaces/IERC6900ValidationHookModule.sol";
+import {IERC6900ValidationModule} from "../interfaces/IERC6900ValidationModule.sol";
 
 /// @dev Library to help to check if a selector is a know function selector of the modular account or ERC-4337
 /// contract.
@@ -22,22 +25,22 @@ library KnownSelectorsLib {
         return
         // check against IAccount methods
         selector == IAccount.validateUserOp.selector
-        // check against IModularAccount methods
-        || selector == IModularAccount.installExecution.selector
-            || selector == IModularAccount.uninstallExecution.selector
-            || selector == IModularAccount.installValidation.selector
-            || selector == IModularAccount.uninstallValidation.selector || selector == IModularAccount.execute.selector
-            || selector == IModularAccount.executeBatch.selector
-            || selector == IModularAccount.executeWithRuntimeValidation.selector
-            || selector == IModularAccount.accountId.selector
+        // check against IERC6900Account methods
+        || selector == IERC6900Account.installExecution.selector
+            || selector == IERC6900Account.uninstallExecution.selector
+            || selector == IERC6900Account.installValidation.selector
+            || selector == IERC6900Account.uninstallValidation.selector || selector == IERC6900Account.execute.selector
+            || selector == IERC6900Account.executeBatch.selector
+            || selector == IERC6900Account.executeWithRuntimeValidation.selector
+            || selector == IERC6900Account.accountId.selector
         // check against IERC165 methods
         || selector == IERC165.supportsInterface.selector
         // check against UUPSUpgradeable methods
         || selector == UUPSUpgradeable.proxiableUUID.selector
             || selector == UUPSUpgradeable.upgradeToAndCall.selector
-        // check against IModularAccountView methods
-        || selector == IModularAccountView.getExecutionData.selector
-            || selector == IModularAccountView.getValidationData.selector;
+        // check against IERC6900AccountView methods
+        || selector == IERC6900AccountView.getExecutionData.selector
+            || selector == IERC6900AccountView.getValidationData.selector;
     }
 
     function isErc4337Function(bytes4 selector) internal pure returns (bool) {
@@ -48,14 +51,15 @@ library KnownSelectorsLib {
     }
 
     function isIModuleFunction(bytes4 selector) internal pure returns (bool) {
-        return selector == IModule.onInstall.selector || selector == IModule.onUninstall.selector
-            || selector == IModule.moduleId.selector || selector == IExecutionModule.executionManifest.selector
-            || selector == IExecutionHookModule.preExecutionHook.selector
-            || selector == IExecutionHookModule.postExecutionHook.selector
-            || selector == IValidationModule.validateUserOp.selector
-            || selector == IValidationModule.validateRuntime.selector
-            || selector == IValidationModule.validateSignature.selector
-            || selector == IValidationHookModule.preUserOpValidationHook.selector
-            || selector == IValidationHookModule.preRuntimeValidationHook.selector;
+        return selector == IERC6900Module.onInstall.selector || selector == IERC6900Module.onUninstall.selector
+            || selector == IERC6900Module.moduleId.selector
+            || selector == IERC6900ExecutionModule.executionManifest.selector
+            || selector == IERC6900ExecutionHookModule.preExecutionHook.selector
+            || selector == IERC6900ExecutionHookModule.postExecutionHook.selector
+            || selector == IERC6900ValidationModule.validateUserOp.selector
+            || selector == IERC6900ValidationModule.validateRuntime.selector
+            || selector == IERC6900ValidationModule.validateSignature.selector
+            || selector == IERC6900ValidationHookModule.preUserOpValidationHook.selector
+            || selector == IERC6900ValidationHookModule.preRuntimeValidationHook.selector;
     }
 }

--- a/src/libraries/ModuleEntityLib.sol
+++ b/src/libraries/ModuleEntityLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {ModuleEntity} from "../interfaces/IModularAccount.sol";
+import {ModuleEntity} from "../interfaces/IERC6900Account.sol";
 // ModuleEntity is a packed representation of a module function
 // Layout:
 // 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA________________________ // Address

--- a/src/libraries/ValidationConfigLib.sol
+++ b/src/libraries/ValidationConfigLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {ModuleEntity, ValidationConfig, ValidationFlags} from "../interfaces/IModularAccount.sol";
+import {ModuleEntity, ValidationConfig, ValidationFlags} from "../interfaces/IERC6900Account.sol";
 
 // Validation config is a packed representation of a validation function and flags for its configuration.
 // Layout:

--- a/src/modules/BaseModule.sol
+++ b/src/modules/BaseModule.sol
@@ -5,13 +5,13 @@ import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IA
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {IModule} from "../interfaces/IModule.sol";
+import {IERC6900Module} from "../interfaces/IERC6900Module.sol";
 
 /// @title Base contract for modules
-/// @dev Implements ERC-165 to support IModule's interface, which is a requirement
+/// @dev Implements ERC-165 to support IERC6900Module's interface, which is a requirement
 /// for module installation. This also ensures that module interactions cannot
 /// happen via the standard execution funtions `execute` and `executeBatch`.
-abstract contract BaseModule is ERC165, IModule {
+abstract contract BaseModule is ERC165, IERC6900Module {
     error NotImplemented();
 
     /// @dev Returns true if this contract implements the interface defined by
@@ -21,13 +21,13 @@ abstract contract BaseModule is ERC165, IModule {
     ///
     /// This function call must use less than 30 000 gas.
     ///
-    /// Supporting the IModule interface is a requirement for module installation. This is also used
+    /// Supporting the IERC6900Module interface is a requirement for module installation. This is also used
     /// by the modular account to prevent standard execution functions `execute` and `executeBatch` from
     /// making calls to modules.
     /// @param interfaceId The interface ID to check for support.
     /// @return True if the contract supports `interfaceId`.
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
-        return interfaceId == type(IModule).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC6900Module).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _getSelectorAndCalldata(bytes calldata data) internal pure returns (bytes4, bytes memory) {

--- a/src/modules/TokenReceiverModule.sol
+++ b/src/modules/TokenReceiverModule.sol
@@ -4,16 +4,16 @@ pragma solidity ^0.8.20;
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {ExecutionManifest, ManifestExecutionFunction} from "../interfaces/IExecutionModule.sol";
-import {ExecutionManifest, IExecutionModule} from "../interfaces/IExecutionModule.sol";
-import {IModule} from "../interfaces/IModule.sol";
+import {ExecutionManifest, ManifestExecutionFunction} from "../interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest, IERC6900ExecutionModule} from "../interfaces/IERC6900ExecutionModule.sol";
+import {IERC6900Module} from "../interfaces/IERC6900Module.sol";
 import {BaseModule} from "./BaseModule.sol";
 
 /// @title Token Receiver Module
 /// @author ERC-6900 Authors
 /// @notice This module allows modular accounts to receive various types of tokens by implementing
 /// required token receiver interfaces.
-contract TokenReceiverModule is BaseModule, IExecutionModule, IERC721Receiver, IERC1155Receiver {
+contract TokenReceiverModule is BaseModule, IERC6900ExecutionModule, IERC721Receiver, IERC1155Receiver {
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃    Execution functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -44,15 +44,15 @@ contract TokenReceiverModule is BaseModule, IExecutionModule, IERC721Receiver, I
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     // solhint-disable-next-line no-empty-blocks
     function onInstall(bytes calldata) external pure override {}
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     // solhint-disable-next-line no-empty-blocks
     function onUninstall(bytes calldata) external pure override {}
 
-    /// @inheritdoc IExecutionModule
+    /// @inheritdoc IERC6900ExecutionModule
     function executionManifest() external pure override returns (ExecutionManifest memory) {
         ExecutionManifest memory manifest;
 
@@ -80,7 +80,7 @@ contract TokenReceiverModule is BaseModule, IExecutionModule, IERC721Receiver, I
         return manifest;
     }
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     function moduleId() external pure returns (string memory) {
         return "erc6900.token-receiver-module.1.0.0";
     }

--- a/src/modules/permissions/AllowlistModule.sol
+++ b/src/modules/permissions/AllowlistModule.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.20;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
-import {IModule} from "../../interfaces/IModule.sol";
+import {IERC6900Module} from "../../interfaces/IERC6900Module.sol";
 
-import {Call, IModularAccount} from "../../interfaces/IModularAccount.sol";
-import {IValidationHookModule} from "../../interfaces/IValidationHookModule.sol";
+import {Call, IERC6900Account} from "../../interfaces/IERC6900Account.sol";
+import {IERC6900ValidationHookModule} from "../../interfaces/IERC6900ValidationHookModule.sol";
 import {BaseModule} from "../../modules/BaseModule.sol";
 
-contract AllowlistModule is IValidationHookModule, BaseModule {
+contract AllowlistModule is IERC6900ValidationHookModule, BaseModule {
     struct AllowlistInit {
         address target;
         bool hasSelectorAllowlist;
@@ -89,7 +89,7 @@ contract AllowlistModule is IValidationHookModule, BaseModule {
     // solhint-disable-next-line no-empty-blocks
     function preSignatureValidationHook(uint32, address, bytes32, bytes calldata) external pure override {}
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     function moduleId() external pure returns (string memory) {
         return "erc6900.allowlist-module.0.0.1";
     }
@@ -107,10 +107,10 @@ contract AllowlistModule is IValidationHookModule, BaseModule {
     }
 
     function checkAllowlistCalldata(uint32 entityId, bytes calldata callData) public view {
-        if (bytes4(callData[:4]) == IModularAccount.execute.selector) {
+        if (bytes4(callData[:4]) == IERC6900Account.execute.selector) {
             (address target,, bytes memory data) = abi.decode(callData[4:], (address, uint256, bytes));
             _checkCallPermission(entityId, msg.sender, target, data);
-        } else if (bytes4(callData[:4]) == IModularAccount.executeBatch.selector) {
+        } else if (bytes4(callData[:4]) == IERC6900Account.executeBatch.selector) {
             Call[] memory calls = abi.decode(callData[4:], (Call[]));
 
             for (uint256 i = 0; i < calls.length; i++) {
@@ -126,7 +126,8 @@ contract AllowlistModule is IValidationHookModule, BaseModule {
         override(BaseModule, IERC165)
         returns (bool)
     {
-        return interfaceId == type(IValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IERC6900ValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _checkCallPermission(uint32 entityId, address account, address target, bytes memory data)

--- a/src/modules/validation/ISingleSignerValidationModule.sol
+++ b/src/modules/validation/ISingleSignerValidationModule.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {IValidationModule} from "../../interfaces/IValidationModule.sol";
+import {IERC6900ValidationModule} from "../../interfaces/IERC6900ValidationModule.sol";
 
-interface ISingleSignerValidationModule is IValidationModule {
+interface ISingleSignerValidationModule is IERC6900ValidationModule {
     /// @notice This event is emitted when Signer of the account's validation changes.
     /// @param account The account whose validation Signer changed.
     /// @param entityId The entityId for the account and the signer.

--- a/src/modules/validation/SingleSignerValidationModule.sol
+++ b/src/modules/validation/SingleSignerValidationModule.sol
@@ -6,8 +6,8 @@ import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
-import {IModule} from "../../interfaces/IModule.sol";
-import {IValidationModule} from "../../interfaces/IValidationModule.sol";
+import {IERC6900Module} from "../../interfaces/IERC6900Module.sol";
+import {IERC6900ValidationModule} from "../../interfaces/IERC6900ValidationModule.sol";
 import {BaseModule} from "../BaseModule.sol";
 
 import {ReplaySafeWrapper} from "../ReplaySafeWrapper.sol";
@@ -42,19 +42,19 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, ReplaySa
         _transferSigner(entityId, newSigner);
     }
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     function onInstall(bytes calldata data) external override {
         (uint32 entityId, address newSigner) = abi.decode(data, (uint32, address));
         _transferSigner(entityId, newSigner);
     }
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     function onUninstall(bytes calldata data) external override {
         uint32 entityId = abi.decode(data, (uint32));
         _transferSigner(entityId, address(0));
     }
 
-    /// @inheritdoc IValidationModule
+    /// @inheritdoc IERC6900ValidationModule
     function validateUserOp(uint32 entityId, PackedUserOperation calldata userOp, bytes32 userOpHash)
         external
         view
@@ -72,7 +72,7 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, ReplaySa
         return _SIG_VALIDATION_FAILED;
     }
 
-    /// @inheritdoc IValidationModule
+    /// @inheritdoc IERC6900ValidationModule
     function validateRuntime(
         address account,
         uint32 entityId,
@@ -88,7 +88,7 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, ReplaySa
         return;
     }
 
-    /// @inheritdoc IValidationModule
+    /// @inheritdoc IERC6900ValidationModule
     /// @dev The signature is valid if it is signed by the owner's private key
     /// (if the owner is an EOA) or if it is a valid ERC-1271 signature from the
     /// owner (if the owner is a contract).
@@ -111,7 +111,7 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, ReplaySa
     // ┃    Module interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    /// @inheritdoc IModule
+    /// @inheritdoc IERC6900Module
     function moduleId() external pure returns (string memory) {
         return "erc6900.single-signer-validation-module.1.0.0";
     }
@@ -123,7 +123,7 @@ contract SingleSignerValidationModule is ISingleSignerValidationModule, ReplaySa
         override(BaseModule, IERC165)
         returns (bool)
     {
-        return (interfaceId == type(IValidationModule).interfaceId || super.supportsInterface(interfaceId));
+        return (interfaceId == type(IERC6900ValidationModule).interfaceId || super.supportsInterface(interfaceId));
     }
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import {IExecutionHookModule} from "../../src/interfaces/IExecutionHookModule.sol";
+import {IERC6900ExecutionHookModule} from "../../src/interfaces/IERC6900ExecutionHookModule.sol";
 import {
     ExecutionManifest,
-    IModule,
+    IERC6900Module,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "../../src/interfaces/IExecutionModule.sol";
+} from "../../src/interfaces/IERC6900ExecutionModule.sol";
 
 import {MockModule} from "../mocks/MockModule.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
@@ -58,7 +58,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(
             abi.encodeWithSelector(
-                IExecutionHookModule.preExecutionHook.selector,
+                IERC6900ExecutionHookModule.preExecutionHook.selector,
                 _PRE_HOOK_FUNCTION_ID_1,
                 address(this), // caller
                 uint256(0), // msg.value in call to account
@@ -97,7 +97,7 @@ contract AccountExecHooksTest is AccountTestBase {
         // pre hook call
         emit ReceivedCall(
             abi.encodeWithSelector(
-                IExecutionHookModule.preExecutionHook.selector,
+                IERC6900ExecutionHookModule.preExecutionHook.selector,
                 _BOTH_HOOKS_FUNCTION_ID_3,
                 address(this), // caller
                 uint256(0), // msg.value in call to account
@@ -111,7 +111,7 @@ contract AccountExecHooksTest is AccountTestBase {
         vm.expectEmit(true, true, true, true);
         // post hook call
         emit ReceivedCall(
-            abi.encodeCall(IExecutionHookModule.postExecutionHook, (_BOTH_HOOKS_FUNCTION_ID_3, "")),
+            abi.encodeCall(IERC6900ExecutionHookModule.postExecutionHook, (_BOTH_HOOKS_FUNCTION_ID_3, "")),
             0 // msg value in call to module
         );
 
@@ -143,7 +143,7 @@ contract AccountExecHooksTest is AccountTestBase {
 
         vm.expectEmit(true, true, true, true);
         emit ReceivedCall(
-            abi.encodeCall(IExecutionHookModule.postExecutionHook, (_POST_HOOK_FUNCTION_ID_2, "")),
+            abi.encodeCall(IERC6900ExecutionHookModule.postExecutionHook, (_POST_HOOK_FUNCTION_ID_2, "")),
             0 // msg value in call to module
         );
 
@@ -162,7 +162,7 @@ contract AccountExecHooksTest is AccountTestBase {
         mockModule1 = new MockModule(_m1);
 
         vm.expectEmit(true, true, true, true);
-        emit ReceivedCall(abi.encodeCall(IModule.onInstall, (bytes("a"))), 0);
+        emit ReceivedCall(abi.encodeCall(IERC6900Module.onInstall, (bytes("a"))), 0);
         vm.expectEmit(true, true, true, true);
         emit ExecutionInstalled(address(mockModule1), _m1);
 
@@ -177,7 +177,7 @@ contract AccountExecHooksTest is AccountTestBase {
 
     function _uninstallExecution(MockModule module) internal {
         vm.expectEmit(true, true, true, true);
-        emit ReceivedCall(abi.encodeCall(IModule.onUninstall, (bytes("b"))), 0);
+        emit ReceivedCall(abi.encodeCall(IERC6900Module.onUninstall, (bytes("b"))), 0);
         vm.expectEmit(true, true, true, true);
         emit ExecutionUninstalled(address(module), true, module.executionManifest());
 

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "../../src/helpers/Constants.sol";
-import {Call} from "../../src/interfaces/IModularAccount.sol";
-import {IModularAccount} from "../../src/interfaces/IModularAccount.sol";
+import {Call} from "../../src/interfaces/IERC6900Account.sol";
+import {IERC6900Account} from "../../src/interfaces/IERC6900Account.sol";
 import {ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
 
 import {
@@ -41,7 +41,7 @@ contract AccountReturnDataTest is AccountTestBase {
         });
         // Allow the result consumer module to perform direct calls to the account
         bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = IModularAccount.execute.selector;
+        selectors[0] = IERC6900Account.execute.selector;
         account1.installValidation(
             ValidationConfigLib.pack(
                 address(resultConsumerModule), DIRECT_CALL_VALIDATION_ENTITY_ID, false, false, true
@@ -60,7 +60,7 @@ contract AccountReturnDataTest is AccountTestBase {
         assertEq(result, keccak256("bar"));
     }
 
-    // Tests the ability to read the results of contracts called via IModularAccount.execute
+    // Tests the ability to read the results of contracts called via IERC6900Account.execute
     function test_returnData_singular_execute() public {
         bytes memory returnData = account1.executeWithRuntimeValidation(
             abi.encodeCall(
@@ -75,7 +75,7 @@ contract AccountReturnDataTest is AccountTestBase {
         assertEq(result, keccak256("bar"));
     }
 
-    // Tests the ability to read the results of multiple contract calls via IModularAccount.executeBatch
+    // Tests the ability to read the results of multiple contract calls via IERC6900Account.executeBatch
     function test_returnData_executeBatch() public {
         Call[] memory calls = new Call[](2);
         calls[0] = Call({

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
-import {Call, IModularAccount} from "../../src/interfaces/IModularAccount.sol";
+import {Call, IERC6900Account} from "../../src/interfaces/IERC6900Account.sol";
 import {HookConfigLib} from "../../src/libraries/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {ValidationConfig, ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
@@ -43,7 +43,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
 
     function test_Fail_DirectCallModuleNotInstalled() external {
         vm.prank(address(_module));
-        vm.expectRevert(_buildDirectCallDisallowedError(IModularAccount.execute.selector));
+        vm.expectRevert(_buildDirectCallDisallowedError(IERC6900Account.execute.selector));
         account1.execute(address(0), 0, "");
     }
 
@@ -54,7 +54,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         _uninstallValidation();
 
         vm.prank(address(_module));
-        vm.expectRevert(_buildDirectCallDisallowedError(IModularAccount.execute.selector));
+        vm.expectRevert(_buildDirectCallDisallowedError(IERC6900Account.execute.selector));
         account1.execute(address(0), 0, "");
     }
 
@@ -64,7 +64,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         Call[] memory calls = new Call[](0);
 
         vm.prank(address(_module));
-        vm.expectRevert(_buildDirectCallDisallowedError(IModularAccount.executeBatch.selector));
+        vm.expectRevert(_buildDirectCallDisallowedError(IERC6900Account.executeBatch.selector));
         account1.executeBatch(calls);
     }
 
@@ -115,7 +115,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         _uninstallValidation();
 
         vm.prank(address(_module));
-        vm.expectRevert(_buildDirectCallDisallowedError(IModularAccount.execute.selector));
+        vm.expectRevert(_buildDirectCallDisallowedError(IERC6900Account.execute.selector));
         account1.execute(address(0), 0, "");
     }
 
@@ -123,7 +123,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
         address extraOwner = makeAddr("extraOwner");
 
         bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = IModularAccount.execute.selector;
+        selectors[0] = IERC6900Account.execute.selector;
 
         vm.prank(address(entryPoint));
 
@@ -144,7 +144,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
 
     function _installValidationSelector() internal {
         bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = IModularAccount.execute.selector;
+        selectors[0] = IERC6900Account.execute.selector;
 
         bytes[] memory hooks = new bytes[](1);
         hooks[0] = abi.encodePacked(

--- a/test/account/ModularAccountView.t.sol
+++ b/test/account/ModularAccountView.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.20;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-import {HookConfig, IModularAccount, ValidationFlags} from "../../src/interfaces/IModularAccount.sol";
-import {ExecutionDataView, ValidationDataView} from "../../src/interfaces/IModularAccountView.sol";
+import {HookConfig, IERC6900Account, ValidationFlags} from "../../src/interfaces/IERC6900Account.sol";
+import {ExecutionDataView, ValidationDataView} from "../../src/interfaces/IERC6900AccountView.sol";
 import {HookConfigLib} from "../../src/libraries/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
@@ -36,15 +36,15 @@ contract ModularAccountViewTest is CustomValidationTestBase {
     function test_moduleView_getExecutionData_native() public {
         bytes4[] memory selectorsToCheck = new bytes4[](5);
 
-        selectorsToCheck[0] = IModularAccount.execute.selector;
+        selectorsToCheck[0] = IERC6900Account.execute.selector;
 
-        selectorsToCheck[1] = IModularAccount.executeBatch.selector;
+        selectorsToCheck[1] = IERC6900Account.executeBatch.selector;
 
         selectorsToCheck[2] = UUPSUpgradeable.upgradeToAndCall.selector;
 
-        selectorsToCheck[3] = IModularAccount.installExecution.selector;
+        selectorsToCheck[3] = IERC6900Account.installExecution.selector;
 
-        selectorsToCheck[4] = IModularAccount.uninstallExecution.selector;
+        selectorsToCheck[4] = IERC6900Account.uninstallExecution.selector;
 
         for (uint256 i = 0; i < selectorsToCheck.length; i++) {
             ExecutionDataView memory data = account1.getExecutionData(selectorsToCheck[i]);

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -12,7 +12,7 @@ import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount
 import {ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
 
-import {IModularAccount, ModuleEntity} from "../../src/interfaces/IModularAccount.sol";
+import {IERC6900Account, ModuleEntity} from "../../src/interfaces/IERC6900Account.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
@@ -69,7 +69,7 @@ contract MultiValidationTest is AccountTestBase {
             )
         );
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.execute, (address(0), 0, "")),
+            abi.encodeCall(IERC6900Account.execute, (address(0), 0, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(validator2), TEST_DEFAULT_VALIDATION_ENTITY_ID), GLOBAL_VALIDATION, ""
             )
@@ -77,7 +77,7 @@ contract MultiValidationTest is AccountTestBase {
 
         vm.prank(owner2);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.execute, (address(0), 0, "")),
+            abi.encodeCall(IERC6900Account.execute, (address(0), 0, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(validator2), TEST_DEFAULT_VALIDATION_ENTITY_ID), GLOBAL_VALIDATION, ""
             )

--- a/test/account/ReferenceModularAccount.t.sol
+++ b/test/account/ReferenceModularAccount.t.sol
@@ -12,9 +12,11 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {ModuleManagerInternals} from "../../src/account/ModuleManagerInternals.sol";
 import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
-import {Call} from "../../src/interfaces/IModularAccount.sol";
-import {ExecutionDataView} from "../../src/interfaces/IModularAccountView.sol";
+
+import {Call} from "../../src/interfaces/IERC6900Account.sol";
+
+import {ExecutionDataView} from "../../src/interfaces/IERC6900AccountView.sol";
+import {ExecutionManifest} from "../../src/interfaces/IERC6900ExecutionModule.sol";
 import {ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
 import {TokenReceiverModule} from "../../src/modules/TokenReceiverModule.sol";

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -7,7 +7,7 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 
-import {Call, IModularAccount} from "../../src/interfaces/IModularAccount.sol";
+import {Call, IERC6900Account} from "../../src/interfaces/IERC6900Account.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
 
@@ -100,7 +100,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         calls[0] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
         _runUserOp(
-            abi.encodeCall(IModularAccount.executeBatch, (calls)),
+            abi.encodeCall(IERC6900Account.executeBatch, (calls)),
             abi.encodeWithSelector(
                 IEntryPoint.FailedOpWithRevert.selector,
                 0,
@@ -135,7 +135,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
 
         _runUserOp(
             abi.encodePacked(
-                IAccountExecute.executeUserOp.selector, abi.encodeCall(IModularAccount.executeBatch, (calls))
+                IAccountExecute.executeUserOp.selector, abi.encodeCall(IERC6900Account.executeBatch, (calls))
             ),
             abi.encodeWithSelector(
                 IEntryPoint.FailedOpWithRevert.selector,
@@ -177,7 +177,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         calls[1] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
         PackedUserOperation memory userOp =
-            _generateUserOpWithComprehensiveModuleValidation(abi.encodeCall(IModularAccount.executeBatch, (calls)));
+            _generateUserOpWithComprehensiveModuleValidation(abi.encodeCall(IERC6900Account.executeBatch, (calls)));
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;
@@ -195,7 +195,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
 
         PackedUserOperation memory userOp = _generateUserOpWithComprehensiveModuleValidation(
             abi.encodePacked(
-                IAccountExecute.executeUserOp.selector, abi.encodeCall(IModularAccount.executeBatch, (calls))
+                IAccountExecute.executeUserOp.selector, abi.encodeCall(IERC6900Account.executeBatch, (calls))
             )
         );
 
@@ -215,7 +215,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
 
         vm.expectCall(address(comprehensiveModule), abi.encodeCall(ComprehensiveModule.foo, ()), 2);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.executeBatch, (calls)),
+            abi.encodeCall(IERC6900Account.executeBatch, (calls)),
             _encodeSignature(comprehensiveModuleValidation, SELECTOR_ASSOCIATED_VALIDATION, "")
         );
     }
@@ -227,10 +227,10 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         innerCalls[0] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
         Call[] memory outerCalls = new Call[](1);
-        outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IModularAccount.executeBatch, (innerCalls)));
+        outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IERC6900Account.executeBatch, (innerCalls)));
 
         PackedUserOperation memory userOp = _generateUserOpWithComprehensiveModuleValidation(
-            abi.encodeCall(IModularAccount.executeBatch, (outerCalls))
+            abi.encodeCall(IERC6900Account.executeBatch, (outerCalls))
         );
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
@@ -254,11 +254,11 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         innerCalls[0] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
         Call[] memory outerCalls = new Call[](1);
-        outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IModularAccount.executeBatch, (innerCalls)));
+        outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IERC6900Account.executeBatch, (innerCalls)));
 
         PackedUserOperation memory userOp = _generateUserOpWithComprehensiveModuleValidation(
             abi.encodePacked(
-                IAccountExecute.executeUserOp.selector, abi.encodeCall(IModularAccount.executeBatch, (outerCalls))
+                IAccountExecute.executeUserOp.selector, abi.encodeCall(IERC6900Account.executeBatch, (outerCalls))
             )
         );
 
@@ -283,11 +283,11 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         innerCalls[0] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
         Call[] memory outerCalls = new Call[](1);
-        outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IModularAccount.executeBatch, (innerCalls)));
+        outerCalls[0] = Call(address(account1), 0, abi.encodeCall(IERC6900Account.executeBatch, (innerCalls)));
 
         vm.expectRevert(abi.encodeWithSelector(ReferenceModularAccount.SelfCallRecursionDepthExceeded.selector));
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.executeBatch, (outerCalls)),
+            abi.encodeCall(IERC6900Account.executeBatch, (outerCalls)),
             _encodeSignature(comprehensiveModuleValidation, SELECTOR_ASSOCIATED_VALIDATION, "")
         );
     }
@@ -297,7 +297,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         // self-call.
 
         bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = IModularAccount.executeBatch.selector;
+        selectors[0] = IERC6900Account.executeBatch.selector;
 
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(

--- a/test/libraries/HookConfigLib.t.sol
+++ b/test/libraries/HookConfigLib.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
-import {HookConfig, ModuleEntity} from "../../src/interfaces/IModularAccount.sol";
+import {HookConfig, ModuleEntity} from "../../src/interfaces/IERC6900Account.sol";
 import {HookConfigLib} from "../../src/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 

--- a/test/libraries/KnowSelectorsLib.t.sol
+++ b/test/libraries/KnowSelectorsLib.t.sol
@@ -5,7 +5,7 @@ import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.
 import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
 import {Test} from "forge-std/Test.sol";
 
-import {IModule} from "../../src/interfaces/IModule.sol";
+import {IERC6900Module} from "../../src/interfaces/IERC6900Module.sol";
 import {KnownSelectorsLib} from "../../src/libraries/KnownSelectorsLib.sol";
 
 contract KnownSelectorsLibTest is Test {
@@ -18,6 +18,6 @@ contract KnownSelectorsLibTest is Test {
     }
 
     function test_isIModuleFunction() public {
-        assertTrue(KnownSelectorsLib.isIModuleFunction(IModule.moduleId.selector));
+        assertTrue(KnownSelectorsLib.isIModuleFunction(IERC6900Module.moduleId.selector));
     }
 }

--- a/test/libraries/ModuleEntityLib.t.sol
+++ b/test/libraries/ModuleEntityLib.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
-import {ModuleEntity} from "../../src/interfaces/IModularAccount.sol";
+import {ModuleEntity} from "../../src/interfaces/IERC6900Account.sol";
 import {ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 
 contract ModuleEntityLibTest is Test {

--- a/test/mocks/MockModule.sol
+++ b/test/mocks/MockModule.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.20;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {IExecutionHookModule} from "../../src/interfaces/IExecutionHookModule.sol";
-import {ExecutionManifest} from "../../src/interfaces/IExecutionModule.sol";
-import {IModule} from "../../src/interfaces/IModule.sol";
-import {IValidationModule} from "../../src/interfaces/IValidationModule.sol";
+import {IERC6900ExecutionHookModule} from "../../src/interfaces/IERC6900ExecutionHookModule.sol";
+
+import {ExecutionManifest} from "../../src/interfaces/IERC6900ExecutionModule.sol";
+import {IERC6900Module} from "../../src/interfaces/IERC6900Module.sol";
+import {IERC6900ValidationModule} from "../../src/interfaces/IERC6900ValidationModule.sol";
 
 contract MockModule is ERC165 {
     // It's super inefficient to hold the entire abi-encoded manifest in storage, but this is fine since it's
@@ -58,14 +59,14 @@ contract MockModule is ERC165 {
     ///
     /// This function call must use less than 30 000 gas.
     ///
-    /// Supporting the IModule interface is a requirement for module installation. This is also used
+    /// Supporting the IERC6900Module interface is a requirement for module installation. This is also used
     /// by the modular account to prevent standard execution functions `execute` and `executeBatch` from
     /// making calls to modules.
     /// @param interfaceId The interface ID to check for support.
     /// @return True if the contract supports `interfaceId`.
 
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == type(IModule).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC6900Module).interfaceId || super.supportsInterface(interfaceId);
     }
 
     receive() external payable {}
@@ -74,9 +75,9 @@ contract MockModule is ERC165 {
     fallback() external payable {
         emit ReceivedCall(msg.data, msg.value);
         if (
-            msg.sig == IValidationModule.validateUserOp.selector
-                || msg.sig == IValidationModule.validateRuntime.selector
-                || msg.sig == IExecutionHookModule.preExecutionHook.selector
+            msg.sig == IERC6900ValidationModule.validateUserOp.selector
+                || msg.sig == IERC6900ValidationModule.validateRuntime.selector
+                || msg.sig == IERC6900ExecutionHookModule.preExecutionHook.selector
         ) {
             // return 0 for userOp/runtimeVal case, return bytes("") for preExecutionHook case
             assembly ("memory-safe") {

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -5,24 +5,24 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {
     ExecutionManifest,
-    IExecutionModule,
+    IERC6900ExecutionModule,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "../../../src/interfaces/IExecutionModule.sol";
+} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
 
-import {IExecutionHookModule} from "../../../src/interfaces/IExecutionHookModule.sol";
-import {IExecutionModule} from "../../../src/interfaces/IExecutionModule.sol";
+import {IERC6900ExecutionHookModule} from "../../../src/interfaces/IERC6900ExecutionHookModule.sol";
+import {IERC6900ExecutionModule} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
 
-import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "../../../src/interfaces/IValidationModule.sol";
+import {IERC6900ValidationHookModule} from "../../../src/interfaces/IERC6900ValidationHookModule.sol";
+import {IERC6900ValidationModule} from "../../../src/interfaces/IERC6900ValidationModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
 contract ComprehensiveModule is
-    IExecutionModule,
-    IValidationModule,
-    IValidationHookModule,
-    IExecutionHookModule,
+    IERC6900ExecutionModule,
+    IERC6900ValidationModule,
+    IERC6900ValidationHookModule,
+    IERC6900ExecutionHookModule,
     BaseModule
 {
     enum EntityId {

--- a/test/mocks/modules/DirectCallModule.sol
+++ b/test/mocks/modules/DirectCallModule.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.20;
 
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
-import {IExecutionHookModule} from "../../../src/interfaces/IExecutionHookModule.sol";
-import {IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
+import {IERC6900Account} from "../../../src/interfaces/IERC6900Account.sol";
+import {IERC6900ExecutionHookModule} from "../../../src/interfaces/IERC6900ExecutionHookModule.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
-contract DirectCallModule is BaseModule, IExecutionHookModule {
+contract DirectCallModule is BaseModule, IERC6900ExecutionHookModule {
     bool public preHookRan = false;
     bool public postHookRan = false;
 
@@ -16,7 +16,7 @@ contract DirectCallModule is BaseModule, IExecutionHookModule {
     function onUninstall(bytes calldata) external override {}
 
     function directCall() external returns (bytes memory) {
-        return IModularAccount(msg.sender).execute(address(this), 0, abi.encodeCall(this.getData, ()));
+        return IERC6900Account(msg.sender).execute(address(this), 0, abi.encodeCall(this.getData, ()));
     }
 
     function getData() external pure returns (bytes memory) {
@@ -52,6 +52,6 @@ contract DirectCallModule is BaseModule, IExecutionHookModule {
         override(BaseModule, IERC165)
         returns (bool)
     {
-        return interfaceId == type(IExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC6900ExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/test/mocks/modules/MockAccessControlHookModule.sol
+++ b/test/mocks/modules/MockAccessControlHookModule.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.20;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
-import {IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
-import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
+import {IERC6900Account} from "../../../src/interfaces/IERC6900Account.sol";
+import {IERC6900ValidationHookModule} from "../../../src/interfaces/IERC6900ValidationHookModule.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
 // A pre validaiton hook module that uses per-hook data.
 // This example enforces that the target of an `execute` call must only be the previously specified address.
 // This is just a mock - it does not enforce this over `executeBatch` and other methods of making calls, and should
 // not be used in production..
-contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
+contract MockAccessControlHookModule is IERC6900ValidationHookModule, BaseModule {
     mapping(uint32 entityId => mapping(address account => address allowedTarget)) public allowedTargets;
 
     function onInstall(bytes calldata data) external override {
@@ -31,7 +31,7 @@ contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
         override
         returns (uint256)
     {
-        if (bytes4(userOp.callData[:4]) == IModularAccount.execute.selector) {
+        if (bytes4(userOp.callData[:4]) == IERC6900Account.execute.selector) {
             address target = abi.decode(userOp.callData[4:36], (address));
 
             // Simulate a merkle proof - require that the target address is also provided in the signature
@@ -51,7 +51,7 @@ contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
         bytes calldata data,
         bytes calldata authorization
     ) external view override {
-        if (bytes4(data[:4]) == IModularAccount.execute.selector) {
+        if (bytes4(data[:4]) == IERC6900Account.execute.selector) {
             address target = abi.decode(data[4:36], (address));
 
             // Simulate a merkle proof - require that the target address is also provided in the authorization
@@ -89,6 +89,7 @@ contract MockAccessControlHookModule is IValidationHookModule, BaseModule {
         override(BaseModule, IERC165)
         returns (bool)
     {
-        return interfaceId == type(IValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IERC6900ValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/test/mocks/modules/PermittedCallMocks.sol
+++ b/test/mocks/modules/PermittedCallMocks.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.20;
 
 import {
     ExecutionManifest,
-    IExecutionModule,
+    IERC6900ExecutionModule,
     ManifestExecutionFunction
-} from "../../../src/interfaces/IExecutionModule.sol";
+} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 import {ResultCreatorModule} from "./ReturnDataModuleMocks.sol";
 
-contract PermittedCallerModule is IExecutionModule, BaseModule {
+contract PermittedCallerModule is IERC6900ExecutionModule, BaseModule {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -4,13 +4,14 @@ pragma solidity ^0.8.20;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "../../../src/helpers/Constants.sol";
+
+import {IERC6900Account} from "../../../src/interfaces/IERC6900Account.sol";
 import {
     ExecutionManifest,
-    IExecutionModule,
+    IERC6900ExecutionModule,
     ManifestExecutionFunction
-} from "../../../src/interfaces/IExecutionModule.sol";
-import {IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
-import {IValidationModule} from "../../../src/interfaces/IValidationModule.sol";
+} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
+import {IERC6900ValidationModule} from "../../../src/interfaces/IERC6900ValidationModule.sol";
 import {ModuleEntityLib} from "../../../src/libraries/ModuleEntityLib.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
@@ -26,7 +27,7 @@ contract RegularResultContract {
     }
 }
 
-contract ResultCreatorModule is IExecutionModule, BaseModule {
+contract ResultCreatorModule is IERC6900ExecutionModule, BaseModule {
     function onInstall(bytes calldata) external override {}
 
     function onUninstall(bytes calldata) external override {}
@@ -62,7 +63,12 @@ contract ResultCreatorModule is IExecutionModule, BaseModule {
     }
 }
 
-contract ResultConsumerModule is IExecutionModule, BaseModule, IValidationModule, ModuleSignatureUtils {
+contract ResultConsumerModule is
+    IERC6900ExecutionModule,
+    BaseModule,
+    IERC6900ValidationModule,
+    ModuleSignatureUtils
+{
     ResultCreatorModule public immutable RESULT_CREATOR;
     RegularResultContract public immutable REGULAR_RESULT_CONTRACT;
 
@@ -104,8 +110,8 @@ contract ResultConsumerModule is IExecutionModule, BaseModule, IValidationModule
     // Check the return data through the execute with authorization case
     function checkResultExecuteWithRuntimeValidation(address target, bytes32 expected) external returns (bool) {
         // This result should be allowed based on the manifest permission request
-        bytes memory returnData = IModularAccount(msg.sender).executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
+        bytes memory returnData = IERC6900Account(msg.sender).executeWithRuntimeValidation(
+            abi.encodeCall(IERC6900Account.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
             _encodeSignature(ModuleEntityLib.pack(address(this), DIRECT_CALL_VALIDATION_ENTITY_ID), uint8(0), "")
         );
 

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -5,18 +5,18 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 
 import {
     ExecutionManifest,
-    IExecutionModule,
+    IERC6900ExecutionModule,
     ManifestExecutionFunction
-} from "../../../src/interfaces/IExecutionModule.sol";
+} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
 
-import {IValidationHookModule} from "../../../src/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "../../../src/interfaces/IValidationModule.sol";
+import {IERC6900ValidationHookModule} from "../../../src/interfaces/IERC6900ValidationHookModule.sol";
+import {IERC6900ValidationModule} from "../../../src/interfaces/IERC6900ValidationModule.sol";
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 
 abstract contract MockBaseUserOpValidationModule is
-    IExecutionModule,
-    IValidationModule,
-    IValidationHookModule,
+    IERC6900ExecutionModule,
+    IERC6900ValidationModule,
+    IERC6900ValidationHookModule,
     BaseModule
 {
     enum EntityId {

--- a/test/modules/permissions/AllowlistModule.t.sol
+++ b/test/modules/permissions/AllowlistModule.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
 import {ReferenceModularAccount} from "../../../src/account/ReferenceModularAccount.sol";
-import {Call} from "../../../src/interfaces/IModularAccount.sol";
+import {Call} from "../../../src/interfaces/IERC6900Account.sol";
 import {HookConfigLib} from "../../../src/libraries/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../../src/libraries/ModuleEntityLib.sol";
 import {AllowlistModule} from "../../../src/modules/permissions/AllowlistModule.sol";

--- a/test/modules/permissions/ERC20TokenLimitModule.t.sol
+++ b/test/modules/permissions/ERC20TokenLimitModule.t.sol
@@ -6,8 +6,9 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {ReferenceModularAccount} from "../../../src/account/ReferenceModularAccount.sol";
-import {ExecutionManifest} from "../../../src/interfaces/IExecutionModule.sol";
-import {Call, IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
+
+import {Call, IERC6900Account} from "../../../src/interfaces/IERC6900Account.sol";
+import {ExecutionManifest} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
 import {HookConfigLib} from "../../../src/libraries/HookConfigLib.sol";
 import {ModuleEntity} from "../../../src/libraries/ModuleEntityLib.sol";
 import {ModuleEntityLib} from "../../../src/libraries/ModuleEntityLib.sol";
@@ -105,7 +106,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         (, uint256 limit) = module.limits(0, address(erc20), address(acct));
         assertEq(limit, 10 ether);
-        acct.executeUserOp(_getPackedUO(abi.encodeCall(IModularAccount.executeBatch, (calls))), bytes32(0));
+        acct.executeUserOp(_getPackedUO(abi.encodeCall(IERC6900Account.executeBatch, (calls))), bytes32(0));
 
         (, limit) = module.limits(0, address(erc20), address(acct));
         assertEq(limit, 10 ether - 6 ether - 100_001);
@@ -126,7 +127,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         (, uint256 limit) = module.limits(0, address(erc20), address(acct));
         assertEq(limit, 10 ether);
-        acct.executeUserOp(_getPackedUO(abi.encodeCall(IModularAccount.executeBatch, (calls))), bytes32(0));
+        acct.executeUserOp(_getPackedUO(abi.encodeCall(IERC6900Account.executeBatch, (calls))), bytes32(0));
 
         (, limit) = module.limits(0, address(erc20), address(acct));
         assertEq(limit, 10 ether - 6 ether - 100_001);
@@ -148,7 +149,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         (, uint256 limit) = module.limits(0, address(erc20), address(acct));
         assertEq(limit, 10 ether);
         PackedUserOperation[] memory uos = new PackedUserOperation[](1);
-        uos[0] = _getPackedUO(abi.encodeCall(IModularAccount.executeBatch, (calls)));
+        uos[0] = _getPackedUO(abi.encodeCall(IERC6900Account.executeBatch, (calls)));
         entryPoint.handleOps(uos, bundler);
         // no spend consumed
 
@@ -183,7 +184,7 @@ contract ERC20TokenLimitModuleTest is AccountTestBase {
         (, uint256 limit) = module.limits(0, address(erc20), address(acct));
         assertEq(limit, 10 ether);
         acct.executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.executeBatch, (calls)),
+            abi.encodeCall(IERC6900Account.executeBatch, (calls)),
             _encodeSignature(ModuleEntityLib.pack(address(validationModule), 0), 1, "")
         );
 

--- a/test/modules/permissions/NativeTokenLimitModule.t.sol
+++ b/test/modules/permissions/NativeTokenLimitModule.t.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.20;
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
 import {ReferenceModularAccount} from "../../../src/account/ReferenceModularAccount.sol";
-import {ExecutionManifest} from "../../../src/interfaces/IExecutionModule.sol";
-import {Call, HookConfig, IModularAccount} from "../../../src/interfaces/IModularAccount.sol";
+
+import {Call, HookConfig, IERC6900Account} from "../../../src/interfaces/IERC6900Account.sol";
+import {ExecutionManifest} from "../../../src/interfaces/IERC6900ExecutionModule.sol";
 import {HookConfigLib} from "../../../src/libraries/HookConfigLib.sol";
 import {ModuleEntity} from "../../../src/libraries/ModuleEntityLib.sol";
 import {ModuleEntityLib} from "../../../src/libraries/ModuleEntityLib.sol";
@@ -130,7 +131,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         assertEq(module.limits(0, address(acct)), 10 ether);
         acct.executeUserOp(
-            _getPackedUO(0, 0, 0, 0, abi.encodeCall(IModularAccount.executeBatch, (calls))), bytes32(0)
+            _getPackedUO(0, 0, 0, 0, abi.encodeCall(IERC6900Account.executeBatch, (calls))), bytes32(0)
         );
         assertEq(module.limits(0, address(acct)), 10 ether - 6 ether - 100_001);
         assertEq(recipient.balance, 6 ether + 100_001);
@@ -155,7 +156,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
         vm.startPrank(address(entryPoint));
         assertEq(module.limits(0, address(acct)), 10 ether);
         PackedUserOperation[] memory uos = new PackedUserOperation[](1);
-        uos[0] = _getPackedUO(200_000, 200_000, 200_000, 1, abi.encodeCall(IModularAccount.executeBatch, (calls)));
+        uos[0] = _getPackedUO(200_000, 200_000, 200_000, 1, abi.encodeCall(IERC6900Account.executeBatch, (calls)));
         entryPoint.handleOps(uos, bundler);
 
         assertEq(module.limits(0, address(acct)), 10 ether - 6 ether - 700_001);
@@ -188,7 +189,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
 
         assertEq(module.limits(0, address(acct)), 10 ether);
         acct.executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.executeBatch, (calls)), _encodeSignature(validationFunction, 1, "")
+            abi.encodeCall(IERC6900Account.executeBatch, (calls)), _encodeSignature(validationFunction, 1, "")
         );
         assertEq(module.limits(0, address(acct)), 4 ether - 100_001);
     }

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -7,7 +7,7 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 
 import {ReferenceModularAccount} from "../../src/account/ReferenceModularAccount.sol";
 import {SemiModularAccount} from "../../src/account/SemiModularAccount.sol";
-import {Call, IModularAccount} from "../../src/interfaces/IModularAccount.sol";
+import {Call, IERC6900Account} from "../../src/interfaces/IERC6900Account.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
 import {SingleSignerValidationModule} from "../../src/modules/validation/SingleSignerValidationModule.sol";
 
@@ -64,19 +64,19 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
     }
 
     function _runExecUserOp(address target, bytes memory callData) internal {
-        _runUserOp(abi.encodeCall(IModularAccount.execute, (target, 0, callData)));
+        _runUserOp(abi.encodeCall(IERC6900Account.execute, (target, 0, callData)));
     }
 
     function _runExecUserOp(address target, bytes memory callData, bytes memory revertReason) internal {
-        _runUserOp(abi.encodeCall(IModularAccount.execute, (target, 0, callData)), revertReason);
+        _runUserOp(abi.encodeCall(IERC6900Account.execute, (target, 0, callData)), revertReason);
     }
 
     function _runExecBatchUserOp(Call[] memory calls) internal {
-        _runUserOp(abi.encodeCall(IModularAccount.executeBatch, (calls)));
+        _runUserOp(abi.encodeCall(IERC6900Account.executeBatch, (calls)));
     }
 
     function _runExecBatchUserOp(Call[] memory calls, bytes memory revertReason) internal {
-        _runUserOp(abi.encodeCall(IModularAccount.executeBatch, (calls)), revertReason);
+        _runUserOp(abi.encodeCall(IERC6900Account.executeBatch, (calls)), revertReason);
     }
 
     function _runUserOp(bytes memory callData) internal {
@@ -114,29 +114,29 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
     }
 
     function _runtimeExec(address target, bytes memory callData) internal {
-        _runtimeCall(abi.encodeCall(IModularAccount.execute, (target, 0, callData)));
+        _runtimeCall(abi.encodeCall(IERC6900Account.execute, (target, 0, callData)));
     }
 
     function _runtimeExec(address target, bytes memory callData, bytes memory expectedRevertData) internal {
-        _runtimeCall(abi.encodeCall(IModularAccount.execute, (target, 0, callData)), expectedRevertData);
+        _runtimeCall(abi.encodeCall(IERC6900Account.execute, (target, 0, callData)), expectedRevertData);
     }
 
     function _runtimeExecExpFail(address target, bytes memory callData, bytes memory expectedRevertData)
         internal
     {
-        _runtimeCallExpFail(abi.encodeCall(IModularAccount.execute, (target, 0, callData)), expectedRevertData);
+        _runtimeCallExpFail(abi.encodeCall(IERC6900Account.execute, (target, 0, callData)), expectedRevertData);
     }
 
     function _runtimeExecBatch(Call[] memory calls) internal {
-        _runtimeCall(abi.encodeCall(IModularAccount.executeBatch, (calls)));
+        _runtimeCall(abi.encodeCall(IERC6900Account.executeBatch, (calls)));
     }
 
     function _runtimeExecBatch(Call[] memory calls, bytes memory expectedRevertData) internal {
-        _runtimeCall(abi.encodeCall(IModularAccount.executeBatch, (calls)), expectedRevertData);
+        _runtimeCall(abi.encodeCall(IERC6900Account.executeBatch, (calls)), expectedRevertData);
     }
 
     function _runtimeExecBatchExpFail(Call[] memory calls, bytes memory expectedRevertData) internal {
-        _runtimeCallExpFail(abi.encodeCall(IModularAccount.executeBatch, (calls)), expectedRevertData);
+        _runtimeCallExpFail(abi.encodeCall(IERC6900Account.executeBatch, (calls)), expectedRevertData);
     }
 
     function _runtimeCall(bytes memory callData) internal {


### PR DESCRIPTION
Context in https://github.com/ethereum/ERCs/pull/875

After merging, this will go into release v0.8.1.