### PR TITLE
`getExecutionData()` to Also Include Execution Hooks for Native Account Selectors

### DIFF
--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -30,12 +30,11 @@ abstract contract ModularAccountView is IERC6900AccountView {
             data.module = executionStorage.module;
             data.skipRuntimeValidation = executionStorage.skipRuntimeValidation;
             data.allowGlobalValidation = executionStorage.allowGlobalValidation;
-
-            uint256 executionHooksLen = executionStorage.executionHooks.length();
-            data.executionHooks = new HookConfig[](executionHooksLen);
-            for (uint256 i = 0; i < executionHooksLen; ++i) {
-                data.executionHooks[i] = toHookConfig(executionStorage.executionHooks.at(i));
-            }
+        }
+        uint256 executionHooksLen = executionStorage.executionHooks.length();
+        data.executionHooks = new HookConfig[](executionHooksLen);
+        for (uint256 i = 0; i < executionHooksLen; ++i) {
+            data.executionHooks[i] = toHookConfig(executionStorage.executionHooks.at(i));
         }
     }
 

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -17,6 +17,7 @@ abstract contract ModularAccountView is IERC6900AccountView {
 
     /// @inheritdoc IERC6900AccountView
     function getExecutionData(bytes4 selector) external view override returns (ExecutionDataView memory data) {
+        ExecutionStorage storage executionStorage = getAccountStorage().executionStorage[selector];
         if (
             selector == IERC6900Account.execute.selector || selector == IERC6900Account.executeBatch.selector
                 || selector == UUPSUpgradeable.upgradeToAndCall.selector
@@ -26,7 +27,6 @@ abstract contract ModularAccountView is IERC6900AccountView {
             data.module = address(this);
             data.allowGlobalValidation = true;
         } else {
-            ExecutionStorage storage executionStorage = getAccountStorage().executionStorage[selector];
             data.module = executionStorage.module;
             data.skipRuntimeValidation = executionStorage.skipRuntimeValidation;
             data.allowGlobalValidation = executionStorage.allowGlobalValidation;


### PR DESCRIPTION
There's a minor bug in the `getExecutionData()` view function. It will currently not return the execution hooks for the ERC-6900-native account selectors, as `executionData.executionHooks` is only populated in the case the selector is not an account selector.

Solution is super straight forward, to have `executionStorage.executionHooks` populated outside of the branch-logic.